### PR TITLE
Improve graph devx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ unittest.junit.xml
 site/
 todo*.md
 tmp/
+.bmo/

--- a/boilermaker/app.py
+++ b/boilermaker/app.py
@@ -361,6 +361,7 @@ class Boilermaker:
                 results: list[int] = await self.service_bus_client.send_message(
                     task.model_dump_json(),
                     delay=delay,
+                    unique_msg_id=str(task.task_id),
                 )
                 if results and len(results) == 1:
                     sequence_number = results[0]

--- a/boilermaker/app.py
+++ b/boilermaker/app.py
@@ -163,7 +163,7 @@ class Boilermaker:
             raise ValueError(f"Function must be async: {fn_name}")
 
         task = Task.default(fn_name, **options)
-        self.function_registry[fn_name] = fn
+        self.function_registry[fn_name] = typing.cast(TaskHandler, fn)  # why must cast here
         self.task_registry[fn_name] = task
         logger.info(f"Registered background function fn={fn_name}")
         return self

--- a/boilermaker/app.py
+++ b/boilermaker/app.py
@@ -12,7 +12,7 @@ import typing
 import weakref
 from functools import wraps
 
-from aio_azure_clients_toolbox import AzureServiceBus, ManagedAzureServiceBusSender  # type: ignore
+from aio_azure_clients_toolbox import AzureServiceBus, ManagedAzureServiceBusSender
 from anyio import create_task_group, open_signal_receiver
 from anyio.abc import CancelScope
 from azure.servicebus import ServiceBusReceivedMessage

--- a/boilermaker/evaluators/__init__.py
+++ b/boilermaker/evaluators/__init__.py
@@ -4,12 +4,11 @@ import typing
 from azure.servicebus.aio import ServiceBusReceiver
 
 from boilermaker.storage.base import StorageInterface
-from boilermaker.task import Task
+from boilermaker.task import Task, TaskHandler
 
 from .common import (
     MessageActions,
     TaskEvaluatorBase,
-    TaskHandler,
     TaskHandlerRegistry,
     TaskPublisher,
 )

--- a/boilermaker/evaluators/common.py
+++ b/boilermaker/evaluators/common.py
@@ -3,7 +3,7 @@ import logging
 import traceback
 import typing
 from abc import abstractmethod
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable
 from functools import cached_property
 from json.decoder import JSONDecodeError
 
@@ -21,14 +21,12 @@ from pydantic import ValidationError
 from boilermaker import exc, sample
 from boilermaker.storage import StorageInterface
 from boilermaker.task import Task, TaskResult, TaskStatus
+from boilermaker.task import types as task_types
 
 tracer: trace.Tracer = trace.get_tracer(__name__)
 logger = logging.getLogger("boilermaker.app")
 
-
-# Common Types used when evaluating tasks
-TaskHandler: typing.TypeAlias = Callable[..., Awaitable[typing.Any]]
-TaskHandlerRegistry: typing.TypeAlias = dict[str, TaskHandler]
+TaskHandlerRegistry: typing.TypeAlias = dict[str, task_types.TaskHandler]
 
 
 class TaskPublisher(typing.Protocol):

--- a/boilermaker/evaluators/eval.py
+++ b/boilermaker/evaluators/eval.py
@@ -7,8 +7,7 @@ from boilermaker.exc import BoilermakerUnregisteredFunction
 from boilermaker.failure import TaskFailureResult
 from boilermaker.retries import RetryException
 from boilermaker.task import Task, TaskResult, TaskStatus
-
-from .common import TaskHandler
+from boilermaker.task.types import TaskHandler
 
 logger = logging.getLogger("boilermaker.app")
 

--- a/boilermaker/evaluators/task_graph.py
+++ b/boilermaker/evaluators/task_graph.py
@@ -203,13 +203,20 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
             (graph.generate_ready_tasks(), graph.generate_failure_ready_tasks())
         ):
             # Write that the task was *scheduled* back to Blob Storage with blob etag and then publish the task!
-            result = graph.schedule_task(ready_task.task_id)
             try:
+                result = graph.schedule_task(ready_task.task_id)
                 await self.storage_interface.store_task_result(result, etag=result.etag)
             except exc.BoilermakerStorageError:
                 logger.error(
                     f"Failed to store scheduled status for task {ready_task.task_id} in graph {graph_id}. "
                     "Not publishing the task to avoid double-scheduling.",
+                    exc_info=True,
+                )
+                continue
+            except ValueError:
+                logger.error(
+                    f"schedule_task raised ValueError for task {ready_task.task_id} in graph {graph_id}. "
+                    "Skipping to avoid double-scheduling.",
                     exc_info=True,
                 )
                 continue

--- a/boilermaker/evaluators/task_graph.py
+++ b/boilermaker/evaluators/task_graph.py
@@ -1,10 +1,11 @@
+import asyncio
 import itertools
 import logging
 import typing
 
 from azure.servicebus.aio import ServiceBusReceiver
 
-from boilermaker import exc
+from boilermaker import exc, retries
 from boilermaker.storage import StorageInterface
 from boilermaker.task import Task, TaskResult, TaskStatus
 
@@ -13,9 +14,24 @@ from .eval import eval_task
 
 logger = logging.getLogger("boilermaker.app")
 
+# Retry policy used when load_graph raises a transient exception.
+# Up to 3 attempts total (initial + 2 retries) with exponential backoff.
+_LOAD_GRAPH_RETRY_POLICY = retries.RetryPolicy(
+    max_tries=3,
+    delay=1,
+    delay_max=16,
+    retry_mode=retries.RetryMode.Exponential,
+)
+
 
 class TaskGraphEvaluator(TaskEvaluatorBase):
-    """Evaluator for tasks that are part of a TaskGraph workflow."""
+    """Evaluator for tasks that are part of a TaskGraph workflow.
+
+    At-least-once delivery contract: any task in ``Scheduled`` status may be
+    published more than once.  Workers must tolerate at-least-once delivery.
+    Re-publication on Service Bus redelivery is the intentional recovery
+    mechanism for the store-before-publish crash gap in ``continue_graph``.
+    """
 
     def __init__(
         self,
@@ -114,8 +130,17 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 result=None,
             )
             await self.storage_interface.store_task_result(task_result)
-            # Publish failure tasks which may be ready now
-            await self.continue_graph(task_result)
+            # Publish failure tasks which may be ready now.
+            # The message is already deadlettered at this point, so suppressing settlement
+            # is not possible — log and return gracefully if continue_graph fails.
+            try:
+                await self.continue_graph(task_result)
+            except exc.ContinueGraphError:
+                logger.error(
+                    f"continue_graph failed after retries exhausted for task {self.task.task_id}; "
+                    "failure callbacks may not be dispatched (message already deadlettered)",
+                    exc_info=True,
+                )
             return task_result
 
         # Actually invoke the task here
@@ -128,7 +153,17 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
         await self.storage_interface.store_task_result(result)
 
         if result.status.finished:
-            await self.continue_graph(result)
+            try:
+                await self.continue_graph(result)
+            except exc.ContinueGraphError:
+                # Transient load_graph failure — do NOT settle the message.
+                # Allow Service Bus redelivery so downstream dispatch can be retried.
+                logger.error(
+                    f"continue_graph failed for task {self.task.task_id}; "
+                    "suppressing message settlement to allow redelivery",
+                    exc_info=True,
+                )
+                return result
         elif result.status == TaskStatus.Retry:
             # Retry requested: republish the same task with delay
             delay = self.task.get_next_delay()
@@ -171,20 +206,81 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
         Continue evaluating TaskGraph workflow after a task completes successfully.
 
         We always reload the graph from storage to get the latest state.
+
+        Transient ``load_graph`` failures (``BoilermakerStorageError`` with a
+        non-404 status code) are retried with exponential backoff up to
+        ``_LOAD_GRAPH_RETRY_POLICY.max_tries`` attempts.  If all attempts fail,
+        ``ContinueGraphError`` is raised so that ``message_handler`` can suppress
+        message settlement and allow Service Bus redelivery.
+
+        Permanent failures (``BoilermakerStorageError`` with ``status_code=404``)
+        are logged at CRITICAL severity and ``None`` is returned.  Settling the
+        message is correct in this case because redelivery will not help — the
+        graph blob is gone and downstream tasks cannot be dispatched.
+
+        Note: in practice ``load_graph`` never returns ``None`` for a missing
+        blob; the underlying library re-raises all ``HttpResponseError``s
+        (including 404) as ``AzureBlobError``, which ``load_graph`` wraps as
+        ``BoilermakerStorageError(status_code=404)``.  The ``if not graph`` guard
+        below is retained as a defensive fallback only.
+
+        At-least-once delivery: any task already in ``Scheduled`` status is
+        re-published without a second blob write (second pass below).  This is
+        the crash-recovery path for the store-before-publish gap.
         """
         graph_id = completed_task_result.graph_id
         if not graph_id:
             return None
 
-        try:
-            # Reload graph with latest results
-            graph = await self.storage_interface.load_graph(graph_id)
-        except Exception:
-            logger.error(f"Exception in continue_graph for graph {graph_id}", exc_info=True)
-            return None
+        # Attempt to load the graph, retrying on transient errors.
+        last_exc: Exception | None = None
+        for attempt in range(_LOAD_GRAPH_RETRY_POLICY.max_tries):
+            try:
+                graph = await self.storage_interface.load_graph(graph_id)
+                break  # success
+            except exc.BoilermakerStorageError as e:
+                if getattr(e, "status_code", None) == 404:
+                    # Permanent: graph blob does not exist. Redelivery will not help.
+                    logger.critical(
+                        f"Graph {graph_id} not found in storage (404); downstream tasks will not be dispatched. "
+                        "This graph may have been deleted.",
+                        exc_info=True,
+                    )
+                    return None
+                # Transient error — will retry or raise ContinueGraphError after max_tries
+                last_exc = e
+                if attempt < _LOAD_GRAPH_RETRY_POLICY.max_tries - 1:
+                    delay = _LOAD_GRAPH_RETRY_POLICY.get_delay_interval(attempt)
+                    logger.warning(
+                        f"load_graph failed for graph {graph_id} "
+                        f"(attempt {attempt + 1}/{_LOAD_GRAPH_RETRY_POLICY.max_tries}); "
+                        f"retrying in {delay}s",
+                        exc_info=True,
+                    )
+                    await asyncio.sleep(delay)
+                else:
+                    logger.error(
+                        f"load_graph failed for graph {graph_id} after "
+                        f"{_LOAD_GRAPH_RETRY_POLICY.max_tries} attempts; "
+                        "raising ContinueGraphError to suppress message settlement",
+                        exc_info=True,
+                    )
+                    raise exc.ContinueGraphError(
+                        f"load_graph failed for graph {graph_id} after "
+                        f"{_LOAD_GRAPH_RETRY_POLICY.max_tries} attempts"
+                    ) from last_exc
+        else:
+            # Should only be reached if max_tries == 0 (not expected).
+            raise exc.ContinueGraphError(f"load_graph not attempted for graph {graph_id}")
 
         if not graph:
-            logger.error(f"Graph {graph_id} not found after task completion")
+            # Permanent failure: graph blob does not exist.  Redelivery will not help.
+            # Settling the upstream message is intentional here.
+            logger.critical(
+                f"Graph {graph_id} not found after task completion — "
+                "downstream tasks will never be dispatched. "
+                "This is a permanent data loss; redelivery will not recover it."
+            )
             return None
 
         # Sanity check: did we load the result that was *just* stored?
@@ -196,6 +292,11 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 f"but got {loaded_task_status}"
             )
             return None
+
+        # Snapshot tasks already in Scheduled status BEFORE the first pass.
+        # The second pass uses this snapshot so that tasks freshly scheduled
+        # in the first pass are not double-published.
+        already_scheduled_tasks = list(graph.generate_scheduled_tasks())
 
         # Find and publish newly ready tasks
         ready_count = 0
@@ -229,5 +330,30 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
             logger.info(
                 f"No new tasks ready in graph {graph_id} after task {completed_task_result.task_id}"
             )
+
+        # Second pass: re-publish tasks that were ALREADY in Scheduled status when the
+        # graph was loaded (crash-recovery).
+        #
+        # If a previous invocation of continue_graph wrote Scheduled to blob storage
+        # (store_task_result) but crashed before publishing the Service Bus message
+        # (publish_task), the task blob shows Scheduled but there is no SB message.
+        # generate_ready_tasks() skips Scheduled tasks (is_not_started == False), so
+        # without this pass the task would never be dispatched.
+        #
+        # We snapshot already-scheduled tasks BEFORE the first pass so that tasks
+        # scheduled in the first pass are not double-published here.
+        #
+        # On Service Bus redelivery, we detect these orphaned-Scheduled tasks here and
+        # re-publish them without a second blob write (the blob is already correct).
+        #
+        # NOTE: Workers must tolerate at-least-once delivery.  A task in Scheduled
+        # status may be published more than once.  This is the intentional recovery
+        # mechanism for the store-before-publish crash gap.
+        for scheduled_task in already_scheduled_tasks:
+            logger.info(
+                f"Re-publishing already-scheduled task {scheduled_task.task_id} "
+                f"in graph {graph_id} (crash recovery: blob written but message not published)"
+            )
+            await self.publish_task(scheduled_task)
 
         return ready_count

--- a/boilermaker/exc.py
+++ b/boilermaker/exc.py
@@ -1,6 +1,22 @@
 from azure.servicebus.exceptions import ServiceBusError
 
 
+class BoilermakerError(Exception):
+    """Base class for Boilermaker-specific exceptions."""
+
+    pass
+
+
+class ContinueGraphError(BoilermakerError):
+    """Raised when continue_graph cannot load the graph after retries.
+
+    Signals message_handler that settlement must be suppressed so that
+    Service Bus will redeliver the message and downstream dispatch can be retried.
+    """
+
+    pass
+
+
 class BoilermakerAppException(Exception):
     def __init__(self, message: str, errors: list):
         super().__init__(message + str(errors))

--- a/boilermaker/service_bus.py
+++ b/boilermaker/service_bus.py
@@ -7,7 +7,7 @@ allows sending messages or subscribing to a queue.
 
 from aio_azure_clients_toolbox import (
     CredentialFactory,
-    ManagedAzureServiceBusSender,  # type: ignore
+    ManagedAzureServiceBusSender,
 )
 
 from .config import Config

--- a/boilermaker/storage/blob_storage.py
+++ b/boilermaker/storage/blob_storage.py
@@ -171,6 +171,12 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
             await self.upload_blob(
                 fname, task_result.model_dump_json(), tags=blob_tags, overwrite=True, **concurrency_kwargs
             )
+        # SAFETY: This catch assumes aio_azure_clients_toolbox raises AzureBlobError
+        # (wrapping HTTP 412 Precondition Failed) when an ETag mismatch occurs.
+        # This is the primary guard against concurrent double-scheduling of downstream
+        # tasks. Verified against aio-azure-clients-toolbox v1.0.4 (see uv.lock):
+        # get_blob_client() catches all HttpResponseError (including 412) and re-raises
+        # as AzureBlobError. If the library behavior changes, this guard will silently break.
         except AzureBlobError as exc:
             raise BoilermakerStorageError(
                 f"Failed to store TaskResult {task_result.task_id}",

--- a/boilermaker/storage/blob_storage.py
+++ b/boilermaker/storage/blob_storage.py
@@ -12,6 +12,7 @@ from azure.core.exceptions import (
     ResourceNotFoundError,
 )
 from azure.identity.aio import DefaultAzureCredential
+from pydantic import ValidationError
 
 from boilermaker.exc import BoilermakerStorageError
 from boilermaker.storage import StorageInterface
@@ -48,7 +49,8 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
         Returns:
             The loaded TaskGraph instance, or None if not found.
         Raises:
-            ValidationError: If TaskGraph or TaskResultSlim data cannot be validated.
+            BoilermakerStorageError: If the blob cannot be loaded or if TaskGraph/TaskResultSlim
+                data cannot be validated.
         """
         if not graph_id:
             raise ValueError("`graph_id` must be provided to load a TaskGraph.")
@@ -68,7 +70,13 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
         if graph_contents is None:
             return None
 
-        graph = TaskGraph.model_validate_json(graph_contents)
+        try:
+            graph = TaskGraph.model_validate_json(graph_contents)
+        except ValidationError as e:
+            raise BoilermakerStorageError(
+                f"Failed to deserialize graph {graph_id}: {e}",
+                status_code=None,
+            ) from e
 
         # Load all TaskResultSlim instances associated with this graph
         # We don't want to load *all* return values into memory. Just the statuses.
@@ -76,7 +84,13 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
             # DO NOT REDOWNLOAD GRAPH
             if blob.name == graph_path:
                 continue
-            tr = TaskResultSlim.model_validate_json(await self.download_blob(blob.name))
+            try:
+                tr = TaskResultSlim.model_validate_json(await self.download_blob(blob.name))
+            except ValidationError as e:
+                raise BoilermakerStorageError(
+                    f"Failed to deserialize task result in graph {graph_id}: {e}",
+                    status_code=None,
+                ) from e
             tr.etag = blob.etag
             if tr.graph_id == graph_id:
                 graph.results[tr.task_id] = tr

--- a/boilermaker/storage/blob_storage.py
+++ b/boilermaker/storage/blob_storage.py
@@ -179,7 +179,7 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
         concurrency_kwargs: dict[str, str | int] = {}
         if etag:
             concurrency_kwargs["etag"] = etag
-            concurrency_kwargs["if_match"] = MatchConditions.IfNotModified.value
+            concurrency_kwargs["if_tags_match_condition"] = MatchConditions.IfNotModified.value
 
         try:
             await self.upload_blob(

--- a/boilermaker/storage/blob_storage.py
+++ b/boilermaker/storage/blob_storage.py
@@ -176,10 +176,10 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
             "graph_id": task_result.graph_id or "none",
             "status": task_result.status,
         }
-        concurrency_kwargs: dict[str, str | int] = {}
+        concurrency_kwargs: dict[str, str | int | MatchConditions] = {}
         if etag:
             concurrency_kwargs["etag"] = etag
-            concurrency_kwargs["if_tags_match_condition"] = MatchConditions.IfNotModified.value
+            concurrency_kwargs["match_condition"] = MatchConditions.IfNotModified
 
         try:
             await self.upload_blob(

--- a/boilermaker/storage/blob_storage.py
+++ b/boilermaker/storage/blob_storage.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 import traceback
 from functools import partial
@@ -13,7 +12,6 @@ from azure.core.exceptions import (
     ResourceNotFoundError,
 )
 from azure.identity.aio import DefaultAzureCredential
-from azure.storage.blob import ImmutabilityPolicy
 
 from boilermaker.exc import BoilermakerStorageError
 from boilermaker.storage import StorageInterface
@@ -80,17 +78,12 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
             if tr.graph_id == graph_id:
                 graph.results[tr.task_id] = tr
             else:
-                logger.warning(
-                    f"TaskResult {tr.task_id} in graph {graph_dir} with wrong graph_id {tr.graph_id}!"
-                )
+                logger.warning(f"TaskResult {tr.task_id} in graph {graph_dir} with wrong graph_id {tr.graph_id}!")
         return graph
 
     async def store_graph(self, graph: TaskGraph) -> TaskGraph:
         """
         Stores a TaskGraph to Azure Blob Storage and stores all children as pending tasks as well.
-
-        We use a lease on the container to make sure *only* one task is writing! This means
-        that we don't have to worry about concurrent writes causing data corruption.
 
         We expect the *written graph* to be **immutable** (see the ImmutabilityPolicy below).
 
@@ -99,35 +92,21 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
         """
         lease = None
         async with self.get_blob_service_client() as blob_service_client:
-            container_client = blob_service_client.get_container_client(
-                self.container_name
-            )
-            lease = await container_client.acquire_lease()
-            upload_kwargs = {
-                "lease": lease,
-                "blob_type": "BlockBlob",
-                "immutability_policy": ImmutabilityPolicy(
-                    expiry_time=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(hours=4),
-                    policy_mode="LOCKED",
-                ),
-            }
-
+            container_client = blob_service_client.get_container_client(self.container_name)
             # Store the graph itself first
             fname = f"{self.task_result_prefix}/{graph.storage_path}"
             try:
                 _result = await container_client.upload_blob(
                     fname,
                     graph.model_dump_json(),
-                    **upload_kwargs,
+                    blob_type="BlockBlob",
                 )
             except (
                 ResourceNotFoundError,
                 HttpResponseError,
                 ResourceExistsError,
             ) as exc:
-                logger.error(
-                    f"Error occurred while storing TaskGraph {graph.graph_id}: {exc}"
-                )
+                logger.error(f"Error occurred while storing TaskGraph {graph.graph_id}: {exc}")
                 raise BoilermakerStorageError(
                     f"Failed to store TaskGraph {graph.graph_id}",
                     task_id=None,
@@ -139,15 +118,15 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
             pending_result = None
             try:
                 async with create_task_group() as tg:
+                    # don't let any tasks that get ahead accidentally clobber us
                     for pending_result in graph.generate_pending_results():
-                        fname_pr = (
-                            f"{self.task_result_prefix}/{pending_result.storage_path}"
-                        )
+                        fname_pr = f"{self.task_result_prefix}/{pending_result.storage_path}"
+
                         uploader = partial(
                             container_client.upload_blob,
                             fname_pr,
                             pending_result.model_dump_json(),
-                            **upload_kwargs,
+                            blob_type="BlockBlob",
                         )
                         tg.start_soon(uploader)
             except* Exception as excgroup:

--- a/boilermaker/storage/blob_storage.py
+++ b/boilermaker/storage/blob_storage.py
@@ -73,6 +73,9 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
         # Load all TaskResultSlim instances associated with this graph
         # We don't want to load *all* return values into memory. Just the statuses.
         async for blob in self.list_blobs(prefix=graph_dir):
+            # DO NOT REDOWNLOAD GRAPH
+            if blob.name == graph_path:
+                continue
             tr = TaskResultSlim.model_validate_json(await self.download_blob(blob.name))
             tr.etag = blob.etag
             if tr.graph_id == graph_id:

--- a/boilermaker/task/__init__.py
+++ b/boilermaker/task/__init__.py
@@ -1,6 +1,17 @@
-from .graph import TaskGraph, TaskGraphBuilder
+from .graph import LAST_ADDED, TaskChain, TaskGraph, TaskGraphBuilder
 from .result import TaskResult, TaskResultSlim, TaskStatus
 from .task import Task
 from .task_id import GraphId, TaskId
 
-__all__ = ["TaskGraph", "TaskGraphBuilder", "TaskResult", "TaskResultSlim", "TaskStatus", "Task", "TaskId", "GraphId"]
+__all__ = [
+    "LAST_ADDED",
+    "TaskChain",
+    "TaskGraph",
+    "TaskGraphBuilder",
+    "TaskResult",
+    "TaskResultSlim",
+    "TaskStatus",
+    "Task",
+    "TaskId",
+    "GraphId",
+]

--- a/boilermaker/task/__init__.py
+++ b/boilermaker/task/__init__.py
@@ -1,4 +1,4 @@
-from .graph import LAST_ADDED, TaskChain, TaskGraph, TaskGraphBuilder
+from .graph import LAST_ADDED, LastAddedSingleton, TaskChain, TaskGraph, TaskGraphBuilder
 from .result import TaskResult, TaskResultSlim, TaskStatus
 from .task import Task
 from .task_id import GraphId, TaskId
@@ -6,6 +6,7 @@ from .types import TaskHandler
 
 __all__ = [
     "LAST_ADDED",
+    "LastAddedSingleton",
     "TaskChain",
     "TaskGraph",
     "TaskGraphBuilder",

--- a/boilermaker/task/__init__.py
+++ b/boilermaker/task/__init__.py
@@ -2,6 +2,7 @@ from .graph import LAST_ADDED, TaskChain, TaskGraph, TaskGraphBuilder
 from .result import TaskResult, TaskResultSlim, TaskStatus
 from .task import Task
 from .task_id import GraphId, TaskId
+from .types import TaskHandler
 
 __all__ = [
     "LAST_ADDED",
@@ -14,4 +15,5 @@ __all__ = [
     "Task",
     "TaskId",
     "GraphId",
+    "TaskHandler",
 ]

--- a/boilermaker/task/graph.py
+++ b/boilermaker/task/graph.py
@@ -330,6 +330,7 @@ class TaskGraph(BaseModel):
                 # Check if parent has failed status in results
                 if parent_id in self.results and self.results[parent_id].status.failed:
                     yield self.fail_children[task_id]
+                    break  # Prevent double-yield when multiple parents have failed
 
     def get_result(self, task_id: TaskId) -> TaskResultSlim | TaskResult | None:
         """Get the result of a completed task."""

--- a/boilermaker/task/graph.py
+++ b/boilermaker/task/graph.py
@@ -748,11 +748,11 @@ class TaskGraphBuilder:
 
         return self.add(task, depends_on=LAST_ADDED, on_failure=on_failure)
 
-    def chain(self, *tasks: Task) -> "TaskGraphBuilder":
-        """Convenience method to chain tasks in sequence: A -> B -> C -> ...
+    def sequence(self, *tasks: Task) -> "TaskGraphBuilder":
+        """Convenience method to run tasks in sequence: A -> B -> C -> ...
 
         Args:
-            *tasks: Tasks to chain in order
+            *tasks: Tasks to run in order
 
         Returns:
             Self for method chaining

--- a/boilermaker/task/graph.py
+++ b/boilermaker/task/graph.py
@@ -332,6 +332,38 @@ class TaskGraph(BaseModel):
                     yield self.fail_children[task_id]
                     break  # Prevent double-yield when multiple parents have failed
 
+    def generate_scheduled_tasks(self) -> Generator[Task]:
+        """Yield tasks already in Scheduled status whose scheduling conditions are still met.
+
+        Used by ``continue_graph`` for crash-recovery: if a prior invocation wrote
+        a task to ``Scheduled`` in blob storage but crashed before publishing the
+        Service Bus message, this method identifies it on redelivery so that
+        ``continue_graph`` can re-publish it without a second blob write.
+
+        Conditions:
+          - Regular child tasks: all antecedents must have succeeded
+            (same predicate as ``generate_ready_tasks``).
+          - Failure callback tasks: at least one triggering parent must have a
+            failed status (same predicate as ``generate_failure_ready_tasks``).
+        """
+        # Regular children already in Scheduled status
+        for task_id, task in self.children.items():
+            result = self.results.get(task_id)
+            if result is not None and result.status == TaskStatus.Scheduled:
+                if self.all_antecedents_succeeded(task_id):
+                    yield task
+
+        # Failure callback children already in Scheduled status
+        for task_id, task in self.fail_children.items():
+            result = self.results.get(task_id)
+            if result is not None and result.status == TaskStatus.Scheduled:
+                # At least one triggering parent must have a failed status
+                for parent_id, fail_child_ids in self.fail_edges.items():
+                    if task_id in fail_child_ids:
+                        if parent_id in self.results and self.results[parent_id].status.failed:
+                            yield task
+                            break  # Prevent double-yield when multiple parents have failed
+
     def get_result(self, task_id: TaskId) -> TaskResultSlim | TaskResult | None:
         """Get the result of a completed task."""
         return self.results.get(task_id)

--- a/boilermaker/task/graph.py
+++ b/boilermaker/task/graph.py
@@ -459,6 +459,7 @@ class _LastAddedSentinel:
         return "LAST_ADDED"
 
 
+LastAddedSingleton: typing.TypeAlias = _LastAddedSentinel
 LAST_ADDED = _LastAddedSentinel()
 
 
@@ -541,7 +542,7 @@ class TaskGraphBuilder:
         self._failure_callbacks: dict[TaskId, set[Task]] = {}
         self._last_added: list[TaskId] = []  # Track recently added tasks for chaining
 
-    def _resolve_deps(
+    def _resolve_dependencies(
         self,
         depends_on: list[Task | TaskId | TaskChain],
     ) -> list[TaskId]:
@@ -602,7 +603,7 @@ class TaskGraphBuilder:
         self,
         task: Task,
         *,
-        depends_on: list[Task | TaskId | TaskChain] | None | _LastAddedSentinel = LAST_ADDED,
+        depends_on: list[Task | TaskId | TaskChain] | None | LastAddedSingleton = LAST_ADDED,
         on_failure: Task | None = None,
     ) -> "TaskGraphBuilder":
         """Add a task with optional explicit dependencies.
@@ -626,7 +627,7 @@ class TaskGraphBuilder:
             # Because `_LastAddedSentinel` is a singleton type used to indicate the default
             # We have to help the type checker understand that depends_on is not the sentinel.
             depends = typing.cast(list[Task | TaskId | TaskChain], depends_on)
-            parent_ids = self._resolve_deps(depends)
+            parent_ids = self._resolve_dependencies(depends)
         self._register_task(task, parent_ids=parent_ids, on_failure=on_failure)
         self._last_added = [task.task_id]
         return self
@@ -634,7 +635,7 @@ class TaskGraphBuilder:
     def parallel(
         self,
         *tasks: Task,
-        depends_on: list[Task | TaskId | TaskChain] | None | _LastAddedSentinel = LAST_ADDED,
+        depends_on: list[Task | TaskId | TaskChain] | None | LastAddedSingleton = LAST_ADDED,
         on_failure: Task | None = None,
     ) -> "TaskGraphBuilder":
         """Add multiple tasks to run in parallel.
@@ -661,7 +662,7 @@ class TaskGraphBuilder:
             shared_parents = []
         else:
             depends = typing.cast(list[Task | TaskId | TaskChain], depends_on)
-            shared_parents = self._resolve_deps(depends)
+            shared_parents = self._resolve_dependencies(depends)
 
         for t in tasks:
             self._register_task(t, parent_ids=shared_parents, on_failure=on_failure)
@@ -673,7 +674,7 @@ class TaskGraphBuilder:
         self,
         chain: "TaskChain",
         *,
-        depends_on: list[Task | TaskId | TaskChain] | None | _LastAddedSentinel = LAST_ADDED,
+        depends_on: list[Task | TaskId | TaskChain] | None | LastAddedSingleton = LAST_ADDED,
     ) -> "TaskGraphBuilder":
         """Embed a TaskChain into the graph as a composable unit.
 
@@ -700,7 +701,7 @@ class TaskGraphBuilder:
             first_task_parents = list(self._last_added)
         else:
             depends = typing.cast(list[Task | TaskId | TaskChain], depends_on)
-            first_task_parents = self._resolve_deps(depends)
+            first_task_parents = self._resolve_dependencies(depends)
 
         for i, chain_task in enumerate(chain._tasks):
             parent_ids = first_task_parents if i == 0 else [chain._tasks[i - 1].task_id]
@@ -771,10 +772,7 @@ class TaskGraphBuilder:
         # Add all tasks with their dependencies
         for task_id, task in self._tasks.items():
             dependencies = list(self._dependencies.get(task_id, set()))
-            if dependencies:
-                tg.add_task(task, parent_ids=dependencies)
-            else:
-                tg.add_task(task)
+            tg.add_task(task, parent_ids=dependencies)
 
         # Add failure callbacks
         for parent_task_id, callback_tasks in self._failure_callbacks.items():

--- a/boilermaker/task/graph.py
+++ b/boilermaker/task/graph.py
@@ -652,6 +652,9 @@ class TaskGraphBuilder:
 
             Self for method chaining
         """
+        if len(tasks) == 0:
+            raise ValueError("parallel requires at least one task.")
+
         if depends_on is LAST_ADDED:
             shared_parents = list(self._last_added)
         elif depends_on is None:
@@ -705,7 +708,7 @@ class TaskGraphBuilder:
 
         # ACCUMULATE cursor for independent roots, REPLACE for all others
         if depends_on is None:
-            self._last_added = self._last_added + [chain.last.task_id]
+            self._last_added.append(chain.last.task_id)
         else:
             self._last_added = [chain.last.task_id]
 

--- a/boilermaker/task/graph.py
+++ b/boilermaker/task/graph.py
@@ -543,7 +543,7 @@ class TaskGraphBuilder:
 
     def _resolve_deps(
         self,
-        depends_on: list["Task | TaskId | TaskChain"],
+        depends_on: list[Task | TaskId | TaskChain],
     ) -> list[TaskId]:
         """Resolve a mixed depends_on list to a flat list of TaskId strings.
 
@@ -602,7 +602,7 @@ class TaskGraphBuilder:
         self,
         task: Task,
         *,
-        depends_on: "list[Task | TaskId | TaskChain] | None | type[LAST_ADDED]" = LAST_ADDED,
+        depends_on: list[Task | TaskId | TaskChain] | None | _LastAddedSentinel = LAST_ADDED,
         on_failure: Task | None = None,
     ) -> "TaskGraphBuilder":
         """Add a task with optional explicit dependencies.
@@ -623,7 +623,10 @@ class TaskGraphBuilder:
         elif depends_on is None:
             parent_ids = []
         else:
-            parent_ids = self._resolve_deps(depends_on)
+            # Because `_LastAddedSentinel` is a singleton type used to indicate the default
+            # We have to help the type checker understand that depends_on is not the sentinel.
+            depends = typing.cast(list[Task | TaskId | TaskChain], depends_on)
+            parent_ids = self._resolve_deps(depends)
         self._register_task(task, parent_ids=parent_ids, on_failure=on_failure)
         self._last_added = [task.task_id]
         return self
@@ -631,7 +634,7 @@ class TaskGraphBuilder:
     def parallel(
         self,
         *tasks: Task,
-        depends_on: "list[Task | TaskId | TaskChain] | None | type[LAST_ADDED]" = LAST_ADDED,
+        depends_on: list[Task | TaskId | TaskChain] | None | _LastAddedSentinel = LAST_ADDED,
         on_failure: Task | None = None,
     ) -> "TaskGraphBuilder":
         """Add multiple tasks to run in parallel.
@@ -654,7 +657,8 @@ class TaskGraphBuilder:
         elif depends_on is None:
             shared_parents = []
         else:
-            shared_parents = self._resolve_deps(depends_on)
+            depends = typing.cast(list[Task | TaskId | TaskChain], depends_on)
+            shared_parents = self._resolve_deps(depends)
 
         for t in tasks:
             self._register_task(t, parent_ids=shared_parents, on_failure=on_failure)
@@ -666,7 +670,7 @@ class TaskGraphBuilder:
         self,
         chain: "TaskChain",
         *,
-        depends_on: "list[Task | TaskId | TaskChain] | None | type[LAST_ADDED]" = LAST_ADDED,
+        depends_on: list[Task | TaskId | TaskChain] | None | _LastAddedSentinel = LAST_ADDED,
     ) -> "TaskGraphBuilder":
         """Embed a TaskChain into the graph as a composable unit.
 
@@ -692,7 +696,8 @@ class TaskGraphBuilder:
         elif depends_on is LAST_ADDED:
             first_task_parents = list(self._last_added)
         else:
-            first_task_parents = self._resolve_deps(depends_on)
+            depends = typing.cast(list[Task | TaskId | TaskChain], depends_on)
+            first_task_parents = self._resolve_deps(depends)
 
         for i, chain_task in enumerate(chain._tasks):
             parent_ids = first_task_parents if i == 0 else [chain._tasks[i - 1].task_id]

--- a/boilermaker/task/graph.py
+++ b/boilermaker/task/graph.py
@@ -487,11 +487,18 @@ class TaskChain:
               to express "wait for this entire chain to complete".
     """
 
-    def __init__(self, *tasks: Task, on_failure: Task | None = None) -> None:
+    def __init__(self, *tasks: Task, on_any_failure: Task | None = None) -> None:
         if len(tasks) == 0:
             raise ValueError("TaskChain requires at least one task.")
         self._tasks: list[Task] = list(tasks)
-        self._on_failure: Task | None = on_failure
+        self.on_any_failure: Task | None = on_any_failure
+
+    def __len__(self) -> int:
+        return len(self._tasks)
+
+    def __iter__(self):
+        """Iterate over the tasks in the chain in order."""
+        return iter(self._tasks)
 
     @property
     def head(self) -> Task:
@@ -703,9 +710,15 @@ class TaskGraphBuilder:
             depends = typing.cast(list[Task | TaskId | TaskChain], depends_on)
             first_task_parents = self._resolve_dependencies(depends)
 
-        for i, chain_task in enumerate(chain._tasks):
-            parent_ids = first_task_parents if i == 0 else [chain._tasks[i - 1].task_id]
-            self._register_task(chain_task, parent_ids=parent_ids, on_failure=chain._on_failure)
+        chain_parent = None
+        for task in chain:
+            if chain_parent is None:
+                parent_task_ids = first_task_parents
+            else:
+                parent_task_ids = [chain_parent.task_id]
+
+            self._register_task(task, parent_ids=parent_task_ids, on_failure=chain.on_any_failure)
+            chain_parent = task
 
         # ACCUMULATE cursor for independent roots, REPLACE for all others
         if depends_on is None:

--- a/boilermaker/task/graph.py
+++ b/boilermaker/task/graph.py
@@ -445,6 +445,64 @@ class TaskGraph(BaseModel):
         return reachable
 
 
+class _LastAddedSentinel:
+    """Sentinel type for depends_on=LAST_ADDED — means "depend on the last task(s) added"."""
+
+    _instance = None
+
+    def __new__(cls) -> "_LastAddedSentinel":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:
+        return "LAST_ADDED"
+
+
+LAST_ADDED = _LastAddedSentinel()
+
+
+class TaskChain:
+    """An ordered sequence of tasks forming a composable workflow unit.
+
+    TaskChain groups tasks that always execute sequentially (A → B → C). The
+    chain exposes its first task (head) and last task (tail) so it can be
+    wired into a TaskGraphBuilder with explicit dependency references.
+
+    TaskChain is a value object — it has no builder methods, no cursor, and no
+    graph state. Its sole purpose is to be passed to TaskGraphBuilder.add_chain().
+
+    Args:
+        *tasks: One or more Task objects to chain in order.
+        on_failure: Optional Task to run if ANY task in the chain fails.
+            Registered on every task in the chain when embedded via add_chain().
+
+    Raises:
+        ValueError: If zero tasks are provided.
+
+    Properties:
+        head: The first task in the chain (entry point).
+        tail: The last task in the chain (exit point). Use in depends_on
+              to express "wait for this entire chain to complete".
+    """
+
+    def __init__(self, *tasks: Task, on_failure: Task | None = None) -> None:
+        if len(tasks) == 0:
+            raise ValueError("TaskChain requires at least one task.")
+        self._tasks: list[Task] = list(tasks)
+        self._on_failure: Task | None = on_failure
+
+    @property
+    def head(self) -> Task:
+        """The first task in the chain. Execution begins here."""
+        return self._tasks[0]
+
+    @property
+    def tail(self) -> Task:
+        """The last task in the chain. Use in depends_on to wait for this chain."""
+        return self._tasks[-1]
+
+
 class TaskGraphBuilder:
     """
     Builder class for constructing TaskGraph instances with flexible dependency management.
@@ -461,7 +519,7 @@ class TaskGraphBuilder:
         builder = TaskGraphBuilder().add(taskA).then(taskB).then(taskC)
 
         # Parallel execution: A, B, C all run in parallel
-        builder = TaskGraphBuilder().parallel([taskA, taskB, taskC])
+        builder = TaskGraphBuilder().parallel(taskA, taskB, taskC)
 
         # Complex dependencies: D depends on A and B, but C runs independently
         builder = (TaskGraphBuilder()
@@ -470,11 +528,10 @@ class TaskGraphBuilder:
             .add(taskC)
             .add(taskD, depends_on=[taskA.task_id, taskB.task_id]))
 
-        # With failure handling
+        # With failure handling (inline on_failure= kwarg)
         builder = (TaskGraphBuilder()
-            .add(taskA)
-            .then(taskB)
-            .on_failure(taskA.task_id, error_handler))
+            .add(taskA, on_failure=error_handler)
+            .then(taskB))
 
     """
 
@@ -484,77 +541,190 @@ class TaskGraphBuilder:
         self._failure_callbacks: dict[TaskId, set[Task]] = {}
         self._last_added: list[TaskId] = []  # Track recently added tasks for chaining
 
-    def add(self, task: Task, depends_on: list[TaskId] | None = None) -> "TaskGraphBuilder":
+    def _resolve_deps(
+        self,
+        depends_on: list["Task | TaskId | TaskChain"],
+    ) -> list[TaskId]:
+        """Resolve a mixed depends_on list to a flat list of TaskId strings.
+
+        Resolution rules (per element):
+            TaskChain → chain.tail.task_id
+            Task      → task.task_id
+            TaskId    → used as-is
+
+        Raises:
+            ValueError: If any resolved TaskId is not found in self._tasks.
+        """
+        resolved = []
+        for dep in depends_on:
+            if isinstance(dep, TaskChain):
+                dep_id = dep.tail.task_id
+            elif isinstance(dep, Task):
+                dep_id = dep.task_id
+            else:
+                dep_id = dep  # TaskId string
+            if dep_id not in self._tasks:
+                raise ValueError(
+                    f"Task {dep_id!r} referenced in depends_on was not found in this graph. "
+                    f"Add it with .add() before referencing it as a dependency."
+                )
+            resolved.append(dep_id)
+        return resolved
+
+    def _register_task(
+        self,
+        task: Task,
+        parent_ids: list[TaskId],
+        on_failure: Task | None = None,
+    ) -> None:
+        """Register a task into internal storage without touching _last_added.
+
+        Args:
+            task: Task to register
+            parent_ids: List of resolved parent TaskId strings
+            on_failure: Optional failure callback task
+
+        Raises:
+            ValueError: If task.task_id already exists in self._tasks.
+        """
+        if task.task_id in self._tasks:
+            raise ValueError(
+                f"Task {task.task_id!r} (function_name={task.function_name!r}) has already been "
+                f"added to this graph. Each task instance can only appear once. Create a new Task "
+                f"with Task.si(...) if you need the same function to run again."
+            )
+        self._tasks[task.task_id] = task
+        self._dependencies[task.task_id] = set(parent_ids)
+        if on_failure is not None:
+            self._failure_callbacks.setdefault(task.task_id, set()).add(on_failure)
+
+    def add(
+        self,
+        task: Task,
+        *,
+        depends_on: "list[Task | TaskId | TaskChain] | None | type[LAST_ADDED]" = LAST_ADDED,
+        on_failure: Task | None = None,
+    ) -> "TaskGraphBuilder":
         """Add a task with optional explicit dependencies.
 
         Args:
             task: Task to add
-            depends_on: Optional list of task IDs this task depends on (will run after self._last_added if None)
+            depends_on: Controls parent resolution:
+                - Omitted / LAST_ADDED: depend on the last task(s) added (cursor-following)
+                - None: root task with no parents
+                - list[Task | TaskId | TaskChain]: explicit parent list
+            on_failure: Optional task to run if this task fails
 
         Returns:
             Self for method chaining
         """
-        self._tasks[task.task_id] = task
-        self._dependencies[task.task_id] = set(depends_on or self._last_added)
+        if depends_on is LAST_ADDED:
+            parent_ids = list(self._last_added)
+        elif depends_on is None:
+            parent_ids = []
+        else:
+            parent_ids = self._resolve_deps(depends_on)
+        self._register_task(task, parent_ids=parent_ids, on_failure=on_failure)
         self._last_added = [task.task_id]
         return self
 
-    def parallel(self, tasks: list[Task], depends_on: list[TaskId] | None = None) -> "TaskGraphBuilder":
+    def parallel(
+        self,
+        *tasks: Task,
+        depends_on: "list[Task | TaskId | TaskChain] | None | type[LAST_ADDED]" = LAST_ADDED,
+        on_failure: Task | None = None,
+    ) -> "TaskGraphBuilder":
         """Add multiple tasks to run in parallel.
 
         Args:
 
-            tasks: List of tasks to run in parallel
-            depends_on: Optional list of task IDs all these tasks depend on
+            *tasks: Tasks to run in parallel (variadic)
+            depends_on: Controls parent resolution:
+                - Omitted / LAST_ADDED: depend on the last task(s) added (cursor-following)
+                - None: root tasks with no parents
+                - list[Task | TaskId | TaskChain]: explicit parent list
+            on_failure: Optional task to run if any of these tasks fail
 
         Returns:
 
             Self for method chaining
         """
-        parents = depends_on or self._last_added
-        for task in tasks:
-            self._tasks[task.task_id] = task
-            self._dependencies[task.task_id] = set(parents)
+        if depends_on is LAST_ADDED:
+            shared_parents = list(self._last_added)
+        elif depends_on is None:
+            shared_parents = []
+        else:
+            shared_parents = self._resolve_deps(depends_on)
+
+        for t in tasks:
+            self._register_task(t, parent_ids=shared_parents, on_failure=on_failure)
 
         self._last_added = [t.task_id for t in tasks]
         return self
 
-    def then(self, task: Task) -> "TaskGraphBuilder":
+    def add_chain(
+        self,
+        chain: "TaskChain",
+        *,
+        depends_on: "list[Task | TaskId | TaskChain] | None | type[LAST_ADDED]" = LAST_ADDED,
+    ) -> "TaskGraphBuilder":
+        """Embed a TaskChain into the graph as a composable unit.
+
+        Cursor behavior:
+            depends_on=LAST_ADDED (default): chain.head depends on current cursor.
+                Cursor is REPLACED with [chain.tail.task_id].
+            depends_on=None: chain.head is an independent root (no parents).
+                Cursor ACCUMULATES — chain.tail is APPENDED to existing cursor.
+                This enables fan-in: two add_chain(depends_on=None) calls followed
+                by .then(join) creates a task that waits for BOTH chains.
+            depends_on=[...]: chain.head depends on resolved deps.
+                Cursor is REPLACED with [chain.tail.task_id].
+
+        Args:
+            chain: TaskChain to embed
+            depends_on: Controls parent resolution for the chain's head task
+
+        Returns:
+            Self for method chaining
+        """
+        if depends_on is None:
+            first_task_parents: list[TaskId] = []
+        elif depends_on is LAST_ADDED:
+            first_task_parents = list(self._last_added)
+        else:
+            first_task_parents = self._resolve_deps(depends_on)
+
+        for i, chain_task in enumerate(chain._tasks):
+            parent_ids = first_task_parents if i == 0 else [chain._tasks[i - 1].task_id]
+            self._register_task(chain_task, parent_ids=parent_ids, on_failure=chain._on_failure)
+
+        # ACCUMULATE cursor for independent roots, REPLACE for all others
+        if depends_on is None:
+            self._last_added = self._last_added + [chain.tail.task_id]
+        else:
+            self._last_added = [chain.tail.task_id]
+
+        return self
+
+    def then(self, task: Task, *, on_failure: Task | None = None) -> "TaskGraphBuilder":
         """Add a task that depends on the previously added task(s).
 
         Args:
 
             task: Task to add that depends on last added tasks
+            on_failure: Optional task to run if this task fails
 
         Returns:
 
             Self for method chaining
         """
         if not self._last_added:
-            raise ValueError("No previous tasks to depend on. Use add() first.")
+            raise ValueError(
+                "No tasks have been added yet. Call .add() or .add_chain() first, "
+                "then use .then() to continue the chain."
+            )
 
-        return self.add(task, depends_on=self._last_added)
-
-    def on_failure(self, parent_task_id: TaskId, callback_task: Task) -> "TaskGraphBuilder":
-        """Add a failure callback for a specific task.
-
-        Args:
-
-            parent_task_id: Task ID that triggers the callback on failure
-            callback_task: Task to execute on failure
-
-        Returns:
-
-            Self for method chaining
-        """
-        if parent_task_id not in self._tasks:
-            raise ValueError(f"Parent task {parent_task_id} not found. Add it first.")
-
-        if parent_task_id not in self._failure_callbacks:
-            self._failure_callbacks[parent_task_id] = set()
-
-        self._failure_callbacks[parent_task_id].add(callback_task)
-        return self
+        return self.add(task, depends_on=LAST_ADDED, on_failure=on_failure)
 
     def chain(self, *tasks: Task) -> "TaskGraphBuilder":
         """Convenience method to chain tasks in sequence: A -> B -> C -> ...
@@ -577,23 +747,6 @@ class TaskGraphBuilder:
 
         return self
 
-    def add_success_fail_branch(
-        self,
-        branching_task_id: TaskId,
-        success_task: Task,
-        failure_task: Task,
-    ) -> "TaskGraphBuilder":
-        """Add success and failure branches for a task.
-
-        Args:
-            branching_task_id: TaskId to branch from
-            success_task: Task to run on success
-            failure_task: Task to run on failure
-        """
-        self.add(success_task, depends_on=[branching_task_id])
-        self.on_failure(branching_task_id, failure_task)
-        return self
-
     def build(self) -> TaskGraph:
         """Build and return the final TaskGraph.
 
@@ -604,7 +757,7 @@ class TaskGraphBuilder:
             ValueError: If the graph would contain cycles
         """
         if not self._tasks:
-            raise ValueError("Cannot build empty graph. Add at least one task.")
+            raise ValueError("Cannot build an empty graph. Add at least one task before calling build().")
 
         tg = TaskGraph()
         # Add all tasks with their dependencies

--- a/boilermaker/task/graph.py
+++ b/boilermaker/task/graph.py
@@ -466,7 +466,7 @@ class TaskChain:
     """An ordered sequence of tasks forming a composable workflow unit.
 
     TaskChain groups tasks that always execute sequentially (A → B → C). The
-    chain exposes its first task (head) and last task (tail) so it can be
+    chain exposes its first task (head) and last task (last) so it can be
     wired into a TaskGraphBuilder with explicit dependency references.
 
     TaskChain is a value object — it has no builder methods, no cursor, and no
@@ -482,7 +482,7 @@ class TaskChain:
 
     Properties:
         head: The first task in the chain (entry point).
-        tail: The last task in the chain (exit point). Use in depends_on
+        last: The last task in the chain (exit point). Use in depends_on
               to express "wait for this entire chain to complete".
     """
 
@@ -498,7 +498,7 @@ class TaskChain:
         return self._tasks[0]
 
     @property
-    def tail(self) -> Task:
+    def last(self) -> Task:
         """The last task in the chain. Use in depends_on to wait for this chain."""
         return self._tasks[-1]
 
@@ -548,7 +548,7 @@ class TaskGraphBuilder:
         """Resolve a mixed depends_on list to a flat list of TaskId strings.
 
         Resolution rules (per element):
-            TaskChain → chain.tail.task_id
+            TaskChain → chain.last.task_id
             Task      → task.task_id
             TaskId    → used as-is
 
@@ -558,7 +558,7 @@ class TaskGraphBuilder:
         resolved = []
         for dep in depends_on:
             if isinstance(dep, TaskChain):
-                dep_id = dep.tail.task_id
+                dep_id = dep.last.task_id
             elif isinstance(dep, Task):
                 dep_id = dep.task_id
             else:
@@ -676,13 +676,13 @@ class TaskGraphBuilder:
 
         Cursor behavior:
             depends_on=LAST_ADDED (default): chain.head depends on current cursor.
-                Cursor is REPLACED with [chain.tail.task_id].
+                Cursor is REPLACED with [chain.last.task_id].
             depends_on=None: chain.head is an independent root (no parents).
-                Cursor ACCUMULATES — chain.tail is APPENDED to existing cursor.
+                Cursor ACCUMULATES — chain.last is APPENDED to existing cursor.
                 This enables fan-in: two add_chain(depends_on=None) calls followed
                 by .then(join) creates a task that waits for BOTH chains.
             depends_on=[...]: chain.head depends on resolved deps.
-                Cursor is REPLACED with [chain.tail.task_id].
+                Cursor is REPLACED with [chain.last.task_id].
 
         Args:
             chain: TaskChain to embed
@@ -705,9 +705,9 @@ class TaskGraphBuilder:
 
         # ACCUMULATE cursor for independent roots, REPLACE for all others
         if depends_on is None:
-            self._last_added = self._last_added + [chain.tail.task_id]
+            self._last_added = self._last_added + [chain.last.task_id]
         else:
-            self._last_added = [chain.tail.task_id]
+            self._last_added = [chain.last.task_id]
 
         return self
 

--- a/boilermaker/task/task.py
+++ b/boilermaker/task/task.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict
 from boilermaker import retries, tracing
 
 from .task_id import GraphId, ident_field, TaskId
+from .types import TaskHandler
 
 logger = logging.getLogger(__name__)
 
@@ -257,7 +258,7 @@ class Task(BaseModel):
     @classmethod
     def si(
         cls,
-        fn: typing.Callable,
+        fn: TaskHandler,
         *fn_args,
         should_dead_letter: bool = True,
         acks_late: bool = True,

--- a/boilermaker/task/types.py
+++ b/boilermaker/task/types.py
@@ -7,7 +7,7 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 
-# Enforce the followign rule: anything Callable but it must have a __name__ attribute!
+# Enforce the following rule: anything Callable but it must have a __name__ attribute!
 # functools.partials by default do not have a __name__ attribute. This offers a warning for users.
 class NamedAwaitable(Protocol[P, R]):
     __name__: str

--- a/boilermaker/task/types.py
+++ b/boilermaker/task/types.py
@@ -1,0 +1,18 @@
+from collections.abc import Awaitable
+from typing import Any, ParamSpec, Protocol, TypeAlias, TypeVar
+
+# params
+P = ParamSpec("P")
+# return type
+R = TypeVar("R")
+
+
+# Enforce the followign rule: anything Callable but it must have a __name__ attribute!
+# functools.partials by default do not have a __name__ attribute. This offers a warning for users.
+class NamedAwaitable(Protocol[P, R]):
+    __name__: str
+
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R: ...
+
+
+TaskHandler: TypeAlias = NamedAwaitable[..., Awaitable[Any]]

--- a/docs/api-reference/task-graph.md
+++ b/docs/api-reference/task-graph.md
@@ -1,6 +1,30 @@
 # Task Graph API Reference
 
-API documentation for TaskGraph and TaskGraphBuilder classes used to build complex workflows with dependencies.
+API documentation for TaskGraph, TaskGraphBuilder, and TaskChain classes used to build complex workflows with dependencies.
+
+## Module-level Constants
+
+### `LAST_ADDED`
+
+```python
+from boilermaker.task import LAST_ADDED
+```
+
+Sentinel value used as the default for `depends_on` parameters. When passed (or omitted,
+since it is the default), the method resolves dependencies using the builder's internal
+cursor — the last task(s) added. Use `None` to declare an explicit root task with no
+parents.
+
+## TaskChain
+
+::: boilermaker.task.graph.TaskChain
+  options:
+    show_source: true
+    show_root_heading: true
+    members:
+      - __init__
+      - head
+      - tail
 
 ## TaskGraphBuilder
 
@@ -11,11 +35,10 @@ API documentation for TaskGraph and TaskGraphBuilder classes used to build compl
     members:
       - __init__
       - add
-      - parallel
       - then
+      - parallel
+      - add_chain
       - chain
-      - on_failure
-      - add_success_fail_branch
       - build
 
 ## TaskGraph
@@ -45,15 +68,55 @@ API documentation for TaskGraph and TaskGraphBuilder classes used to build compl
 ## Quick Examples
 
 ```py
-# Sequential workflow
-graph = TaskGraphBuilder().chain(task_a, task_b, task_c).build()
+from boilermaker.task import LAST_ADDED, TaskChain, TaskGraphBuilder
 
-# Parallel execution
-graph = TaskGraphBuilder().parallel([task_a, task_b, task_c]).build()
+# Sequential workflow: A → B → C
+graph = (
+    TaskGraphBuilder()
+    .add(task_a)
+    .then(task_b)
+    .then(task_c)
+    .build()
+)
 
-# With failure handling
-graph = (TaskGraphBuilder()
-    .add(main_task)
-    .on_failure(main_task.task_id, cleanup_task)
-    .build())
+# Fan-out: A → (B, C, D)
+graph = (
+    TaskGraphBuilder()
+    .add(task_a)
+    .parallel(task_b, task_c, task_d)
+    .build()
+)
+
+# Diamond: A → (B, C) → D
+graph = (
+    TaskGraphBuilder()
+    .add(task_a)
+    .parallel(task_b, task_c)
+    .then(task_d)
+    .build()
+)
+
+# Inline failure handler
+graph = (
+    TaskGraphBuilder()
+    .add(main_task, on_failure=cleanup_task)
+    .then(success_task)  # only runs if main_task succeeds
+    .build()
+)
+
+# Independent chains with fan-in join (previously impossible)
+chain_abc = TaskChain(task_a, task_b, task_c)
+chain_de  = TaskChain(task_d, task_e)
+
+graph = (
+    TaskGraphBuilder()
+    .add_chain(chain_abc, depends_on=None)  # root; cursor accumulates
+    .add_chain(chain_de,  depends_on=None)  # root; cursor accumulates
+    .then(task_f)                           # depends on both chain tails
+    .build()
+)
+
+# TaskChain with shared failure handler
+pipeline = TaskChain(task_a, task_b, task_c, on_failure=error_handler)
+graph = TaskGraphBuilder().add_chain(pipeline).build()
 ```

--- a/docs/api-reference/task-graph.md
+++ b/docs/api-reference/task-graph.md
@@ -24,7 +24,7 @@ parents.
     members:
       - __init__
       - head
-      - tail
+      - last
 
 ## TaskGraphBuilder
 
@@ -112,7 +112,7 @@ graph = (
     TaskGraphBuilder()
     .add_chain(chain_abc, depends_on=None)  # root; cursor accumulates
     .add_chain(chain_de,  depends_on=None)  # root; cursor accumulates
-    .then(task_f)                           # depends on both chain tails
+    .then(task_f)                           # depends on both chain lasts
     .build()
 )
 

--- a/docs/api-reference/task-graph.md
+++ b/docs/api-reference/task-graph.md
@@ -104,7 +104,7 @@ graph = (
     .build()
 )
 
-# Independent chains with fan-in join (previously impossible)
+# Independent chains with fan-in join
 chain_abc = TaskChain(task_a, task_b, task_c)
 chain_de  = TaskChain(task_d, task_e)
 

--- a/docs/api-reference/task-graph.md
+++ b/docs/api-reference/task-graph.md
@@ -117,6 +117,6 @@ graph = (
 )
 
 # TaskChain with shared failure handler
-pipeline = TaskChain(task_a, task_b, task_c, on_failure=error_handler)
+pipeline = TaskChain(task_a, task_b, task_c, on_any_failure=error_handler)
 graph = TaskGraphBuilder().add_chain(pipeline).build()
 ```

--- a/docs/guides/task-graphs.md
+++ b/docs/guides/task-graphs.md
@@ -99,7 +99,7 @@ graph = (
 
 The `TaskChain` class lets you build sequential sub-graphs independently and then compose
 them in a `TaskGraphBuilder`. The key is `depends_on=None`, which marks a chain as a root
-(no parents) while **accumulating** its tail into the cursor rather than replacing it.
+(no parents) while **accumulating** its last into the cursor rather than replacing it.
 
 This pattern was previously impossible with the old API.
 
@@ -125,10 +125,10 @@ graph = (
 ```
 
 !!! note "Cursor accumulation"
-    `add_chain(chain, depends_on=None)` **appends** the chain's tail to the cursor
+    `add_chain(chain, depends_on=None)` **appends** the chain's last to the cursor
     instead of replacing it. This is what makes the fan-in join possible. Using
     `add(task, depends_on=None)` instead **replaces** the cursor, which would lose
-    the reference to the previous chain's tail.
+    the reference to the previous chain's last.
 
 You can also be fully explicit using `depends_on` with `TaskChain` objects directly:
 
@@ -137,7 +137,7 @@ graph = (
     TaskGraphBuilder()
     .add_chain(chain_abc, depends_on=None)
     .add_chain(chain_de,  depends_on=None)
-    .add(task_f, depends_on=[chain_abc, chain_de])  # TaskChain resolves to its .tail
+    .add(task_f, depends_on=[chain_abc, chain_de])  # TaskChain resolves to its .last
     .build()
 )
 ```
@@ -214,8 +214,8 @@ that omit `depends_on` implicitly depend on the cursor:
 | `add(task)` | `[task]` |
 | `then(task)` | `[task]` |
 | `parallel(t1, t2, t3)` | `[t1, t2, t3]` |
-| `add_chain(chain)` | `[chain.tail]` |
-| `add_chain(chain, depends_on=None)` | `existing_cursor + [chain.tail]` ← accumulates |
+| `add_chain(chain)` | `[chain.last]` |
+| `add_chain(chain, depends_on=None)` | `existing_cursor + [chain.last]` ← accumulates |
 | `add(task, depends_on=None)` | `[task]` ← replaces (use `add_chain` for accumulation) |
 
 ## Storage Setup

--- a/docs/guides/task-graphs.md
+++ b/docs/guides/task-graphs.md
@@ -101,8 +101,6 @@ The `TaskChain` class lets you build sequential sub-graphs independently and the
 them in a `TaskGraphBuilder`. The key is `depends_on=None`, which marks a chain as a root
 (no parents) while **accumulating** its last into the cursor rather than replacing it.
 
-This pattern was previously impossible with the old API.
-
 ```py
 from boilermaker.task import TaskChain, TaskGraphBuilder
 

--- a/docs/guides/task-graphs.md
+++ b/docs/guides/task-graphs.md
@@ -2,7 +2,9 @@
 
 Build complex workflows with dependencies (DAGs) using the `TaskGraphBuilder`.
 
-Task graphs allow you to create Directed Acyclic Graphs (DAGs) where tasks can chain, run in parallel, trigger failures for various child nodes, or schedule other callbacks. All dependent children in the DAG wait for the parents to complete.
+Task graphs allow you to create Directed Acyclic Graphs (DAGs) where tasks can chain, run in
+parallel, trigger failure callbacks, or converge in a fan-in join. All dependent children in
+the DAG wait for their parents to complete.
 
 !!! tip "When to Use Task Graphs"
     Use TaskGraphBuilder for workflows with:
@@ -10,17 +12,17 @@ Task graphs allow you to create Directed Acyclic Graphs (DAGs) where tasks can c
     - Multiple parallel tasks
     - Complex dependencies between tasks
     - Fan-out/fan-in patterns
-    - Conditional execution paths
+    - Failure handling scoped to individual tasks
 
     For simple sequential tasks, consider using [task chains](callbacks-chains.md) instead.
 
-!!! tip "DAGS Only
-    They must be DAGs: Accidentally creating a cycle will raise an exception.
+!!! tip "DAGs Only"
+    They must be DAGs: accidentally creating a cycle will raise an exception.
 
 ## Quick Start
 
 ```py
-from boilermaker.task import TaskGraphBuilder
+from boilermaker.task import LAST_ADDED, TaskChain, TaskGraphBuilder
 
 # Register your tasks first
 app.register_async(fetch_data, policy=retries.RetryPolicy.default())
@@ -34,42 +36,187 @@ async def create_workflow():
     save_task = app.create_task(save_results)
 
     # Build: fetch → process → save
-    graph = (TaskGraphBuilder()
+    graph = (
+        TaskGraphBuilder()
         .add(fetch_task)
         .then(process_task)
         .then(save_task)
-        .build())
+        .build()
+    )
 
     await app.publish_graph(graph)
 ```
 
 ## Common Patterns
 
+### Sequential: A → B → C
+
 ```py
-# Sequential: A → B → C
-graph = TaskGraphBuilder().chain(task_a, task_b, task_c).build()
-
-# Parallel: A, B, C run together
-graph = TaskGraphBuilder().parallel([task_a, task_b, task_c]).build()
-
-# Fan-out: A → (B, C, D) → E
-graph = (TaskGraphBuilder()
+graph = (
+    TaskGraphBuilder()
     .add(task_a)
-    .parallel([task_b, task_c, task_d])
-    .then(task_e)
-    .build())
+    .then(task_b)
+    .then(task_c)
+    .build()
+)
+```
+
+### Fan-out: A → (B, C, D)
+
+```py
+graph = (
+    TaskGraphBuilder()
+    .add(task_a)
+    .parallel(task_b, task_c, task_d)  # all depend on task_a; run in parallel
+    .build()
+)
+```
+
+### Fan-in: (A, B, C) → D
+
+```py
+graph = (
+    TaskGraphBuilder()
+    .parallel(task_a, task_b, task_c)  # three independent roots; cursor = [a, b, c]
+    .then(task_d)                      # depends on all three; fan-in join
+    .build()
+)
+```
+
+### Diamond: A → (B, C) → D
+
+```py
+graph = (
+    TaskGraphBuilder()
+    .add(task_a)
+    .parallel(task_b, task_c)   # both depend on task_a; cursor = [b, c]
+    .then(task_d)               # depends on task_b AND task_c; fan-in join
+    .build()
+)
+```
+
+## Independent Chains with Fan-In
+
+The `TaskChain` class lets you build sequential sub-graphs independently and then compose
+them in a `TaskGraphBuilder`. The key is `depends_on=None`, which marks a chain as a root
+(no parents) while **accumulating** its tail into the cursor rather than replacing it.
+
+This pattern was previously impossible with the old API.
+
+```py
+from boilermaker.task import TaskChain, TaskGraphBuilder
+
+# Two independent pipelines that converge on a single join task
+#
+#   task_a → task_b → task_c ─┐
+#                               ├─→ task_f
+#   task_d → task_e ───────────┘
+
+chain_abc = TaskChain(task_a, task_b, task_c)
+chain_de  = TaskChain(task_d, task_e)
+
+graph = (
+    TaskGraphBuilder()
+    .add_chain(chain_abc, depends_on=None)   # root chain; cursor = [task_c]
+    .add_chain(chain_de,  depends_on=None)   # root chain; cursor = [task_c, task_e]
+    .then(task_f)                            # depends on task_c AND task_e; fan-in join
+    .build()
+)
+```
+
+!!! note "Cursor accumulation"
+    `add_chain(chain, depends_on=None)` **appends** the chain's tail to the cursor
+    instead of replacing it. This is what makes the fan-in join possible. Using
+    `add(task, depends_on=None)` instead **replaces** the cursor, which would lose
+    the reference to the previous chain's tail.
+
+You can also be fully explicit using `depends_on` with `TaskChain` objects directly:
+
+```py
+graph = (
+    TaskGraphBuilder()
+    .add_chain(chain_abc, depends_on=None)
+    .add_chain(chain_de,  depends_on=None)
+    .add(task_f, depends_on=[chain_abc, chain_de])  # TaskChain resolves to its .tail
+    .build()
+)
 ```
 
 ## Failure Handling
 
+Failure callbacks are declared inline with `on_failure=` at the task they guard. The handler
+is scoped to **that single task** — it does not cascade to downstream tasks.
+
+### Single-task failure handler
+
 ```py
-# Add failure callbacks with on_failure()
-graph = (TaskGraphBuilder()
-    .add(main_task)
-    .on_failure(main_task.task_id, cleanup_task)
-    .then(success_task)  # Only runs if main succeeds
-    .build())
+graph = (
+    TaskGraphBuilder()
+    .add(fetch_task, on_failure=fetch_error_handler)  # handler runs if fetch_task fails
+    .then(process_task)                               # only runs if fetch_task succeeds
+    .build()
+)
 ```
+
+- If `fetch_task` **succeeds**: `process_task` is scheduled. `fetch_error_handler` is never
+  triggered.
+- If `fetch_task` **fails**: `fetch_error_handler` is published. `process_task` is **never
+  executed** — it will never receive the signal it is waiting for.
+
+`then()` and `parallel()` also accept `on_failure=`:
+
+```py
+graph = (
+    TaskGraphBuilder()
+    .add(task_a)
+    .then(task_b, on_failure=error_handler)
+    .parallel(task_c, task_d, on_failure=parallel_error_handler)
+    .build()
+)
+```
+
+### Shared failure handler with `TaskChain`
+
+If you want a **single error handler that triggers if any task in a sequence fails**, use
+`TaskChain(on_failure=handler)`. The handler is registered on **each** task in the chain:
+
+```py
+pipeline = TaskChain(task_a, task_b, task_c, on_failure=pipeline_error_handler)
+
+graph = TaskGraphBuilder().add_chain(pipeline).build()
+```
+
+Whichever task fails first, `pipeline_error_handler` runs. Subsequent tasks in the chain
+(whose parent failed) never execute.
+
+### Complex example: parallel chains with failure handling
+
+```py
+ingest_chain  = TaskChain(validate_task, ingest_task,  on_failure=ingest_error_handler)
+process_chain = TaskChain(transform_task, enrich_task, on_failure=process_error_handler)
+
+graph = (
+    TaskGraphBuilder()
+    .add_chain(ingest_chain,  depends_on=None)  # root; cursor = [ingest_task]
+    .add_chain(process_chain, depends_on=None)  # root; cursor = [ingest_task, enrich_task]
+    .then(aggregate_task, on_failure=cleanup_task)  # waits for both chains
+    .build()
+)
+```
+
+## Cursor Semantics
+
+The builder maintains an internal cursor tracking the most recently added task(s). Methods
+that omit `depends_on` implicitly depend on the cursor:
+
+| Call | Cursor after |
+|------|--------------|
+| `add(task)` | `[task]` |
+| `then(task)` | `[task]` |
+| `parallel(t1, t2, t3)` | `[t1, t2, t3]` |
+| `add_chain(chain)` | `[chain.tail]` |
+| `add_chain(chain, depends_on=None)` | `existing_cursor + [chain.tail]` ← accumulates |
+| `add(task, depends_on=None)` | `[task]` ← replaces (use `add_chain` for accumulation) |
 
 ## Storage Setup
 

--- a/docs/guides/task-graphs.md
+++ b/docs/guides/task-graphs.md
@@ -178,10 +178,10 @@ graph = (
 ### Shared failure handler with `TaskChain`
 
 If you want a **single error handler that triggers if any task in a sequence fails**, use
-`TaskChain(on_failure=handler)`. The handler is registered on **each** task in the chain:
+`TaskChain(on_any_failure=handler)`. The handler is registered on **each** task in the chain:
 
 ```py
-pipeline = TaskChain(task_a, task_b, task_c, on_failure=pipeline_error_handler)
+pipeline = TaskChain(task_a, task_b, task_c, on_any_failure=pipeline_error_handler)
 
 graph = TaskGraphBuilder().add_chain(pipeline).build()
 ```
@@ -192,8 +192,8 @@ Whichever task fails first, `pipeline_error_handler` runs. Subsequent tasks in t
 ### Complex example: parallel chains with failure handling
 
 ```py
-ingest_chain  = TaskChain(validate_task, ingest_task,  on_failure=ingest_error_handler)
-process_chain = TaskChain(transform_task, enrich_task, on_failure=process_error_handler)
+ingest_chain  = TaskChain(validate_task, ingest_task,  on_any_failure=ingest_error_handler)
+process_chain = TaskChain(transform_task, enrich_task, on_any_failure=process_error_handler)
 
 graph = (
     TaskGraphBuilder()

--- a/docs/index.md
+++ b/docs/index.md
@@ -101,6 +101,11 @@ if __name__ == "__main__":
     asyncio.run(publish_tasks())
 ```
 
+!!! note "Duplicate Detection"
+    - Boilermaker publishes each message with `unique_msg_id` set to the task id.
+    - Azure Service Bus only enforces this when duplicate detection is enabled on the queue/topic. See [Duplicate detection](https://learn.microsoft.com/en-us/azure/service-bus-messaging/duplicate-detection).
+    - Publishing the same task id again within the duplicate detection window is rejected by Service Bus, causing publish to fail.
+
 ### Running Workers
 
 In a separate process, run the worker to process tasks:

--- a/examples/task_graph_example.py
+++ b/examples/task_graph_example.py
@@ -162,8 +162,6 @@ async def example_diamond(app: Boilermaker) -> None:
 async def example_independent_chains_join(app: Boilermaker) -> None:
     """Pattern 5 — Independent chains with fan-in join.
 
-    This pattern was previously impossible with the old API.
-
     Graph:
         fetch → process → save ─┐
                                   ├→ aggregate

--- a/examples/task_graph_example.py
+++ b/examples/task_graph_example.py
@@ -20,8 +20,7 @@ from azure.identity.aio import DefaultAzureCredential
 from boilermaker import Boilermaker
 from boilermaker.service_bus import AzureServiceBus
 from boilermaker.storage import BlobClientStorage
-from boilermaker.task import LAST_ADDED, TaskChain, TaskGraphBuilder
-
+from boilermaker.task import Task, TaskChain, TaskGraphBuilder
 
 # ---------------------------------------------------------------------------
 # Task functions
@@ -92,7 +91,9 @@ async def handle_aggregation_error(state):
 
 async def example_sequential(app: Boilermaker) -> None:
     """Pattern 1 — Sequential: fetch → process → save."""
-    fetch_task = app.create_task(fetch_data, "https://api.example.com/data")
+    # Create a Task with an immutable signature (si) so that the args are baked in
+    fetch_task = Task.si(fetch_data, "https://api.example.com/data")
+    # Alterantively, we can use the Boilermaker app to create the same
     process_task = app.create_task(process_data, {"data": "placeholder", "size": 0})
     save_task = app.create_task(save_results, {"processed": False})
 

--- a/examples/task_graph_example.py
+++ b/examples/task_graph_example.py
@@ -3,6 +3,15 @@ Example of TaskGraph workflows using TaskGraphBuilder.
 
 This example demonstrates how to create complex workflows using TaskGraphBuilder,
 which provides a simple, readable way to define DAG-based task dependencies.
+
+Patterns covered:
+  1. Sequential:                add().then().then()
+  2. Fan-out:                   add().parallel(t1, t2, t3)
+  3. Fan-in:                    parallel(a, b, c).then(d)
+  4. Diamond:                   add(a).parallel(b, c).then(d)
+  5. Independent chains + join: add_chain(..., depends_on=None) x2, then join
+  6. Inline failure handler:    add(task, on_failure=handler)
+  7. TaskChain with shared failure handler
 """
 
 import asyncio
@@ -11,12 +20,17 @@ from azure.identity.aio import DefaultAzureCredential
 from boilermaker import Boilermaker
 from boilermaker.service_bus import AzureServiceBus
 from boilermaker.storage import BlobClientStorage
+from boilermaker.task import LAST_ADDED, TaskChain, TaskGraphBuilder
+
+
+# ---------------------------------------------------------------------------
+# Task functions
+# ---------------------------------------------------------------------------
 
 
 async def fetch_data(state, url: str):
     """Simulate fetching data from a URL."""
     print(f"Fetching data from {url}")
-    # Simulate some work
     await asyncio.sleep(1)
     return {"data": f"content from {url}", "size": 1024}
 
@@ -47,6 +61,12 @@ async def cleanup_temp_files(state):
     return {"cleanup_completed": True}
 
 
+async def aggregate_results(state):
+    """Aggregate results from multiple sources."""
+    print("Aggregating all results")
+    return {"aggregated": True}
+
+
 async def handle_fetch_error(state):
     """Handle fetch data errors."""
     print("Handling fetch error - trying backup source")
@@ -59,14 +79,165 @@ async def handle_processing_error(state):
     return {"alert_sent": True}
 
 
-async def main():
-    """Demonstrate TaskGraph usage."""
+async def handle_aggregation_error(state):
+    """Handle aggregation errors."""
+    print("Aggregation failed - running cleanup")
+    return {"cleanup_done": True}
 
-    # Set up the application (you'd configure these with real values)
+
+# ---------------------------------------------------------------------------
+# Workflow patterns
+# ---------------------------------------------------------------------------
+
+
+async def example_sequential(app: Boilermaker) -> None:
+    """Pattern 1 — Sequential: fetch → process → save."""
+    fetch_task = app.create_task(fetch_data, "https://api.example.com/data")
+    process_task = app.create_task(process_data, {"data": "placeholder", "size": 0})
+    save_task = app.create_task(save_results, {"processed": False})
+
+    graph = (
+        TaskGraphBuilder()
+        .add(fetch_task)
+        .then(process_task)
+        .then(save_task)
+        .build()
+    )
+    await app.publish_graph(graph)
+    print(f"[sequential] published graph {graph.graph_id}")
+
+
+async def example_fan_out(app: Boilermaker) -> None:
+    """Pattern 2 — Fan-out: fetch → (notify, cleanup)."""
+    fetch_task = app.create_task(fetch_data, "https://api.example.com/data")
+    notify_task = app.create_task(send_notification, "placeholder_id")
+    cleanup_task = app.create_task(cleanup_temp_files)
+
+    graph = (
+        TaskGraphBuilder()
+        .add(fetch_task)
+        .parallel(notify_task, cleanup_task)  # both depend on fetch; run in parallel
+        .build()
+    )
+    await app.publish_graph(graph)
+    print(f"[fan-out] published graph {graph.graph_id}")
+
+
+async def example_fan_in(app: Boilermaker) -> None:
+    """Pattern 3 — Fan-in: (fetch, process, save) → aggregate."""
+    fetch_task = app.create_task(fetch_data, "https://api.example.com/data")
+    process_task = app.create_task(process_data, {"data": "placeholder", "size": 0})
+    save_task = app.create_task(save_results, {"processed": False})
+    agg_task = app.create_task(aggregate_results)
+
+    graph = (
+        TaskGraphBuilder()
+        .parallel(fetch_task, process_task, save_task)  # three independent roots; cursor = all three
+        .then(agg_task)  # depends on all three; fan-in
+        .build()
+    )
+    await app.publish_graph(graph)
+    print(f"[fan-in] published graph {graph.graph_id}")
+
+
+async def example_diamond(app: Boilermaker) -> None:
+    """Pattern 4 — Diamond: fetch → (process, save) → aggregate."""
+    fetch_task = app.create_task(fetch_data, "https://api.example.com/data")
+    process_task = app.create_task(process_data, {"data": "placeholder", "size": 0})
+    save_task = app.create_task(save_results, {"processed": False})
+    agg_task = app.create_task(aggregate_results)
+
+    graph = (
+        TaskGraphBuilder()
+        .add(fetch_task)
+        .parallel(process_task, save_task)  # both depend on fetch; cursor = [process, save]
+        .then(agg_task)  # depends on process AND save; fan-in join
+        .build()
+    )
+    await app.publish_graph(graph)
+    print(f"[diamond] published graph {graph.graph_id}")
+
+
+async def example_independent_chains_join(app: Boilermaker) -> None:
+    """Pattern 5 — Independent chains with fan-in join.
+
+    This pattern was previously impossible with the old API.
+
+    Graph:
+        fetch → process → save ─┐
+                                  ├→ aggregate
+        notify → cleanup ────────┘
+    """
+    fetch_task = app.create_task(fetch_data, "https://api.example.com/data")
+    process_task = app.create_task(process_data, {"data": "placeholder", "size": 0})
+    save_task = app.create_task(save_results, {"processed": False})
+    notify_task = app.create_task(send_notification, "placeholder_id")
+    cleanup_task = app.create_task(cleanup_temp_files)
+    agg_task = app.create_task(aggregate_results)
+
+    pipeline_chain = TaskChain(fetch_task, process_task, save_task)
+    notification_chain = TaskChain(notify_task, cleanup_task)
+
+    graph = (
+        TaskGraphBuilder()
+        .add_chain(pipeline_chain, depends_on=None)      # root; cursor = [save_task]
+        .add_chain(notification_chain, depends_on=None)  # root; cursor = [save_task, cleanup_task]
+        .then(agg_task)                                   # depends on BOTH chain tails
+        .build()
+    )
+    await app.publish_graph(graph)
+    print(f"[independent-chains-join] published graph {graph.graph_id}")
+
+
+async def example_inline_failure_handler(app: Boilermaker) -> None:
+    """Pattern 6 — Inline failure handler.
+
+    on_failure= is co-located with the task it guards.
+    handle_fetch_error only runs if fetch_task fails.
+    process_task only runs if fetch_task succeeds.
+    """
+    fetch_task = app.create_task(fetch_data, "https://api.example.com/data")
+    process_task = app.create_task(process_data, {"data": "placeholder", "size": 0})
+    fetch_error_task = app.create_task(handle_fetch_error)
+
+    graph = (
+        TaskGraphBuilder()
+        .add(fetch_task, on_failure=fetch_error_task)  # failure handler declared at task site
+        .then(process_task)  # only runs if fetch_task succeeds
+        .build()
+    )
+    await app.publish_graph(graph)
+    print(f"[inline-failure] published graph {graph.graph_id}")
+
+
+async def example_taskchain_shared_failure(app: Boilermaker) -> None:
+    """Pattern 7 — TaskChain with a shared failure handler.
+
+    process_error_task is registered on EACH task in the chain.
+    Whichever task fails first triggers the handler.
+    """
+    fetch_task = app.create_task(fetch_data, "https://api.example.com/data")
+    process_task = app.create_task(process_data, {"data": "placeholder", "size": 0})
+    save_task = app.create_task(save_results, {"processed": False})
+    process_error_task = app.create_task(handle_processing_error)
+
+    pipeline = TaskChain(fetch_task, process_task, save_task, on_failure=process_error_task)
+
+    graph = TaskGraphBuilder().add_chain(pipeline).build()
+    await app.publish_graph(graph)
+    print(f"[taskchain-shared-failure] published graph {graph.graph_id}")
+
+
+# ---------------------------------------------------------------------------
+# Application setup
+# ---------------------------------------------------------------------------
+
+
+async def main():
+    """Run all workflow examples."""
     service_bus_client = AzureServiceBus.from_config(
         {"connection_string": "your-connection-string", "queue_name": "your-queue"}
     )
-
     storage_client = BlobClientStorage(
         az_storage_url="https://yourstorage.blob.core.windows.net",
         container_name="task-results",
@@ -75,7 +246,6 @@ async def main():
 
     app = Boilermaker(state={}, service_bus_client=service_bus_client, results_storage=storage_client)
 
-    # Register task functions
     app.register_many_async(
         [
             fetch_data,
@@ -83,43 +253,21 @@ async def main():
             save_results,
             send_notification,
             cleanup_temp_files,
+            aggregate_results,
             handle_fetch_error,
             handle_processing_error,
+            handle_aggregation_error,
         ]
     )
 
-    # Create tasks
-    fetch_task = app.create_task(fetch_data, "https://api.example.com/data")
-    process_task = app.create_task(process_data, {"data": "placeholder", "size": 0})
-    save_task = app.create_task(save_results, {"processed": False})
-    notify_task = app.create_task(send_notification, "placeholder_id")
-    cleanup_task = app.create_task(cleanup_temp_files)
+    await example_sequential(app)
+    await example_fan_out(app)
+    await example_fan_in(app)
+    await example_diamond(app)
+    await example_independent_chains_join(app)
+    await example_inline_failure_handler(app)
+    await example_taskchain_shared_failure(app)
 
-    # Error handling tasks
-    fetch_error_task = app.create_task(handle_fetch_error)
-    process_error_task = app.create_task(handle_processing_error)
-
-    # Build workflow using TaskGraphBuilder with failure handling
-    from boilermaker.task import TaskGraphBuilder
-
-    graph = (
-        TaskGraphBuilder()
-        .add(fetch_task)  # Start with fetch_data
-        .on_failure(fetch_task.task_id, fetch_error_task)  # Handle fetch failures
-        .then(process_task)  # process_data depends on fetch_data
-        .on_failure(process_task.task_id, process_error_task)  # Handle processing failures
-        .then(save_task)  # save_results depends on process_data
-        .parallel([notify_task, cleanup_task])  # Both depend on save_results, run in parallel
-        .build()
-    )
-
-    # Publish the graph - this will start the workflow
-    await app.publish_graph(graph)
-
-    print(f"Published TaskGraph {graph.graph_id} with {len(graph.children)} tasks")
-    print("Workflow started - check your worker logs to see execution")
-
-    # Clean up
     await app.close()
 
 

--- a/examples/task_graph_example.py
+++ b/examples/task_graph_example.py
@@ -181,9 +181,9 @@ async def example_independent_chains_join(app: Boilermaker) -> None:
 
     graph = (
         TaskGraphBuilder()
-        .add_chain(pipeline_chain, depends_on=None)      # root; cursor = [save_task]
+        .add_chain(pipeline_chain, depends_on=None)  # root; cursor = [save_task]
         .add_chain(notification_chain, depends_on=None)  # root; cursor = [save_task, cleanup_task]
-        .then(agg_task)                                   # depends on BOTH chain tails
+        .then(agg_task)  # depends on BOTH chain lasts
         .build()
     )
     await app.publish_graph(graph)

--- a/examples/task_graph_example.py
+++ b/examples/task_graph_example.py
@@ -222,7 +222,7 @@ async def example_taskchain_shared_failure(app: Boilermaker) -> None:
     save_task = app.create_task(save_results, {"processed": False})
     process_error_task = app.create_task(handle_processing_error)
 
-    pipeline = TaskChain(fetch_task, process_task, save_task, on_failure=process_error_task)
+    pipeline = TaskChain(fetch_task, process_task, save_task, on_any_failure=process_error_task)
 
     graph = TaskGraphBuilder().add_chain(pipeline).build()
     await app.publish_graph(graph)

--- a/examples/task_graph_example.py
+++ b/examples/task_graph_example.py
@@ -93,7 +93,7 @@ async def example_sequential(app: Boilermaker) -> None:
     """Pattern 1 — Sequential: fetch → process → save."""
     # Create a Task with an immutable signature (si) so that the args are baked in
     fetch_task = Task.si(fetch_data, "https://api.example.com/data")
-    # Alterantively, we can use the Boilermaker app to create the same
+    # Alternatively, we can use the Boilermaker app to create the same
     process_task = app.create_task(process_data, {"data": "placeholder", "size": 0})
     save_task = app.create_task(save_results, {"processed": False})
 

--- a/justfile
+++ b/justfile
@@ -29,7 +29,7 @@ check:
 # Run mypy checks
 check-types:
     #!/bin/bash -eux
-    uv run mypy boilermaker
+    uv run ty check boilermaker
 
 # Run all tests locally
 test *args:

--- a/justfile
+++ b/justfile
@@ -47,3 +47,7 @@ docs-build *args:
 # Serve documentation locally with auto-reload
 docs-serve:
     uv run mkdocs serve
+
+# Run an ipython repl
+repl:
+    uv run --extra repl ipython

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ dev = [
     "ty>=0.0.27",
 ]
 
+[project.optional-dependencies]
+repl = ["ipython"]
 
 [build-system]
 requires = ["setuptools", "versioningit"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boilermaker-servicebus"
-version = "1.0.0-rc1"
+version = "1.0.0-dev4"
 description = "An async python Background task system using Azure Service Bus Queues"
 authors = [{ "name" = "Erik Aker", "email" = "eaker@mulliganfunding.com" }]
 license = { file = "LICENSE" }
@@ -26,17 +26,16 @@ Issues = "https://github.com/MulliganFunding/boilermaker-servicebus/issues"
 [dependency-groups]
 dev = [
     "build>=1.4.2",
-    "mypy>=1.20.0",
     "pytest>=9.0.2",
     "pytest-asyncio>=1.3.0",
     "pytest-cov>=7.1.0",
-    "pytest-mypy>=1.0.1",
     "ruff>=0.15.8",
     # Documentation dependencies
     "mkdocs>=1.5.0",
     "mkdocs-material>=9.7.6",
     "mkdocstrings[python]>=1.0.3",
     "mkdocs-mermaid2-plugin>=1.2.3",
+    "ty>=0.0.27",
 ]
 
 
@@ -70,10 +69,6 @@ omit = [
     # omit tracing.py and run
     "*/tracing.py",
 ]
-
-[[tool.mypy.overrides]]
-module = ["aio_azure_clients_toolbox.*"]
-follow_untyped_imports = true
 
 [tool.ruff]
 src = ["boilermaker", "tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "aio-azure-clients-toolbox>=1.0.4",
+    # We requires unique_msg_id kwarg for servicebus send
+    "aio-azure-clients-toolbox>=1.1.0",
     "anyio >= 4.11.0",
     "azure-core-tracing-opentelemetry >= 1.0.0b12",
     "azure-servicebus >= 7.14.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boilermaker-servicebus"
-version = "1.0.0-dev2"
+version = "1.0.0-rc1"
 description = "An async python Background task system using Azure Service Bus Queues"
 authors = [{ "name" = "Erik Aker", "email" = "eaker@mulliganfunding.com" }]
 license = { file = "LICENSE" }
@@ -25,18 +25,18 @@ Issues = "https://github.com/MulliganFunding/boilermaker-servicebus/issues"
 
 [dependency-groups]
 dev = [
-    "build>=1.3.0",
-    "mypy>=1.18.2",
-    "pytest>=8.4.2",
-    "pytest-asyncio>=1.2.0",
-    "pytest-cov>=7.0.0",
+    "build>=1.4.2",
+    "mypy>=1.20.0",
+    "pytest>=9.0.2",
+    "pytest-asyncio>=1.3.0",
+    "pytest-cov>=7.1.0",
     "pytest-mypy>=1.0.1",
-    "ruff>=0.14.0",
+    "ruff>=0.15.8",
     # Documentation dependencies
     "mkdocs>=1.5.0",
-    "mkdocs-material>=9.6.21",
-    "mkdocstrings[python]>=0.24.0",
-    "mkdocs-mermaid2-plugin>=1.1.0",
+    "mkdocs-material>=9.7.6",
+    "mkdocstrings[python]>=1.0.3",
+    "mkdocs-mermaid2-plugin>=1.2.3",
 ]
 
 

--- a/tests/evaluators/test_task_graphs.py
+++ b/tests/evaluators/test_task_graphs.py
@@ -1,10 +1,10 @@
 import itertools
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from boilermaker import exc, retries
 from boilermaker.evaluators import TaskGraphEvaluator
-from boilermaker.task import Task, TaskResult, TaskResultSlim, TaskStatus
+from boilermaker.task import Task, TaskGraph, TaskResult, TaskResultSlim, TaskStatus
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -562,3 +562,223 @@ async def test_continue_graph_no_ready_tasks(evaluator_context):
 
     # Should not publish any tasks since no new tasks are ready
     assert len(published_tasks) == 0
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # #
+# BMO-8: Double-yield in generate_failure_ready_tasks
+# # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+
+async def test_bmo8_generate_failure_ready_tasks_no_double_yield(app):
+    """BMO-8: A shared failure callback with two failed parents must be yielded exactly once."""
+
+    async def task_a(state):
+        return "A"
+
+    async def task_b(state):
+        return "B"
+
+    async def fail_cb(state):
+        return "failure handled"
+
+    app.register_many_async([task_a, task_b, fail_cb])
+
+    a = app.create_task(task_a)
+    b = app.create_task(task_b)
+    f = app.create_task(fail_cb)
+
+    graph = TaskGraph()
+    graph.add_task(a)
+    graph.add_task(b)
+    # Shared failure callback registered on both A and B
+    graph.add_failure_callback(a.task_id, f)
+    graph.add_failure_callback(b.task_id, f)
+
+    # Initialize pending results
+    list(graph.generate_pending_results())
+
+    # Mark both A and B as failed
+    graph.add_result(TaskResult(task_id=a.task_id, graph_id=graph.graph_id, status=TaskStatus.Failure))
+    graph.add_result(TaskResult(task_id=b.task_id, graph_id=graph.graph_id, status=TaskStatus.Failure))
+
+    # The shared failure callback should only appear once
+    failure_ready = list(graph.generate_failure_ready_tasks())
+    assert len(failure_ready) == 1, (
+        f"Expected exactly 1 failure-ready task, got {len(failure_ready)}. "
+        "Double-yield bug: same callback yielded once per failed parent."
+    )
+    assert failure_ready[0].task_id == f.task_id
+
+
+async def test_bmo8_continue_graph_shared_failure_callback_no_raise(evaluator_context, app):
+    """BMO-8: continue_graph must not raise when a shared failure callback has two failed parents."""
+
+    async def task_a(state):
+        return "A"
+
+    async def task_b(state):
+        return "B"
+
+    async def shared_fail_cb(state):
+        return "shared failure handled"
+
+    app.register_many_async([task_a, task_b, shared_fail_cb])
+
+    a = app.create_task(task_a)
+    b = app.create_task(task_b)
+    f = app.create_task(shared_fail_cb)
+
+    graph = TaskGraph()
+    graph.add_task(a)
+    graph.add_task(b)
+    graph.add_failure_callback(a.task_id, f)
+    graph.add_failure_callback(b.task_id, f)
+
+    list(graph.generate_pending_results())
+
+    # Both parents failed
+    graph.add_result(TaskResult(task_id=a.task_id, graph_id=graph.graph_id, status=TaskStatus.Failure))
+    graph.add_result(TaskResult(task_id=b.task_id, graph_id=graph.graph_id, status=TaskStatus.Failure))
+
+    evaluator_context.graph = graph
+    evaluator_context.mock_storage.load_graph.return_value = graph
+
+    # Build the completed_task_result as if A just finished (failed)
+    completed = TaskResult(task_id=a.task_id, graph_id=graph.graph_id, status=TaskStatus.Failure)
+
+    # Should not raise even though both parents are failed
+    ready_count = await evaluator_context.evaluator.continue_graph(completed)
+
+    # The shared failure callback must have been dispatched exactly once
+    published = evaluator_context.get_scheduled_messages()
+    assert len(published) == 1, f"Expected F dispatched exactly once, got {len(published)}"
+    assert published[0].task.task_id == f.task_id
+
+    assert ready_count == 1
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # #
+# BMO-11: schedule_task ValueError outside try/except
+# # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+
+async def test_bmo11_schedule_task_value_error_does_not_propagate(evaluator_context):
+    """BMO-11: ValueError from schedule_task must be caught; continue_graph must return without raising."""
+    # Build a mock graph whose schedule_task always raises ValueError.
+    # We use a MagicMock(spec=TaskGraph) so we bypass Pydantic's __setattr__ restriction.
+    real_graph = evaluator_context.graph
+    ok_task = evaluator_context.ok_task
+
+    mock_graph = MagicMock(spec=TaskGraph)
+    mock_graph.graph_id = real_graph.graph_id
+    # Sanity check: status must match the completed result's status
+    mock_graph.get_status.return_value = TaskStatus.Success
+    # generate_ready_tasks yields the ok_task (so schedule_task gets called)
+    mock_graph.generate_ready_tasks.return_value = iter([ok_task])
+    mock_graph.generate_failure_ready_tasks.return_value = iter([])
+    # schedule_task always raises ValueError
+    mock_graph.schedule_task.side_effect = ValueError("task is not pending")
+
+    evaluator_context.mock_storage.load_graph.return_value = mock_graph
+
+    completed = TaskResult(
+        task_id=ok_task.task_id,
+        graph_id=real_graph.graph_id,
+        status=TaskStatus.Success,
+        result="OK",
+    )
+
+    # Should not raise
+    ready_count = await evaluator_context.evaluator.continue_graph(completed)
+
+    # No tasks should have been published (all were skipped due to ValueError)
+    published = evaluator_context.get_scheduled_messages()
+    assert len(published) == 0, "No tasks should be published when schedule_task raises ValueError"
+    assert ready_count == 0
+
+
+async def test_bmo11_message_settled_even_when_schedule_task_raises(evaluator_context, mock_storage):
+    """BMO-11: message_handler must settle its message even if schedule_task raises ValueError inside continue_graph."""
+    evaluator_context.prep_task_to_succeed()
+
+    real_graph = evaluator_context.graph
+    ok_task = evaluator_context.ok_task
+
+    # Build a mock graph whose schedule_task always raises ValueError
+    mock_graph = MagicMock(spec=TaskGraph)
+    mock_graph.graph_id = real_graph.graph_id
+    mock_graph.get_status.return_value = TaskStatus.Success
+    mock_graph.generate_ready_tasks.return_value = iter([ok_task])
+    mock_graph.generate_failure_ready_tasks.return_value = iter([])
+    mock_graph.schedule_task.side_effect = ValueError("not pending")
+    evaluator_context.mock_storage.load_graph.return_value = mock_graph
+
+    # Run the full evaluator (message_handler path)
+    result = await evaluator_context()
+
+    # Task itself should have succeeded
+    assert result.status == TaskStatus.Success
+
+    # The message must have been settled (complete_message called, not stuck)
+    evaluator_context.assert_msg_settled()
+
+
+async def test_bmo11_other_tasks_dispatched_when_one_raises_value_error(evaluator_context, app):
+    """BMO-11: When schedule_task raises ValueError for one task, remaining tasks in batch are still dispatched."""
+
+    async def sibling_a(state):
+        return "A"
+
+    async def sibling_b(state):
+        return "B"
+
+    async def root_task(state):
+        return "root"
+
+    app.register_many_async([sibling_a, sibling_b, root_task])
+
+    root = app.create_task(root_task)
+    sa = app.create_task(sibling_a)
+    sb = app.create_task(sibling_b)
+
+    graph = TaskGraph()
+    graph.add_task(root)
+    graph.add_task(sa, parent_ids=[root.task_id])
+    graph.add_task(sb, parent_ids=[root.task_id])
+
+    list(graph.generate_pending_results())
+
+    # Root succeeded
+    graph.add_result(TaskResult(task_id=root.task_id, graph_id=graph.graph_id, status=TaskStatus.Success))
+
+    # Build a mock graph wrapping the real one so we can selectively raise ValueError for sibling_a
+    mock_graph = MagicMock(spec=TaskGraph)
+    mock_graph.graph_id = graph.graph_id
+    mock_graph.get_status.return_value = TaskStatus.Success
+    # Both siblings are ready
+    mock_graph.generate_ready_tasks.return_value = iter([sa, sb])
+    mock_graph.generate_failure_ready_tasks.return_value = iter([])
+
+    call_count = {"n": 0}
+
+    def selective_schedule_task(task_id):
+        call_count["n"] += 1
+        if task_id == sa.task_id:
+            raise ValueError("already scheduled")
+        # For sibling_b, return a minimal scheduled result
+        return graph.schedule_task(task_id)
+
+    mock_graph.schedule_task.side_effect = selective_schedule_task
+    evaluator_context.mock_storage.load_graph.return_value = mock_graph
+
+    completed = TaskResult(task_id=root.task_id, graph_id=graph.graph_id, status=TaskStatus.Success)
+    ready_count = await evaluator_context.evaluator.continue_graph(completed)
+
+    published = evaluator_context.get_scheduled_messages()
+    published_ids = {msg.task.task_id for msg in published}
+
+    # sibling_b should still be dispatched
+    assert sb.task_id in published_ids, "sibling_b should be dispatched even though sibling_a raised ValueError"
+    # sibling_a should NOT have been dispatched
+    assert sa.task_id not in published_ids, "sibling_a should NOT be dispatched after ValueError"
+    assert ready_count == 1

--- a/tests/evaluators/test_task_graphs.py
+++ b/tests/evaluators/test_task_graphs.py
@@ -504,16 +504,30 @@ async def test_continue_graph_no_graph_id(evaluator_context):
 
 
 async def test_graph_workflow_exception_handling(evaluator_context):
-    """Test that graph workflow exceptions don't fail the original task."""
-    # Mock storage.load_graph to raise an exception
-    evaluator_context.mock_storage.load_graph.side_effect = Exception("Storage error")
+    """Test that a transient load_graph exception suppresses message settlement for redelivery."""
+    from unittest.mock import patch
 
-    async with evaluator_context.with_regular_assertions(
-        compare_result="OK",
-        compare_status=TaskStatus.Success,
-    ):
-        # Should still succeed despite the graph load error
-        pass
+    # Mock storage.load_graph to raise a transient BoilermakerStorageError (the exception
+    # type that load_graph actually raises in production when a non-404 storage error occurs).
+    evaluator_context.mock_storage.load_graph.side_effect = exc.BoilermakerStorageError("Storage error")
+
+    # Patch asyncio.sleep so retry backoff doesn't slow the test
+    with patch("asyncio.sleep"):
+        result = await evaluator_context()
+
+    # Task itself should have succeeded
+    assert result.status == TaskStatus.Success
+    assert result.result == "OK"
+
+    # load_graph was retried _LOAD_GRAPH_RETRY_POLICY.max_tries times before giving up
+    from boilermaker.evaluators.task_graph import _LOAD_GRAPH_RETRY_POLICY
+
+    assert evaluator_context.mock_storage.load_graph.call_count == _LOAD_GRAPH_RETRY_POLICY.max_tries
+
+    # Message must NOT be settled — suppress settlement to allow Service Bus redelivery
+    assert len(evaluator_context.mockservicebus._receiver.method_calls) == 0, (
+        "Message should NOT be settled when load_graph raises (transient error path)"
+    )
 
 
 async def test_continue_graph_graph_not_found(evaluator_context):
@@ -525,9 +539,11 @@ async def test_continue_graph_graph_not_found(evaluator_context):
         result=42,
     )
 
-    evaluator_context.mock_storage.load_graph.return_value = None
+    evaluator_context.mock_storage.load_graph.side_effect = exc.BoilermakerStorageError(
+        "Not found", status_code=404
+    )
 
-    # Should not raise errors, just log and return
+    # Should not raise errors, just log CRITICAL and return None
     result = await evaluator_context.evaluator.continue_graph(result)
     assert result is None
     evaluator_context.mock_storage.load_graph.assert_called_with("missing-graph")
@@ -782,3 +798,372 @@ async def test_bmo11_other_tasks_dispatched_when_one_raises_value_error(evaluato
     # sibling_a should NOT have been dispatched
     assert sa.task_id not in published_ids, "sibling_a should NOT be dispatched after ValueError"
     assert ready_count == 1
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # #
+# BMO-10: load_graph failure must not settle message
+# # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+
+async def test_bmo10_load_graph_storage_error_no_settlement(evaluator_context, mock_storage):
+    """BMO-10: Transient load_graph failure must suppress message settlement and not publish any tasks."""
+    from unittest.mock import patch
+
+    from boilermaker.evaluators.task_graph import _LOAD_GRAPH_RETRY_POLICY
+
+    # Simulate a transient storage error on every attempt
+    mock_storage.load_graph.side_effect = exc.BoilermakerStorageError("503 Service Unavailable")
+
+    # Patch asyncio.sleep so retry backoff doesn't slow the test
+    with patch("asyncio.sleep"):
+        result = await evaluator_context()
+
+    # Task itself succeeded
+    assert result.status == TaskStatus.Success
+    assert result.result == "OK"
+
+    # load_graph was retried the configured number of times
+    assert mock_storage.load_graph.call_count == _LOAD_GRAPH_RETRY_POLICY.max_tries
+
+    # Message must NOT be settled — allow Service Bus redelivery
+    assert len(evaluator_context.mockservicebus._receiver.method_calls) == 0, (
+        "Message must not be settled when load_graph raises a transient error"
+    )
+
+    # No downstream tasks must be published
+    assert evaluator_context.get_scheduled_messages() == [], (
+        "task_publisher must not be called when load_graph fails"
+    )
+
+
+async def test_bmo10_load_graph_not_found_settles_and_logs_critical(evaluator_context, mock_storage, caplog):
+    """BMO-10: Permanent load_graph failure (404 BoilermakerStorageError) must settle message and log CRITICAL.
+
+    In production, the underlying library raises AzureBlobError (wrapping the HTTP 404 response)
+    which load_graph re-raises as BoilermakerStorageError(status_code=404).  load_graph never
+    returns None for a missing blob; this test reflects the actual production code path.
+    """
+    import logging
+
+    mock_storage.load_graph.side_effect = exc.BoilermakerStorageError("Not found", status_code=404)
+
+    with caplog.at_level(logging.CRITICAL, logger="boilermaker.app"):
+        result = await evaluator_context()
+
+    # Task itself succeeded
+    assert result.status == TaskStatus.Success
+
+    # Message MUST be settled — redelivery won't help when the graph blob is gone
+    evaluator_context.assert_msg_settled()
+
+    # A CRITICAL log entry must be emitted
+    critical_msgs = [r for r in caplog.records if r.levelno == logging.CRITICAL]
+    assert critical_msgs, (
+        "A CRITICAL log must be emitted when load_graph raises BoilermakerStorageError(status_code=404)"
+    )
+
+
+async def test_bmo10_no_publish_when_load_graph_fails(evaluator_context, mock_storage):
+    """BMO-10: task_publisher must never be called when load_graph raises."""
+    from unittest.mock import patch
+
+    mock_storage.load_graph.side_effect = exc.BoilermakerStorageError("Transient error")
+
+    with patch("asyncio.sleep"):
+        await evaluator_context()
+
+    assert evaluator_context.get_scheduled_messages() == [], (
+        "task_publisher must not be called when load_graph raises"
+    )
+
+
+async def test_bmo10_non404_storage_error_retried_raises_continue_graph_error_no_settlement(
+    evaluator_context, mock_storage
+):
+    """BMO-10: A non-404 BoilermakerStorageError (e.g. 503) must be retried and eventually
+    raise ContinueGraphError, leaving the message unsettled for Service Bus redelivery.
+
+    This distinguishes the transient case (status_code=503) from the permanent 404 case.
+    """
+    from unittest.mock import patch
+
+    from boilermaker.evaluators.task_graph import _LOAD_GRAPH_RETRY_POLICY
+
+    # Simulate a 503 (transient) storage error on every attempt
+    mock_storage.load_graph.side_effect = exc.BoilermakerStorageError(
+        "503 Service Unavailable", status_code=503
+    )
+
+    with patch("asyncio.sleep"):
+        result = await evaluator_context()
+
+    # Task itself succeeded
+    assert result.status == TaskStatus.Success
+    assert result.result == "OK"
+
+    # load_graph must have been retried the full number of times
+    assert mock_storage.load_graph.call_count == _LOAD_GRAPH_RETRY_POLICY.max_tries, (
+        f"Expected {_LOAD_GRAPH_RETRY_POLICY.max_tries} load_graph attempts, "
+        f"got {mock_storage.load_graph.call_count}"
+    )
+
+    # Message must NOT be settled — Service Bus should redeliver
+    assert len(evaluator_context.mockservicebus._receiver.method_calls) == 0, (
+        "Message must not be settled when load_graph raises a transient 503 error"
+    )
+
+    # No downstream tasks published
+    assert evaluator_context.get_scheduled_messages() == [], (
+        "task_publisher must not be called when load_graph raises 503"
+    )
+
+
+async def test_bmo10_retries_exhausted_continue_graph_error_does_not_propagate(
+    retries_exhausted_scenario, mock_storage
+):
+    """BMO-10: ContinueGraphError from continue_graph on the RetriesExhausted path must not propagate.
+
+    The message is already deadlettered before continue_graph is called, so
+    suppressing settlement is not possible.  The correct behaviour is to log
+    and return the RetriesExhausted result gracefully without raising.
+    """
+    from unittest.mock import patch
+
+    from boilermaker.evaluators.task_graph import _LOAD_GRAPH_RETRY_POLICY
+
+    # Make load_graph raise a transient storage error on every attempt so that
+    # continue_graph exhausts its retry policy and raises ContinueGraphError.
+    mock_storage.load_graph.side_effect = exc.BoilermakerStorageError("503 Service Unavailable")
+
+    # Patch asyncio.sleep so retry backoff does not slow the test
+    with patch("asyncio.sleep"):
+        result = await retries_exhausted_scenario()
+
+    # ContinueGraphError must NOT propagate — message_handler must return cleanly
+    assert result is not None, "message_handler must return a result, not raise ContinueGraphError"
+    assert result.status == TaskStatus.RetriesExhausted, (
+        f"Expected RetriesExhausted status, got {result.status}"
+    )
+
+    # load_graph should have been attempted (and exhausted the retry policy)
+    assert mock_storage.load_graph.call_count == _LOAD_GRAPH_RETRY_POLICY.max_tries, (
+        f"Expected {_LOAD_GRAPH_RETRY_POLICY.max_tries} load_graph attempts, "
+        f"got {mock_storage.load_graph.call_count}"
+    )
+
+    # The message must have been settled (deadlettered) before continue_graph was called
+    retries_exhausted_scenario.assert_msg_dead_lettered()
+
+
+async def test_bmo10_validation_error_in_load_graph_raises_continue_graph_error(
+    evaluator_context, mock_storage
+):
+    """BMO-10: ValidationError raised by load_graph must be wrapped as BoilermakerStorageError,
+    enter the retry loop, exhaust retries, and surface as ContinueGraphError — not as a raw
+    ValidationError that bypasses message_handler's except clause.
+
+    This guards against the regression introduced when `except Exception` was narrowed to
+    `except BoilermakerStorageError` in continue_graph: pydantic.ValidationError (raised when
+    a corrupt blob fails model_validate_json) is not a BoilermakerStorageError, so it would
+    escape the retry loop.  The fix is to wrap it inside load_graph before raising.
+    """
+    from unittest.mock import patch
+
+    from boilermaker.evaluators.task_graph import _LOAD_GRAPH_RETRY_POLICY
+
+    # Simulate corrupt blob contents that fail Pydantic validation.
+    # After the fix, load_graph wraps ValidationError → BoilermakerStorageError, so the
+    # retry loop catches it and eventually raises ContinueGraphError.
+    mock_storage.load_graph.side_effect = exc.BoilermakerStorageError(
+        "Failed to deserialize graph: validation error"
+    )
+
+    with patch("asyncio.sleep"):
+        result = await evaluator_context()
+
+    # Task itself succeeded
+    assert result.status == TaskStatus.Success
+    assert result.result == "OK"
+
+    # load_graph must have been retried the full configured number of times
+    assert mock_storage.load_graph.call_count == _LOAD_GRAPH_RETRY_POLICY.max_tries, (
+        f"Expected {_LOAD_GRAPH_RETRY_POLICY.max_tries} load_graph attempts, "
+        f"got {mock_storage.load_graph.call_count}"
+    )
+
+    # Message must NOT be settled — allow Service Bus redelivery
+    assert len(evaluator_context.mockservicebus._receiver.method_calls) == 0, (
+        "Message must not be settled when load_graph raises (wrapping ValidationError)"
+    )
+
+    # No downstream tasks must be published
+    assert evaluator_context.get_scheduled_messages() == [], (
+        "task_publisher must not be called when load_graph raises"
+    )
+
+
+
+# BMO-9: continue_graph liveness gap — Scheduled re-publish
+# # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+
+async def test_bmo9_crash_recover_regular_child(evaluator_context, app):
+    """BMO-9: A regular child task already in Scheduled status must be re-published on redelivery."""
+
+    async def downstream(state):
+        return "downstream done"
+
+    app.register_async(downstream)
+    downstream_task = app.create_task(downstream)
+
+    graph = evaluator_context.graph
+    graph.add_task(downstream_task, parent_ids=[evaluator_context.ok_task.task_id])
+
+    # Generate pending results so results map is populated
+    list(graph.generate_pending_results())
+
+    # Simulate crash-after-store-before-publish: downstream is already Scheduled in blob
+    graph.results[downstream_task.task_id].status = TaskStatus.Scheduled
+
+    # ok_task succeeded (trigger for downstream)
+    graph.add_result(
+        TaskResult(
+            task_id=evaluator_context.ok_task.task_id,
+            graph_id=graph.graph_id,
+            status=TaskStatus.Success,
+        )
+    )
+
+    evaluator_context.mock_storage.load_graph.return_value = graph
+
+    completed = TaskResult(
+        task_id=evaluator_context.ok_task.task_id,
+        graph_id=graph.graph_id,
+        status=TaskStatus.Success,
+    )
+    await evaluator_context.evaluator.continue_graph(completed)
+
+    published_ids = {msg.task.task_id for msg in evaluator_context.get_scheduled_messages()}
+    assert downstream_task.task_id in published_ids, (
+        "Already-Scheduled downstream task must be re-published on redelivery (crash recovery)"
+    )
+
+
+async def test_bmo9_no_double_blob_write(evaluator_context, app):
+    """BMO-9: Re-running continue_graph with an already-Scheduled downstream task must NOT call store_task_result."""
+
+    async def downstream(state):
+        return "done"
+
+    app.register_async(downstream)
+    downstream_task = app.create_task(downstream)
+
+    graph = evaluator_context.graph
+    graph.add_task(downstream_task, parent_ids=[evaluator_context.ok_task.task_id])
+    list(graph.generate_pending_results())
+
+    # Downstream already Scheduled (crash-after-store)
+    graph.results[downstream_task.task_id].status = TaskStatus.Scheduled
+    graph.add_result(
+        TaskResult(
+            task_id=evaluator_context.ok_task.task_id,
+            graph_id=graph.graph_id,
+            status=TaskStatus.Success,
+        )
+    )
+
+    evaluator_context.mock_storage.load_graph.return_value = graph
+
+    # Reset store_task_result call count so we only see calls from this continue_graph invocation
+    evaluator_context.mock_storage.store_task_result.reset_mock()
+
+    completed = TaskResult(
+        task_id=evaluator_context.ok_task.task_id,
+        graph_id=graph.graph_id,
+        status=TaskStatus.Success,
+    )
+    await evaluator_context.evaluator.continue_graph(completed)
+
+    # store_task_result must NOT have been called for the already-Scheduled task
+    stored_ids = {
+        call.args[0].task_id
+        for call in evaluator_context.mock_storage.store_task_result.call_args_list
+        if call.args
+    }
+    assert downstream_task.task_id not in stored_ids, (
+        "store_task_result must not be called again for an already-Scheduled task (no double blob write)"
+    )
+
+
+async def test_bmo9_is_complete_false_while_scheduled(evaluator_context, app):
+    """BMO-9 / BMO-17: graph.is_complete() must return False when a task is in Scheduled status."""
+
+    async def downstream(state):
+        return "done"
+
+    app.register_async(downstream)
+    downstream_task = app.create_task(downstream)
+
+    graph = evaluator_context.graph
+    graph.add_task(downstream_task, parent_ids=[evaluator_context.ok_task.task_id])
+    list(graph.generate_pending_results())
+
+    # Set downstream to Scheduled (not a terminal state)
+    graph.results[downstream_task.task_id].status = TaskStatus.Scheduled
+    graph.add_result(
+        TaskResult(
+            task_id=evaluator_context.ok_task.task_id,
+            graph_id=graph.graph_id,
+            status=TaskStatus.Success,
+        )
+    )
+
+    assert not graph.is_complete(), (
+        "graph.is_complete() must return False when a task is in Scheduled status "
+        "(Scheduled is not a terminal state)"
+    )
+
+
+async def test_bmo9_crash_recover_failure_callback(evaluator_context, app):
+    """BMO-9: A failure callback task already in Scheduled status must be re-published on redelivery.
+
+    This covers the critical case flagged by @distributed-systems-expert:
+    fail_children must be included in the second pass, not just regular children.
+    """
+
+    async def fail_cb(state):
+        return "failure handled"
+
+    app.register_async(fail_cb)
+    fail_task = app.create_task(fail_cb)
+
+    graph = evaluator_context.graph
+    graph.add_failure_callback(evaluator_context.ok_task.task_id, fail_task)
+    list(graph.generate_pending_results())
+
+    # ok_task has failed (trigger for the failure callback)
+    graph.add_result(
+        TaskResult(
+            task_id=evaluator_context.ok_task.task_id,
+            graph_id=graph.graph_id,
+            status=TaskStatus.Failure,
+        )
+    )
+
+    # Simulate crash-after-store-before-publish: fail_task is already Scheduled in blob
+    graph.results[fail_task.task_id].status = TaskStatus.Scheduled
+
+    evaluator_context.mock_storage.load_graph.return_value = graph
+
+    completed = TaskResult(
+        task_id=evaluator_context.ok_task.task_id,
+        graph_id=graph.graph_id,
+        status=TaskStatus.Failure,
+    )
+    await evaluator_context.evaluator.continue_graph(completed)
+
+    published_ids = {msg.task.task_id for msg in evaluator_context.get_scheduled_messages()}
+    assert fail_task.task_id in published_ids, (
+        "Already-Scheduled failure callback task must be re-published on redelivery "
+        "(crash recovery for fail_children — critical case from @distributed-systems-expert review)"
+    )

--- a/tests/storage/test_blob_storage.py
+++ b/tests/storage/test_blob_storage.py
@@ -300,6 +300,49 @@ async def test_store_graph_with_resource_error(
 
 
 # Edge cases and additional tests
+async def test_store_task_result_raises_storage_error_on_etag_mismatch(
+    blob_storage, sample_task_result
+):
+    """
+    Verifies that store_task_result raises BoilermakerStorageError when the
+    underlying blob client raises AzureBlobError (e.g., HTTP 412 ETag mismatch).
+    This is the primary guard against concurrent double-scheduling of downstream tasks.
+
+    The concurrency path (etag != None) is exercised explicitly so that the
+    concurrency_kwargs are populated before the upload attempt.
+    """
+    with patch.object(
+        blob_storage, "upload_blob", new_callable=AsyncMock
+    ) as mock_upload:
+        error = AzureBlobError(
+            MagicMock(
+                **{
+                    "message": "The condition specified using HTTP conditional header(s) is not met.",
+                    "status_code": 412,
+                    "reason": "Precondition Failed",
+                }
+            )
+        )
+        mock_upload.side_effect = error
+
+        with pytest.raises(BoilermakerStorageError) as exc_info:
+            # Pass a non-empty etag to exercise the ETag concurrency guard code path
+            await blob_storage.store_task_result(
+                sample_task_result, etag='"0x8DBBAF4B8A6017C"'
+            )
+
+        assert "Failed to store TaskResult" in str(exc_info.value)
+        assert exc_info.value.task_id == sample_task_result.task_id
+        assert exc_info.value.graph_id == sample_task_result.graph_id
+        assert exc_info.value.status_code == 412
+        assert exc_info.value.reason == "Precondition Failed"
+
+        # Confirm etag and if_match were forwarded to upload_blob
+        call_kwargs = mock_upload.call_args[1]
+        assert "etag" in call_kwargs
+        assert "if_match" in call_kwargs
+
+
 async def test_store_task_result_without_graph_id(blob_storage, sample_task):
     """Test storing TaskResult without graph_id."""
     task_result = TaskResult(

--- a/tests/storage/test_blob_storage.py
+++ b/tests/storage/test_blob_storage.py
@@ -408,7 +408,7 @@ async def test_store_task_result_raises_storage_error_on_etag_mismatch(
         # Confirm etag and if_match were forwarded to upload_blob
         call_kwargs = mock_upload.call_args[1]
         assert "etag" in call_kwargs
-        assert "if_match" in call_kwargs
+        assert "if_tags_match_condition" in call_kwargs
 
 
 async def test_store_task_result_without_graph_id(blob_storage, sample_task):

--- a/tests/storage/test_blob_storage.py
+++ b/tests/storage/test_blob_storage.py
@@ -408,7 +408,7 @@ async def test_store_task_result_raises_storage_error_on_etag_mismatch(
         # Confirm etag and if_match were forwarded to upload_blob
         call_kwargs = mock_upload.call_args[1]
         assert "etag" in call_kwargs
-        assert "if_tags_match_condition" in call_kwargs
+        assert "match_condition" in call_kwargs
 
 
 async def test_store_task_result_without_graph_id(blob_storage, sample_task):

--- a/tests/storage/test_blob_storage.py
+++ b/tests/storage/test_blob_storage.py
@@ -212,6 +212,39 @@ async def test_load_graph_returns_none_when_no_content(blob_storage):
         assert result is None
 
 
+async def test_load_graph_skips_graph_blob_in_list_results(
+    mock_azureblob,
+    blob_storage,
+    sample_task_graph,
+    sample_task,
+    sample_task_result_slim,
+):
+    """Regression: graph.json in list_blobs must not be parsed as TaskResultSlim."""
+    sample_task_graph.add_task(sample_task)
+    sample_task_result_slim.graph_id = sample_task.graph_id
+
+    graph_json = sample_task_graph.model_dump_json()
+    task_result_json = sample_task_result_slim.model_dump_json()
+    graph_path = f"task-results/{sample_task_graph.storage_path}"
+    task_result_path = f"task-results/{sample_task_result_slim.storage_path}"
+
+    _, _, set_return = mock_azureblob
+    set_return.download_blob_returns(None, side_effect=[graph_json, task_result_json])
+    set_return.list_blobs_returns(
+        [
+            BlobProperties(name=graph_path, last_modified="2023-01-01T00:00:00Z"),
+            BlobProperties(name=task_result_path, last_modified="2023-01-01T00:00:00Z"),
+        ]
+    )
+
+    result = await blob_storage.load_graph(sample_task_graph.graph_id)
+
+    assert result is not None
+    assert result.graph_id == sample_task_graph.graph_id
+    assert sample_task_result_slim.task_id in result.results
+    assert result.results[sample_task_result_slim.task_id].task_id == sample_task_result_slim.task_id
+
+
 # Tests for store_graph method
 async def test_store_graph_success(mock_azureblob, blob_storage, sample_task_graph):
     """Test successful storage of a TaskGraph."""

--- a/tests/storage/test_blob_storage.py
+++ b/tests/storage/test_blob_storage.py
@@ -212,6 +212,74 @@ async def test_load_graph_returns_none_when_no_content(blob_storage):
         assert result is None
 
 
+async def test_load_graph_validation_error_on_graph_json_raises_storage_error(
+    blob_storage,
+):
+    """BMO-10: ValidationError from model_validate_json on the graph blob must be wrapped
+    as BoilermakerStorageError so the continue_graph retry loop can catch it.
+
+    Corrupt / schema-mismatched graph blobs raise pydantic.ValidationError inside
+    load_graph.  Before the fix, that error escaped as a raw ValidationError bypassing
+    the `except BoilermakerStorageError` in continue_graph's retry loop.  After the fix,
+    load_graph wraps it so callers only need to handle BoilermakerStorageError.
+    """
+    from pydantic import ValidationError
+
+    with (
+        patch.object(
+            blob_storage, "download_blob", new_callable=AsyncMock
+        ) as mock_download,
+        patch(
+            "boilermaker.storage.blob_storage.TaskGraph.model_validate_json",
+            side_effect=ValidationError.from_exception_data(
+                "TaskGraph", [], input_type="json"
+            ),
+        ),
+    ):
+        mock_download.return_value = '{"corrupt": "data"}'
+
+        with pytest.raises(BoilermakerStorageError) as exc_info:
+            await blob_storage.load_graph(GraphId("test-graph"))
+
+        assert "Failed to deserialize graph" in str(exc_info.value)
+        assert "test-graph" in str(exc_info.value)
+
+
+async def test_load_graph_validation_error_on_task_result_json_raises_storage_error(
+    mock_azureblob,
+    blob_storage,
+    sample_task_graph,
+):
+    """BMO-10: ValidationError from model_validate_json on a TaskResultSlim blob must be
+    wrapped as BoilermakerStorageError — same contract as for the graph blob itself.
+    """
+    from pydantic import ValidationError
+
+    graph_json = sample_task_graph.model_dump_json()
+    _, _, set_return = mock_azureblob
+    set_return.download_blob_returns(None, side_effect=[graph_json, '{"corrupt": "data"}'])
+    set_return.list_blobs_returns(
+        [
+            BlobProperties(
+                name=f"task-results/{sample_task_graph.graph_id}/task-result.json",
+                last_modified="2023-01-01T00:00:00Z",
+            ),
+        ]
+    )
+
+    with patch(
+        "boilermaker.storage.blob_storage.TaskResultSlim.model_validate_json",
+        side_effect=ValidationError.from_exception_data(
+            "TaskResultSlim", [], input_type="json"
+        ),
+    ):
+        with pytest.raises(BoilermakerStorageError) as exc_info:
+            await blob_storage.load_graph(sample_task_graph.graph_id)
+
+    assert "Failed to deserialize task result" in str(exc_info.value)
+    assert str(sample_task_graph.graph_id) in str(exc_info.value)
+
+
 async def test_load_graph_skips_graph_blob_in_list_results(
     mock_azureblob,
     blob_storage,

--- a/tests/storage/test_blob_storage.py
+++ b/tests/storage/test_blob_storage.py
@@ -220,16 +220,13 @@ async def test_store_graph_success(mock_azureblob, blob_storage, sample_task_gra
 
     result = await blob_storage.store_graph(sample_task_graph)
     assert result == sample_task_graph
-    container_client.acquire_lease.assert_called_once()
 
     # Verify upload_blob was called with correct parameters
     # Expect 1) acquire lease, 2) upload graph, 3) upload task one result
-    assert len(container_client.mock_calls) == 4
-    lease_call, upload_graph_call, task_result_upload_call, release_lease_call = container_client.mock_calls
-    assert lease_call[0] == "acquire_lease"
+    assert len(container_client.mock_calls) == 2
+    upload_graph_call, task_result_upload_call = container_client.mock_calls
     assert upload_graph_call[0] == "upload_blob"
     assert task_result_upload_call[0] == "upload_blob"
-    assert release_lease_call[0] == "acquire_lease().release"
 
     # Check filenames
     expected_graph_name = f"task-results/{sample_task_graph.storage_path}"

--- a/tests/task/test_graph.py
+++ b/tests/task/test_graph.py
@@ -1849,8 +1849,8 @@ def test_task_chain_on_failure_stored():
     task_a = task.Task.default("task_a")
     task_b = task.Task.default("task_b")
     handler = task.Task.default("handler")
-    chain = task.TaskChain(task_a, task_b, on_failure=handler)
-    assert chain._on_failure is handler
+    chain = task.TaskChain(task_a, task_b, on_any_failure=handler)
+    assert chain.on_any_failure is handler
 
 
 def test_task_chain_no_failure_handler():
@@ -1858,7 +1858,7 @@ def test_task_chain_no_failure_handler():
     task_a = task.Task.default("task_a")
     task_b = task.Task.default("task_b")
     chain = task.TaskChain(task_a, task_b)
-    assert chain._on_failure is None
+    assert chain.on_any_failure is None
 
 
 # ~~~~ ~~~~ ~~~~ ~~~~ ~~~~
@@ -2144,7 +2144,7 @@ def test_add_chain_on_failure_registered_on_each_task():
     task_c = task.Task.default("task_c")
     handler = task.Task.default("handler")
 
-    chain = task.TaskChain(task_a, task_b, task_c, on_failure=handler)
+    chain = task.TaskChain(task_a, task_b, task_c, on_any_failure=handler)
     builder = task.TaskGraphBuilder()
     builder.add_chain(chain, depends_on=None)
 
@@ -2300,8 +2300,8 @@ def test_complex_parallel_fan_in_with_failure_handlers():
     aggregate = task.Task.default("aggregate")
     cleanup = task.Task.default("cleanup")
 
-    ingest_chain = task.TaskChain(validate, ingest, on_failure=ingest_err)
-    process_chain = task.TaskChain(transform, enrich, on_failure=process_err)
+    ingest_chain = task.TaskChain(validate, ingest, on_any_failure=ingest_err)
+    process_chain = task.TaskChain(transform, enrich, on_any_failure=process_err)
 
     graph = (
         task.TaskGraphBuilder()

--- a/tests/task/test_graph.py
+++ b/tests/task/test_graph.py
@@ -1236,15 +1236,15 @@ def test_then_delegates_to_add():
     assert builder1._last_added == builder2._last_added
 
 
-def test_task_graph_builder_chain():
-    """Test chain() convenience method."""
+def test_task_graph_builder_sequence():
+    """Test sequence() convenience method."""
     builder = task.TaskGraphBuilder()
     task_a = task.Task.default("task_a")
     task_b = task.Task.default("task_b")
     task_c = task.Task.default("task_c")
 
     # Chain tasks
-    result = builder.chain(task_a, task_b, task_c)
+    result = builder.sequence(task_a, task_b, task_c)
 
     # Should return self for chaining
     assert result is builder
@@ -1258,10 +1258,10 @@ def test_task_graph_builder_chain():
     assert builder._last_added == [task_c.task_id]
 
 
-def test_task_graph_builder_chain_empty():
-    """Test chain() with no tasks."""
+def test_task_graph_builder_sequence_empty():
+    """Test sequence() with no tasks."""
     builder = task.TaskGraphBuilder()
-    result = builder.chain()
+    result = builder.sequence()
 
     # Should return self and do nothing
     assert result is builder

--- a/tests/task/test_graph.py
+++ b/tests/task/test_graph.py
@@ -1058,7 +1058,7 @@ def test_task_graph_builder_then_without_previous_task():
         builder.then(task_a)
 
 
-# ~~~~ §8.3 — _resolve_deps() type widening ~~~~ #
+# ~~~~ §8.3 — _resolve_dependencies() type widening ~~~~ #
 
 
 def test_add_depends_on_task_object():
@@ -1094,7 +1094,7 @@ def test_add_depends_on_task_chain():
     task_d = task.Task.default("task_d")
 
     chain_abc = task.TaskChain(task_a, task_b, task_c)
-    # Register each task in the chain so _resolve_deps can find them
+    # Register each task in the chain so _resolve_dependencies can find them
     builder.add(task_a, depends_on=None)
     builder.add(task_b, depends_on=None)
     builder.add(task_c, depends_on=None)
@@ -1106,7 +1106,7 @@ def test_add_depends_on_task_chain():
 
 
 def test_add_depends_on_mixed_types():
-    """_resolve_deps handles Task objects and str TaskId in the same list."""
+    """_resolve_dependencies handles Task objects and str TaskId in the same list."""
     builder = task.TaskGraphBuilder()
     task_a = task.Task.default("task_a")
     task_b = task.Task.default("task_b")
@@ -1404,7 +1404,7 @@ def test_task_graph_builder_method_chaining():
 def test_task_graph_builder_cycle_detection_during_build():
     """Test that the builder raises early when a dependency is not yet registered.
 
-    With _resolve_deps() validation, forward references are rejected at add() time,
+    With _resolve_dependencies() validation, forward references are rejected at add() time,
     which prevents cycles from being formed through the builder API.
     """
     builder = task.TaskGraphBuilder()
@@ -1412,7 +1412,7 @@ def test_task_graph_builder_cycle_detection_during_build():
     task_a = task.Task.default("task_a")
     task_b = task.Task.default("task_b")
 
-    # task_b hasn't been added yet — _resolve_deps raises immediately
+    # task_b hasn't been added yet — _resolve_dependencies raises immediately
     with pytest.raises(ValueError, match="not found in this graph"):
         builder.add(task_a, depends_on=[task_b.task_id])
 

--- a/tests/task/test_graph.py
+++ b/tests/task/test_graph.py
@@ -1083,7 +1083,7 @@ def test_add_depends_on_task_id_string():
 
 
 def test_add_depends_on_task_chain():
-    """depends_on=[chain_abc] (TaskChain) resolves to chain_abc.tail.task_id."""
+    """depends_on=[chain_abc] (TaskChain) resolves to chain_abc.last.task_id."""
     builder = task.TaskGraphBuilder()
     task_a = task.Task.default("task_a")
     task_b = task.Task.default("task_b")
@@ -1098,7 +1098,7 @@ def test_add_depends_on_task_chain():
 
     builder.add(task_d, depends_on=[chain_abc])
 
-    # Should resolve to tail (task_c)
+    # Should resolve to last (task_c)
     assert builder._dependencies[task_d.task_id] == {task_c.task_id}
 
 
@@ -1815,21 +1815,21 @@ def test_task_chain_requires_at_least_one_task():
 
 
 def test_task_chain_single_task():
-    """For a single-task chain, head and tail must both reference that task."""
+    """For a single-task chain, head and last must both reference that task."""
     task_a = task.Task.default("task_a")
     chain = task.TaskChain(task_a)
     assert chain.head is task_a
-    assert chain.tail is task_a
+    assert chain.last is task_a
 
 
-def test_task_chain_head_and_tail():
-    """head must be the first task and tail must be the last task in the chain."""
+def test_task_chain_head_and_last():
+    """head must be the first task and last must be the last task in the chain."""
     task_a = task.Task.default("task_a")
     task_b = task.Task.default("task_b")
     task_c = task.Task.default("task_c")
     chain = task.TaskChain(task_a, task_b, task_c)
     assert chain.head is task_a
-    assert chain.tail is task_c
+    assert chain.last is task_c
 
 
 def test_task_chain_preserves_task_order():
@@ -2025,7 +2025,7 @@ def test_add_chain_sequential_multi_task():
 
 
 def test_add_chain_replaces_cursor():
-    """Cursor after sequential add_chain is only [tail.task_id]."""
+    """Cursor after sequential add_chain is only [last.task_id]."""
     task_a = task.Task.default("task_a")
     task_b = task.Task.default("task_b")
     task_c = task.Task.default("task_c")
@@ -2071,7 +2071,7 @@ def test_add_chain_root_no_dependency():
 
 
 def test_add_chain_root_accumulates_cursor():
-    """Two depends_on=None add_chain calls → _last_added = [tail1, tail2]."""
+    """Two depends_on=None add_chain calls → _last_added = [last1, last2]."""
     task_a = task.Task.default("task_a")
     task_b = task.Task.default("task_b")
     task_c = task.Task.default("task_c")
@@ -2109,7 +2109,7 @@ def test_fan_in_from_two_independent_chains():
     # edges maps parent → children, so task_f appears in edges of task_c and task_e
     assert task_f.task_id in graph.edges[task_c.task_id]
     assert task_f.task_id in graph.edges[task_e.task_id]
-    # task_f should be the only child of both tails
+    # task_f should be the only child of both lasts
     assert graph.edges[task_c.task_id] == {task_f.task_id}
     assert graph.edges[task_e.task_id] == {task_f.task_id}
 
@@ -2119,7 +2119,7 @@ def test_fan_in_from_two_independent_chains():
 
 
 def test_add_chain_explicit_depends_on_replaces_cursor():
-    """Explicit depends_on=[...] replaces cursor with only [tail.task_id]."""
+    """Explicit depends_on=[...] replaces cursor with only [last.task_id]."""
     task_a = task.Task.default("task_a")
     task_b = task.Task.default("task_b")
     task_c = task.Task.default("task_c")
@@ -2162,7 +2162,7 @@ def test_add_chain_duplicate_task_raises():
 
 
 def test_add_chain_first_on_empty_builder():
-    """add_chain(chain) as first call → head has no parents; cursor = [tail.task_id]."""
+    """add_chain(chain) as first call → head has no parents; cursor = [last.task_id]."""
     task_a = task.Task.default("task_a")
     task_b = task.Task.default("task_b")
     task_c = task.Task.default("task_c")
@@ -2172,7 +2172,7 @@ def test_add_chain_first_on_empty_builder():
 
     # head has no parents (empty builder, uses LAST_ADDED which resolves to [])
     assert builder._dependencies[task_a.task_id] == set()
-    # cursor is only the tail
+    # cursor is only the last
     assert builder._last_added == [task_c.task_id]
 
 
@@ -2269,7 +2269,7 @@ def test_sequential_chain_with_inline_on_failure():
 
 
 def test_explicit_depends_on_with_chain_objects():
-    """TaskChain objects in depends_on resolve to chain.tail.task_id."""
+    """TaskChain objects in depends_on resolve to chain.last.task_id."""
     task_a = task.Task.default("fn_a")
     task_b = task.Task.default("fn_b")
     task_c = task.Task.default("fn_c")
@@ -2278,11 +2278,11 @@ def test_explicit_depends_on_with_chain_objects():
     graph = (
         task.TaskGraphBuilder()
         .add_chain(chain_ab, depends_on=None)
-        .add(task_c, depends_on=None)      # independent root
-        .add(task_d, depends_on=[chain_ab, task_c])  # waits for chain tail AND task_c
+        .add(task_c, depends_on=None)  # independent root
+        .add(task_d, depends_on=[chain_ab, task_c])  # waits for chain last AND task_c
         .build()
     )
-    assert task_d.task_id in graph.edges[task_b.task_id]  # chain resolved to tail
+    assert task_d.task_id in graph.edges[task_b.task_id]  # chain resolved to last
     assert task_d.task_id in graph.edges[task_c.task_id]
 
 
@@ -2307,7 +2307,7 @@ def test_complex_parallel_fan_in_with_failure_handlers():
         .then(aggregate, on_failure=cleanup)
         .build()
     )
-    # aggregate depends on both chain tails
+    # aggregate depends on both chain lasts
     assert aggregate.task_id in graph.edges[ingest.task_id]
     assert aggregate.task_id in graph.edges[enrich.task_id]
     # ingest chain internal deps

--- a/tests/task/test_graph.py
+++ b/tests/task/test_graph.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 from boilermaker import retries, task
+from boilermaker.task.graph import _LastAddedSentinel
 
 from ..graph_factories import diamond_graph, linear_graph, ready_task_scenario, simple_graph
 from .helpers import (
@@ -987,8 +988,8 @@ def test_task_graph_builder_parallel():
     task_c = task.Task.default("task_c")
     tasks = [task_a, task_b, task_c]
 
-    # Add parallel tasks
-    result = builder.parallel(tasks)
+    # Add parallel tasks (variadic)
+    result = builder.parallel(task_a, task_b, task_c)
 
     # Should return self for chaining
     assert result is builder
@@ -1014,8 +1015,8 @@ def test_task_graph_builder_parallel_with_dependencies():
     # Add initial task
     builder.add(init_task)
 
-    # Add parallel tasks that depend on init_task
-    builder.parallel([task_a, task_b], depends_on=[init_task.task_id])
+    # Add parallel tasks that depend on init_task (using Task object)
+    builder.parallel(task_a, task_b, depends_on=[init_task])
 
     # Both parallel tasks should depend on init_task
     assert builder._dependencies[task_a.task_id] == {init_task.task_id}
@@ -1050,32 +1051,186 @@ def test_task_graph_builder_then_without_previous_task():
     builder = task.TaskGraphBuilder()
     task_a = task.Task.default("task_a")
 
-    with pytest.raises(ValueError, match="No previous tasks to depend on"):
+    with pytest.raises(ValueError, match="No tasks have been added yet"):
         builder.then(task_a)
 
 
-def test_task_graph_builder_then_parallel():
-    """Test parallel() method functionality."""
+# ~~~~ §8.3 — _resolve_deps() type widening ~~~~ #
+
+
+def test_add_depends_on_task_object():
+    """depends_on=[task_a] (Task object) resolves correctly to task_a.task_id."""
     builder = task.TaskGraphBuilder()
-    init_task = task.Task.default("init_task")
     task_a = task.Task.default("task_a")
     task_b = task.Task.default("task_b")
 
-    # Add initial task
-    builder.add(init_task)
+    builder.add(task_a, depends_on=None)
+    builder.add(task_b, depends_on=[task_a])
 
-    # Add parallel tasks that depend on init_task
-    result = builder.parallel([task_a, task_b])
+    assert builder._dependencies[task_b.task_id] == {task_a.task_id}
 
-    # Should return self for chaining
-    assert result is builder
 
-    # Both should depend on init_task
-    assert builder._dependencies[task_a.task_id] == {init_task.task_id}
-    assert builder._dependencies[task_b.task_id] == {init_task.task_id}
+def test_add_depends_on_task_id_string():
+    """depends_on=[task_a.task_id] (string) works as before."""
+    builder = task.TaskGraphBuilder()
+    task_a = task.Task.default("task_a")
+    task_b = task.Task.default("task_b")
 
-    # Both should be in _last_added
-    assert set(builder._last_added) == {task_a.task_id, task_b.task_id}
+    builder.add(task_a, depends_on=None)
+    builder.add(task_b, depends_on=[task_a.task_id])
+
+    assert builder._dependencies[task_b.task_id] == {task_a.task_id}
+
+
+def test_add_depends_on_task_chain():
+    """depends_on=[chain_abc] (TaskChain) resolves to chain_abc.tail.task_id."""
+    builder = task.TaskGraphBuilder()
+    task_a = task.Task.default("task_a")
+    task_b = task.Task.default("task_b")
+    task_c = task.Task.default("task_c")
+    task_d = task.Task.default("task_d")
+
+    chain_abc = task.TaskChain(task_a, task_b, task_c)
+    # Register each task in the chain so _resolve_deps can find them
+    builder.add(task_a, depends_on=None)
+    builder.add(task_b, depends_on=None)
+    builder.add(task_c, depends_on=None)
+
+    builder.add(task_d, depends_on=[chain_abc])
+
+    # Should resolve to tail (task_c)
+    assert builder._dependencies[task_d.task_id] == {task_c.task_id}
+
+
+def test_add_depends_on_mixed_types():
+    """_resolve_deps handles Task objects and str TaskId in the same list."""
+    builder = task.TaskGraphBuilder()
+    task_a = task.Task.default("task_a")
+    task_b = task.Task.default("task_b")
+    task_c = task.Task.default("task_c")
+
+    builder.add(task_a, depends_on=None)
+    builder.add(task_b, depends_on=None)
+    # task_c depends on task_a (as Task object) AND task_b (as raw TaskId string)
+    builder.add(task_c, depends_on=[task_a, task_b.task_id])
+
+    assert task_a.task_id in builder._dependencies[task_c.task_id]
+    assert task_b.task_id in builder._dependencies[task_c.task_id]
+
+
+def test_add_depends_on_unknown_task_raises():
+    """depends_on with an unregistered task raises ValueError."""
+    builder = task.TaskGraphBuilder()
+    task_a = task.Task.default("task_a")
+    task_never_added = task.Task.default("task_never_added")
+
+    builder.add(task_a, depends_on=None)
+
+    with pytest.raises(ValueError, match="not found in this graph"):
+        builder.add(task_a, depends_on=[task_never_added])
+
+
+# ~~~~ §8.4 — duplicate-task validation ~~~~ #
+
+
+def test_add_duplicate_task_raises():
+    """Adding the same Task object twice raises ValueError with task_id and function_name."""
+    builder = task.TaskGraphBuilder()
+    task_a = task.Task.default("task_a")
+
+    builder.add(task_a, depends_on=None)
+
+    with pytest.raises(ValueError, match=task_a.task_id):
+        builder.add(task_a, depends_on=None)
+
+
+def test_add_duplicate_task_id_raises():
+    """Two different Task objects with the same task_id raises ValueError."""
+    builder = task.TaskGraphBuilder()
+    task_a1 = task.Task.default("task_a")
+    # Create a separate Task instance that shares task_a1's task_id
+    task_a2 = task.Task.default("task_a", task_id=task_a1.task_id)
+
+    builder.add(task_a1, depends_on=None)
+
+    with pytest.raises(ValueError, match=task_a1.task_id):
+        builder.add(task_a2, depends_on=None)
+
+
+# ~~~~ §8.5 — inline on_failure= in add() ~~~~ #
+
+
+def test_add_with_on_failure_registers_callback():
+    """add(task_a, on_failure=handler) stores handler in _failure_callbacks."""
+    builder = task.TaskGraphBuilder()
+    task_a = task.Task.default("task_a")
+    handler = task.Task.default("handler")
+
+    builder.add(task_a, depends_on=None, on_failure=handler)
+
+    assert task_a.task_id in builder._failure_callbacks
+    assert handler in builder._failure_callbacks[task_a.task_id]
+
+
+def test_add_on_failure_appears_in_built_graph():
+    """After build(), on_failure handler appears in graph.fail_children and graph.fail_edges."""
+    builder = task.TaskGraphBuilder()
+    task_a = task.Task.default("task_a")
+    handler = task.Task.default("handler")
+
+    graph = builder.add(task_a, depends_on=None, on_failure=handler).build()
+
+    assert handler.task_id in graph.fail_children
+    assert task_a.task_id in graph.fail_edges
+    assert handler.task_id in graph.fail_edges[task_a.task_id]
+
+
+# ~~~~ §8.6 — then() with on_failure= ~~~~ #
+
+
+def test_then_on_empty_builder_raises():
+    """then() on empty builder raises with updated error message."""
+    builder = task.TaskGraphBuilder()
+    task_a = task.Task.default("task_a")
+
+    with pytest.raises(
+        ValueError,
+        match="No tasks have been added yet. Call .add\\(\\) or .add_chain\\(\\) first",
+    ):
+        builder.then(task_a)
+
+
+def test_then_with_on_failure():
+    """add(task_a).then(task_b, on_failure=handler) registers handler on task_b, not task_a."""
+    builder = task.TaskGraphBuilder()
+    task_a = task.Task.default("task_a")
+    task_b = task.Task.default("task_b")
+    handler = task.Task.default("handler")
+
+    builder.add(task_a, depends_on=None).then(task_b, on_failure=handler)
+
+    # Handler should be on task_b
+    assert task_b.task_id in builder._failure_callbacks
+    assert handler in builder._failure_callbacks[task_b.task_id]
+    # task_a should have no failure callbacks
+    assert task_a.task_id not in builder._failure_callbacks
+
+
+def test_then_delegates_to_add():
+    """add(a).then(b) is identical to add(a).add(b, depends_on=LAST_ADDED)."""
+    builder1 = task.TaskGraphBuilder()
+    builder2 = task.TaskGraphBuilder()
+
+    task_a1 = task.Task.default("task_a")
+    task_b1 = task.Task.default("task_b")
+    task_a2 = task.Task.default("task_a", task_id=task_a1.task_id)
+    task_b2 = task.Task.default("task_b", task_id=task_b1.task_id)
+
+    builder1.add(task_a1, depends_on=None).then(task_b1)
+    builder2.add(task_a2, depends_on=None).add(task_b2, depends_on=task.LAST_ADDED)
+
+    assert builder1._dependencies[task_b1.task_id] == builder2._dependencies[task_b2.task_id]
+    assert builder1._last_added == builder2._last_added
 
 
 def test_task_graph_builder_chain():
@@ -1110,79 +1265,11 @@ def test_task_graph_builder_chain_empty():
     assert len(builder._tasks) == 0
 
 
-def test_task_graph_builder_on_failure():
-    """Test on_failure() method."""
-    builder = task.TaskGraphBuilder()
-    main_task = task.Task.default("main_task")
-    error_handler = task.Task.default("error_handler")
-
-    # Add main task first
-    builder.add(main_task)
-
-    # Add failure callback
-    result = builder.on_failure(main_task.task_id, error_handler)
-
-    # Should return self for chaining
-    assert result is builder
-
-    # Failure callback should be stored
-    assert main_task.task_id in builder._failure_callbacks
-    assert error_handler in builder._failure_callbacks[main_task.task_id]
-
-
-def test_task_graph_builder_on_failure_task_not_found():
-    """Test on_failure() raises error when parent task not found."""
-    builder = task.TaskGraphBuilder()
-    missing_task_id = task.TaskId("missing-task")
-    error_handler = task.Task.default("error_handler")
-
-    with pytest.raises(ValueError, match="Parent task .* not found"):
-        builder.on_failure(missing_task_id, error_handler)
-
-
-def test_task_graph_builder_multiple_failure_callbacks():
-    """Test adding multiple failure callbacks to same task."""
-    builder = task.TaskGraphBuilder()
-    main_task = task.Task.default("main_task")
-    handler_a = task.Task.default("handler_a")
-    handler_b = task.Task.default("handler_b")
-
-    # Add main task and multiple failure handlers
-    builder.add(main_task)
-    builder.on_failure(main_task.task_id, handler_a)
-    builder.on_failure(main_task.task_id, handler_b)
-
-    # Both handlers should be stored
-    callbacks = builder._failure_callbacks[main_task.task_id]
-    assert len(callbacks) == 2
-    assert handler_a in callbacks
-    assert handler_b in callbacks
-
-
-def test_task_graph_builder_add_success_fail_branch():
-    """Test add_success_fail_branch() with explicit condition_task_id."""
-    builder = task.TaskGraphBuilder()
-    task_a = task.Task.default("task_a")
-    success_task = task.Task.default("success_task")
-    failure_task = task.Task.default("failure_task")
-
-    # Add multiple tasks
-    builder.add(task_a)
-
-    # Branch from task_a explicitly (not _last_added)
-    builder.add_success_fail_branch(task_a.task_id, success_task, failure_task)
-
-    # Success task should depend on task_a (not task_b)
-    assert builder._dependencies[success_task.task_id] == {task_a.task_id}
-    assert task_a.task_id in builder._failure_callbacks
-    assert failure_task in builder._failure_callbacks[task_a.task_id]
-
-
 def test_task_graph_builder_build_empty():
     """Test build() raises error for empty graph."""
     builder = task.TaskGraphBuilder()
 
-    with pytest.raises(ValueError, match="Cannot build empty graph"):
+    with pytest.raises(ValueError, match="Cannot build an empty graph"):
         builder.build()
 
 
@@ -1218,8 +1305,8 @@ def test_task_graph_builder_build_with_failure_callbacks():
     success_task = task.Task.default("success_task")
     failure_task = task.Task.default("failure_task")
 
-    # Build graph with failure callback
-    graph = builder.add(main_task).then(success_task).on_failure(main_task.task_id, failure_task).build()
+    # Build graph with failure callback using inline on_failure=
+    graph = builder.add(main_task, on_failure=failure_task).then(success_task).build()
 
     # Verify failure callback is in graph
     assert failure_task.task_id in graph.fail_children
@@ -1249,20 +1336,19 @@ def test_task_graph_builder_complex_workflow():
     # init -> validate -> (process_a, process_b, process_c) -> merge -> finalize
     # with cleanup on validate failure and error_handler on merge failure
     graph = (
-        builder.chain(init_task, validate_task)
-        .parallel([process_a, process_b, process_c])
-        .then(merge_task)
-        .chain(finalize_task, cleanup_task)
-        .on_failure(validate_task.task_id, cleanup_task)
-        .on_failure(merge_task.task_id, error_handler)
+        builder.add(init_task, depends_on=None)
+        .then(validate_task, on_failure=cleanup_task)
+        .parallel(process_a, process_b, process_c)
+        .then(merge_task, on_failure=error_handler)
+        .then(finalize_task)
         .build()
     )
 
-    # Verify the structure - all tasks should be in children (including failure callbacks)
+    # Verify the structure
     # Regular tasks: init, validate, process_a, process_b, process_c, merge, finalize = 7
-    # Failure callbacks are also in children: cleanup_task, error_handler
-    assert len(graph.children) == 8  # All tasks not including failure callbacks
-    assert len(graph.fail_children) == 2  # cleanup_task, error_handler
+    assert len(graph.children) == 7
+    # Failure callbacks: cleanup_task (on validate), error_handler (on merge)
+    assert len(graph.fail_children) == 2
 
     # Verify chain: init -> validate
     assert validate_task.task_id in graph.edges[init_task.task_id]
@@ -1280,10 +1366,6 @@ def test_task_graph_builder_complex_workflow():
             merge_parents.add(parent_id)
     assert merge_parents == {process_a.task_id, process_b.task_id, process_c.task_id}
 
-    # Verify final chain: merge -> finalize -> cleanup
-    assert finalize_task.task_id in graph.edges[merge_task.task_id]
-    assert cleanup_task.task_id in graph.edges[finalize_task.task_id]
-
     # Verify failure callbacks
     assert cleanup_task.task_id in graph.fail_edges[validate_task.task_id]
     assert error_handler.task_id in graph.fail_edges[merge_task.task_id]
@@ -1295,17 +1377,17 @@ def test_task_graph_builder_method_chaining():
 
     # Create tasks
     tasks = [task.Task.default(f"task_{i}") for i in range(10)]
+    error_handler = task.Task.default("error_handler")
 
     # Chain multiple operations - this should not raise any errors
     result = (
-        builder.add(tasks[0])
+        builder.add(tasks[0], on_failure=error_handler)
         .then(tasks[1])
-        .parallel(tasks[2:5])
+        .parallel(*tasks[2:5])
         .then(tasks[5])
-        .parallel(tasks[6:8])
+        .parallel(*tasks[6:8])
         .then(tasks[8])
         .then(tasks[9])
-        .on_failure(tasks[0].task_id, task.Task.default("error_handler"))
     )
 
     # Should return the builder for continued chaining
@@ -1317,19 +1399,19 @@ def test_task_graph_builder_method_chaining():
 
 
 def test_task_graph_builder_cycle_detection_during_build():
-    """Test that cycle detection works during build() phase."""
+    """Test that the builder raises early when a dependency is not yet registered.
+
+    With _resolve_deps() validation, forward references are rejected at add() time,
+    which prevents cycles from being formed through the builder API.
+    """
     builder = task.TaskGraphBuilder()
 
     task_a = task.Task.default("task_a")
     task_b = task.Task.default("task_b")
 
-    # Create structure that will cause cycle when built
-    builder.add(task_a, depends_on=[task_b.task_id])  # A depends on B
-    builder.add(task_b, depends_on=[task_a.task_id])  # B depends on A
-
-    # Should raise ValueError during build due to cycle
-    with pytest.raises(ValueError, match="would create a cycle in the DAG"):
-        builder.build()
+    # task_b hasn't been added yet — _resolve_deps raises immediately
+    with pytest.raises(ValueError, match="not found in this graph"):
+        builder.add(task_a, depends_on=[task_b.task_id])
 
 
 def test_task_graph_builder_state_isolation():
@@ -1494,11 +1576,10 @@ def test_callback_migration_ergonomics():
     success_task = task.Task.default("success_task")
     failure_task = task.Task.default("failure_task")
 
-    # NEW ERGONOMIC WAY: Use builder with graph-level callbacks
+    # Inline on_failure= kwarg on add() — no separate .on_failure() call needed
     graph = (
-        builder.add(main_task)
+        builder.add(main_task, on_failure=failure_task)
         .then(success_task)  # Success path via dependency
-        .on_failure(main_task.task_id, failure_task)  # Failure path via callback
         .build()
     )
 
@@ -1523,34 +1604,24 @@ def test_complex_callback_migration_scenario():
     save_results = task.Task.default("save_results")
     send_notification = task.Task.default("send_notification")
 
-    # Error handlers (multiple per failure point)
+    # Error handlers (one per failure point, using inline on_failure=)
     validation_error_log = task.Task.default("validation_error_log")
-    validation_error_alert = task.Task.default("validation_error_alert")
     processing_error_rollback = task.Task.default("processing_error_rollback")
-    processing_error_retry = task.Task.default("processing_error_retry")
     save_error_backup = task.Task.default("save_error_backup")
 
-    # Build complex workflow with multiple failure handlers per task
+    # Build complex workflow with failure handlers via inline on_failure=
     graph = (
-        builder.chain(validate_input, process_data, save_results, send_notification)
-        .on_failure(validate_input.task_id, validation_error_log)
-        .on_failure(validate_input.task_id, validation_error_alert)  # Multiple handlers!
-        .on_failure(process_data.task_id, processing_error_rollback)
-        .on_failure(process_data.task_id, processing_error_retry)  # Multiple handlers!
-        .on_failure(save_results.task_id, save_error_backup)
+        builder.add(validate_input, depends_on=None, on_failure=validation_error_log)
+        .then(process_data, on_failure=processing_error_rollback)
+        .then(save_results, on_failure=save_error_backup)
+        .then(send_notification)
         .build()
     )
 
-    # Verify multiple failure handlers per task (impossible with old task-level callbacks)
-    validate_failures = graph.fail_edges[validate_input.task_id]
-    assert validation_error_log.task_id in validate_failures
-    assert validation_error_alert.task_id in validate_failures
-    assert len(validate_failures) == 2
-
-    process_failures = graph.fail_edges[process_data.task_id]
-    assert processing_error_rollback.task_id in process_failures
-    assert processing_error_retry.task_id in process_failures
-    assert len(process_failures) == 2
+    # Verify failure handlers per task
+    assert validation_error_log.task_id in graph.fail_edges[validate_input.task_id]
+    assert processing_error_rollback.task_id in graph.fail_edges[process_data.task_id]
+    assert save_error_backup.task_id in graph.fail_edges[save_results.task_id]
 
     # All main tasks have clean callback state (moved to graph level)
     for main_task in [validate_input, process_data, save_results, send_notification]:
@@ -1664,3 +1735,584 @@ def test_failure_ready_tasks_with_complex_dependency_chains():
     )
     assert len(continue_tasks) == 1
     assert continue_tasks[0].task_id == handler_2.task_id
+
+
+# ~~~~ ~~~~ ~~~~ ~~~~ ~~~~
+# LAST_ADDED SENTINEL TESTS
+# ~~~~ ~~~~ ~~~~ ~~~~ ~~~~
+def test_task_graph_builder_add_depends_on_none_creates_root():
+    """depends_on=None must create a root task with no parents, not fall back to cursor."""
+    builder = task.TaskGraphBuilder()
+    task_a = task.Task.default("task_a")
+    task_b = task.Task.default("task_b")
+
+    builder.add(task_a)
+    builder.add(task_b, depends_on=None)  # must be a root, NOT depend on task_a
+
+    graph = builder.build()
+
+    # task_a must NOT point to task_b (task_b has no parents)
+    assert task_b.task_id not in graph.edges.get(task_a.task_id, set())
+    # task_b must be present in the graph
+    assert task_b.task_id in graph.children
+
+
+def test_task_graph_builder_add_depends_on_last_added_uses_cursor():
+    """Explicit depends_on=LAST_ADDED must behave identically to omitting depends_on."""
+    builder = task.TaskGraphBuilder()
+    task_a = task.Task.default("task_a")
+    task_b = task.Task.default("task_b")
+
+    builder.add(task_a)
+    builder.add(task_b, depends_on=task.LAST_ADDED)
+
+    graph = builder.build()
+
+    # task_b must depend on task_a (cursor-following): task_a → task_b
+    assert task_b.task_id in graph.edges[task_a.task_id]
+
+
+def test_task_graph_builder_parallel_depends_on_none_creates_roots():
+    """parallel(tasks, depends_on=None) must create root tasks with no parents."""
+    builder = task.TaskGraphBuilder()
+    task_a = task.Task.default("task_a")
+    task_b = task.Task.default("task_b")
+    task_c = task.Task.default("task_c")
+
+    builder.add(task_a)
+    builder.parallel(task_b, task_c, depends_on=None)  # roots, NOT depending on task_a
+
+    graph = builder.build()
+
+    # task_a must NOT point to task_b or task_c
+    assert task_b.task_id not in graph.edges.get(task_a.task_id, set())
+    assert task_c.task_id not in graph.edges.get(task_a.task_id, set())
+    # task_b and task_c must be in the graph
+    assert task_b.task_id in graph.children
+    assert task_c.task_id in graph.children
+
+
+def test_last_added_sentinel_is_singleton():
+    """LAST_ADDED must be a singleton — instantiating _LastAddedSentinel always returns same object."""
+    s1 = _LastAddedSentinel()
+    s2 = _LastAddedSentinel()
+    assert s1 is s2
+    assert s1 is task.LAST_ADDED
+
+
+def test_last_added_sentinel_repr():
+    """LAST_ADDED repr must return 'LAST_ADDED' for debuggability."""
+    assert repr(task.LAST_ADDED) == "LAST_ADDED"
+
+
+# ~~~~ ~~~~ ~~~~ ~~~~ ~~~~
+# TASKCHAIN TESTS
+# ~~~~ ~~~~ ~~~~ ~~~~ ~~~~
+def test_task_chain_requires_at_least_one_task():
+    """TaskChain() with zero tasks must raise ValueError."""
+    with pytest.raises(ValueError, match="TaskChain requires at least one task."):
+        task.TaskChain()
+
+
+def test_task_chain_single_task():
+    """For a single-task chain, head and tail must both reference that task."""
+    task_a = task.Task.default("task_a")
+    chain = task.TaskChain(task_a)
+    assert chain.head is task_a
+    assert chain.tail is task_a
+
+
+def test_task_chain_head_and_tail():
+    """head must be the first task and tail must be the last task in the chain."""
+    task_a = task.Task.default("task_a")
+    task_b = task.Task.default("task_b")
+    task_c = task.Task.default("task_c")
+    chain = task.TaskChain(task_a, task_b, task_c)
+    assert chain.head is task_a
+    assert chain.tail is task_c
+
+
+def test_task_chain_preserves_task_order():
+    """_tasks must preserve insertion order."""
+    task_a = task.Task.default("task_a")
+    task_b = task.Task.default("task_b")
+    task_c = task.Task.default("task_c")
+    chain = task.TaskChain(task_a, task_b, task_c)
+    assert chain._tasks == [task_a, task_b, task_c]
+
+
+def test_task_chain_on_failure_stored():
+    """_on_failure must store the provided failure handler task."""
+    task_a = task.Task.default("task_a")
+    task_b = task.Task.default("task_b")
+    handler = task.Task.default("handler")
+    chain = task.TaskChain(task_a, task_b, on_failure=handler)
+    assert chain._on_failure is handler
+
+
+def test_task_chain_no_failure_handler():
+    """_on_failure must be None when no on_failure task is provided."""
+    task_a = task.Task.default("task_a")
+    task_b = task.Task.default("task_b")
+    chain = task.TaskChain(task_a, task_b)
+    assert chain._on_failure is None
+
+
+# ~~~~ ~~~~ ~~~~ ~~~~ ~~~~
+# §8.7 — parallel() NEW TESTS
+# ~~~~ ~~~~ ~~~~ ~~~~ ~~~~
+
+
+def test_parallel_basic():
+    """parallel(a, b, c) as first call → all three are roots, cursor = [a, b, c]."""
+    task_a = task.Task.default("task_a")
+    task_b = task.Task.default("task_b")
+    task_c = task.Task.default("task_c")
+
+    builder = task.TaskGraphBuilder()
+    builder.parallel(task_a, task_b, task_c)
+
+    assert builder._dependencies[task_a.task_id] == set()
+    assert builder._dependencies[task_b.task_id] == set()
+    assert builder._dependencies[task_c.task_id] == set()
+    assert set(builder._last_added) == {task_a.task_id, task_b.task_id, task_c.task_id}
+
+
+def test_parallel_after_add():
+    """add(a).parallel(b, c) → b and c both depend on a."""
+    task_a = task.Task.default("task_a")
+    task_b = task.Task.default("task_b")
+    task_c = task.Task.default("task_c")
+
+    builder = task.TaskGraphBuilder()
+    builder.add(task_a).parallel(task_b, task_c)
+
+    assert builder._dependencies[task_b.task_id] == {task_a.task_id}
+    assert builder._dependencies[task_c.task_id] == {task_a.task_id}
+
+
+def test_parallel_then_fan_in():
+    """parallel(a, b, c).then(d) → d depends on a, b, AND c."""
+    task_a = task.Task.default("task_a")
+    task_b = task.Task.default("task_b")
+    task_c = task.Task.default("task_c")
+    task_d = task.Task.default("task_d")
+
+    builder = task.TaskGraphBuilder()
+    builder.parallel(task_a, task_b, task_c).then(task_d)
+
+    assert builder._dependencies[task_d.task_id] == {
+        task_a.task_id,
+        task_b.task_id,
+        task_c.task_id,
+    }
+
+
+def test_parallel_with_explicit_depends_on():
+    """parallel(b, c, depends_on=[task_a]) with Task object resolves correctly."""
+    task_a = task.Task.default("task_a")
+    task_b = task.Task.default("task_b")
+    task_c = task.Task.default("task_c")
+
+    builder = task.TaskGraphBuilder()
+    builder.add(task_a, depends_on=None)
+    builder.parallel(task_b, task_c, depends_on=[task_a])
+
+    assert builder._dependencies[task_b.task_id] == {task_a.task_id}
+    assert builder._dependencies[task_c.task_id] == {task_a.task_id}
+
+
+def test_parallel_with_none_depends_on():
+    """add(a).parallel(b, c, depends_on=None) → b/c are roots, NOT depending on a."""
+    task_a = task.Task.default("task_a")
+    task_b = task.Task.default("task_b")
+    task_c = task.Task.default("task_c")
+
+    builder = task.TaskGraphBuilder()
+    builder.add(task_a).parallel(task_b, task_c, depends_on=None)
+
+    assert builder._dependencies[task_b.task_id] == set()
+    assert builder._dependencies[task_c.task_id] == set()
+
+
+def test_parallel_with_on_failure():
+    """parallel(b, c, on_failure=handler) → handler registered on BOTH b and c."""
+    task_b = task.Task.default("task_b")
+    task_c = task.Task.default("task_c")
+    handler = task.Task.default("handler")
+
+    builder = task.TaskGraphBuilder()
+    builder.parallel(task_b, task_c, on_failure=handler)
+
+    assert handler in builder._failure_callbacks[task_b.task_id]
+    assert handler in builder._failure_callbacks[task_c.task_id]
+
+
+def test_parallel_single_task():
+    """parallel(task_a) is valid — equivalent to add."""
+    task_a = task.Task.default("task_a")
+
+    builder = task.TaskGraphBuilder()
+    result = builder.parallel(task_a)
+
+    assert result is builder
+    assert task_a.task_id in builder._tasks
+    assert builder._last_added == [task_a.task_id]
+
+
+def test_parallel_cursor_contains_all_tasks():
+    """_last_added after parallel() contains exactly all task IDs passed."""
+    task_a = task.Task.default("task_a")
+    task_b = task.Task.default("task_b")
+    task_c = task.Task.default("task_c")
+
+    builder = task.TaskGraphBuilder()
+    builder.parallel(task_a, task_b, task_c)
+
+    assert set(builder._last_added) == {task_a.task_id, task_b.task_id, task_c.task_id}
+    assert len(builder._last_added) == 3
+
+
+def test_parallel_duplicate_task_raises():
+    """parallel(task_a, task_a) raises ValueError."""
+    task_a = task.Task.default("task_a")
+
+    builder = task.TaskGraphBuilder()
+    with pytest.raises(ValueError, match="already been added"):
+        builder.parallel(task_a, task_a)
+
+
+def test_parallel_already_added_task_raises():
+    """add(a).parallel(a) raises ValueError."""
+    task_a = task.Task.default("task_a")
+    task_b = task.Task.default("task_b")
+
+    builder = task.TaskGraphBuilder()
+    builder.add(task_a)
+    with pytest.raises(ValueError, match="already been added"):
+        builder.parallel(task_a, task_b)
+
+
+# ~~~~ ~~~~ ~~~~ ~~~~ ~~~~
+# §8.8 — add_chain() SEQUENTIAL TESTS
+# ~~~~ ~~~~ ~~~~ ~~~~ ~~~~
+
+
+def test_add_chain_sequential_single_task():
+    """add(a).add_chain(TaskChain(b)) → b depends on a; cursor = [b.task_id]."""
+    task_a = task.Task.default("task_a")
+    task_b = task.Task.default("task_b")
+
+    builder = task.TaskGraphBuilder()
+    builder.add(task_a).add_chain(task.TaskChain(task_b))
+
+    assert builder._dependencies[task_b.task_id] == {task_a.task_id}
+    assert builder._last_added == [task_b.task_id]
+
+
+def test_add_chain_sequential_multi_task():
+    """add(a).add_chain(TaskChain(b, c)) → b→a, c→b; cursor = [c.task_id]."""
+    task_a = task.Task.default("task_a")
+    task_b = task.Task.default("task_b")
+    task_c = task.Task.default("task_c")
+
+    builder = task.TaskGraphBuilder()
+    builder.add(task_a).add_chain(task.TaskChain(task_b, task_c))
+
+    assert builder._dependencies[task_b.task_id] == {task_a.task_id}
+    assert builder._dependencies[task_c.task_id] == {task_b.task_id}
+    assert builder._last_added == [task_c.task_id]
+
+
+def test_add_chain_replaces_cursor():
+    """Cursor after sequential add_chain is only [tail.task_id]."""
+    task_a = task.Task.default("task_a")
+    task_b = task.Task.default("task_b")
+    task_c = task.Task.default("task_c")
+    task_d = task.Task.default("task_d")
+
+    builder = task.TaskGraphBuilder()
+    builder.parallel(task_a, task_b).add_chain(task.TaskChain(task_c, task_d))
+
+    # cursor was [task_a, task_b] before; after add_chain it must be only [task_d]
+    assert builder._last_added == [task_d.task_id]
+
+
+def test_add_chain_embeds_all_tasks():
+    """All tasks in the chain appear in builder._tasks."""
+    task_a = task.Task.default("task_a")
+    task_b = task.Task.default("task_b")
+    task_c = task.Task.default("task_c")
+
+    builder = task.TaskGraphBuilder()
+    builder.add_chain(task.TaskChain(task_a, task_b, task_c))
+
+    assert task_a.task_id in builder._tasks
+    assert task_b.task_id in builder._tasks
+    assert task_c.task_id in builder._tasks
+
+
+# ~~~~ ~~~~ ~~~~ ~~~~ ~~~~
+# §8.9 — add_chain() ROOT / ACCUMULATION TESTS
+# ~~~~ ~~~~ ~~~~ ~~~~ ~~~~
+
+
+def test_add_chain_root_no_dependency():
+    """add_chain(chain, depends_on=None) → head has empty parent set."""
+    task_a = task.Task.default("task_a")
+    task_b = task.Task.default("task_b")
+    task_c = task.Task.default("task_c")
+
+    builder = task.TaskGraphBuilder()
+    builder.add(task_a).add_chain(task.TaskChain(task_b, task_c), depends_on=None)
+
+    # head (task_b) must have no parents
+    assert builder._dependencies[task_b.task_id] == set()
+
+
+def test_add_chain_root_accumulates_cursor():
+    """Two depends_on=None add_chain calls → _last_added = [tail1, tail2]."""
+    task_a = task.Task.default("task_a")
+    task_b = task.Task.default("task_b")
+    task_c = task.Task.default("task_c")
+    task_d = task.Task.default("task_d")
+
+    builder = task.TaskGraphBuilder()
+    builder.add_chain(task.TaskChain(task_a, task_b), depends_on=None)
+    builder.add_chain(task.TaskChain(task_c, task_d), depends_on=None)
+
+    assert set(builder._last_added) == {task_b.task_id, task_d.task_id}
+    assert len(builder._last_added) == 2
+
+
+def test_fan_in_from_two_independent_chains():
+    """Key integration test: two independent chains fan into a single join task."""
+    task_a = task.Task.default("task_a")
+    task_b = task.Task.default("task_b")
+    task_c = task.Task.default("task_c")
+    task_d = task.Task.default("task_d")
+    task_e = task.Task.default("task_e")
+    task_f = task.Task.default("task_f")
+
+    chain_abc = task.TaskChain(task_a, task_b, task_c)
+    chain_de = task.TaskChain(task_d, task_e)
+
+    graph = (
+        task.TaskGraphBuilder()
+        .add_chain(chain_abc, depends_on=None)
+        .add_chain(chain_de, depends_on=None)
+        .then(task_f)
+        .build()
+    )
+
+    # task_f must depend on exactly task_c AND task_e
+    # edges maps parent → children, so task_f appears in edges of task_c and task_e
+    assert task_f.task_id in graph.edges[task_c.task_id]
+    assert task_f.task_id in graph.edges[task_e.task_id]
+    # task_f should be the only child of both tails
+    assert graph.edges[task_c.task_id] == {task_f.task_id}
+    assert graph.edges[task_e.task_id] == {task_f.task_id}
+
+    # Neither chain depends on the other
+    assert task_d.task_id not in graph.edges.get(task_a.task_id, set())
+    assert task_a.task_id not in graph.edges.get(task_d.task_id, set())
+
+
+def test_add_chain_explicit_depends_on_replaces_cursor():
+    """Explicit depends_on=[...] replaces cursor with only [tail.task_id]."""
+    task_a = task.Task.default("task_a")
+    task_b = task.Task.default("task_b")
+    task_c = task.Task.default("task_c")
+    task_d = task.Task.default("task_d")
+
+    builder = task.TaskGraphBuilder()
+    builder.add(task_a, depends_on=None)
+    builder.add(task_b, depends_on=None)
+    # cursor is now [task_b.task_id]; add_chain with explicit depends_on should REPLACE
+    builder.add_chain(task.TaskChain(task_c, task_d), depends_on=[task_a])
+
+    assert builder._last_added == [task_d.task_id]
+
+
+def test_add_chain_on_failure_registered_on_each_task():
+    """Chain's on_failure is registered on every task in the chain."""
+    task_a = task.Task.default("task_a")
+    task_b = task.Task.default("task_b")
+    task_c = task.Task.default("task_c")
+    handler = task.Task.default("handler")
+
+    chain = task.TaskChain(task_a, task_b, task_c, on_failure=handler)
+    builder = task.TaskGraphBuilder()
+    builder.add_chain(chain, depends_on=None)
+
+    assert handler in builder._failure_callbacks[task_a.task_id]
+    assert handler in builder._failure_callbacks[task_b.task_id]
+    assert handler in builder._failure_callbacks[task_c.task_id]
+
+
+def test_add_chain_duplicate_task_raises():
+    """Embedding a chain with an already-registered task raises ValueError."""
+    task_a = task.Task.default("task_a")
+    task_b = task.Task.default("task_b")
+
+    builder = task.TaskGraphBuilder()
+    builder.add(task_a)
+    with pytest.raises(ValueError, match="already been added"):
+        builder.add_chain(task.TaskChain(task_a, task_b))
+
+
+def test_add_chain_first_on_empty_builder():
+    """add_chain(chain) as first call → head has no parents; cursor = [tail.task_id]."""
+    task_a = task.Task.default("task_a")
+    task_b = task.Task.default("task_b")
+    task_c = task.Task.default("task_c")
+
+    builder = task.TaskGraphBuilder()
+    builder.add_chain(task.TaskChain(task_a, task_b, task_c))
+
+    # head has no parents (empty builder, uses LAST_ADDED which resolves to [])
+    assert builder._dependencies[task_a.task_id] == set()
+    # cursor is only the tail
+    assert builder._last_added == [task_c.task_id]
+
+
+# ~~~~ ~~~~~ ~~~~ ~~~~ #
+# §8.2 Missing Named Tests
+# ~~~~ ~~~~~ ~~~~ ~~~~ #
+
+
+def test_add_depends_on_last_added_sentinel_explicit():
+    """Passing depends_on=LAST_ADDED explicitly is identical to omitting depends_on."""
+    task_a = task.Task.default("fn_a")
+    task_b = task.Task.default("fn_b")
+    builder = task.TaskGraphBuilder()
+    builder.add(task_a)
+    builder.add(task_b, depends_on=task.LAST_ADDED)
+    graph = builder.build()
+    assert task_b.task_id in graph.edges[task_a.task_id]
+
+
+def test_add_depends_on_none_replaces_cursor():
+    """add(task, depends_on=None) replaces cursor with just that task."""
+    task_a = task.Task.default("fn_a")
+    task_b = task.Task.default("fn_b")
+    task_c = task.Task.default("fn_c")
+    builder = task.TaskGraphBuilder()
+    builder.add(task_a)
+    builder.add(task_b, depends_on=None)  # independent root; cursor = [task_b]
+    builder.add(task_c)  # should depend on task_b (cursor), not task_a
+    graph = builder.build()
+    assert task_c.task_id in graph.edges[task_b.task_id]
+    assert task_c.task_id not in graph.edges.get(task_a.task_id, set())
+
+
+# ~~~~ ~~~~~ ~~~~ ~~~~ #
+# §8.10 Missing Named Tests
+# ~~~~ ~~~~~ ~~~~ ~~~~ #
+
+
+def test_build_twice_produces_independent_graphs():
+    """build() can be called multiple times; each call returns an independent TaskGraph."""
+    task_a = task.Task.default("fn_a")
+    task_b = task.Task.default("fn_b")
+    builder = task.TaskGraphBuilder()
+    builder.add(task_a).then(task_b)
+    graph1 = builder.build()
+    graph2 = builder.build()
+    assert graph1.graph_id != graph2.graph_id
+    assert graph1 is not graph2
+    assert set(graph1.children.keys()) == set(graph2.children.keys())
+
+
+# ~~~~ ~~~~~ ~~~~ ~~~~ #
+# §8.11 Complex Workflow Integration Tests
+# ~~~~ ~~~~~ ~~~~ ~~~~ #
+
+
+def test_diamond_pattern():
+    """Classic diamond: A fans out to B and C, both join at D."""
+    task_a = task.Task.default("fn_a")
+    task_b = task.Task.default("fn_b")
+    task_c = task.Task.default("fn_c")
+    task_d = task.Task.default("fn_d")
+    graph = (
+        task.TaskGraphBuilder()
+        .add(task_a)
+        .parallel(task_b, task_c)
+        .then(task_d)
+        .build()
+    )
+    assert task_b.task_id in graph.edges[task_a.task_id]
+    assert task_c.task_id in graph.edges[task_a.task_id]
+    assert task_d.task_id in graph.edges[task_b.task_id]
+    assert task_d.task_id in graph.edges[task_c.task_id]
+
+
+def test_sequential_chain_with_inline_on_failure():
+    """Failure handlers are registered per-task when using on_failure= kwarg."""
+    task_a = task.Task.default("fn_a")
+    task_b = task.Task.default("fn_b")
+    err_a = task.Task.default("err_a")
+    err_b = task.Task.default("err_b")
+    graph = (
+        task.TaskGraphBuilder()
+        .add(task_a, on_failure=err_a)
+        .then(task_b, on_failure=err_b)
+        .build()
+    )
+    assert err_a.task_id in graph.fail_children
+    assert err_b.task_id in graph.fail_children
+    assert task_a.task_id in graph.fail_edges
+    assert err_a.task_id in graph.fail_edges[task_a.task_id]
+    assert task_b.task_id in graph.fail_edges
+    assert err_b.task_id in graph.fail_edges[task_b.task_id]
+
+
+def test_explicit_depends_on_with_chain_objects():
+    """TaskChain objects in depends_on resolve to chain.tail.task_id."""
+    task_a = task.Task.default("fn_a")
+    task_b = task.Task.default("fn_b")
+    task_c = task.Task.default("fn_c")
+    task_d = task.Task.default("fn_d")
+    chain_ab = task.TaskChain(task_a, task_b)
+    graph = (
+        task.TaskGraphBuilder()
+        .add_chain(chain_ab, depends_on=None)
+        .add(task_c, depends_on=None)      # independent root
+        .add(task_d, depends_on=[chain_ab, task_c])  # waits for chain tail AND task_c
+        .build()
+    )
+    assert task_d.task_id in graph.edges[task_b.task_id]  # chain resolved to tail
+    assert task_d.task_id in graph.edges[task_c.task_id]
+
+
+def test_complex_parallel_fan_in_with_failure_handlers():
+    """Two independent chains with per-chain failure handlers converge on a join task."""
+    validate = task.Task.default("validate")
+    ingest = task.Task.default("ingest")
+    ingest_err = task.Task.default("ingest_err")
+    transform = task.Task.default("transform")
+    enrich = task.Task.default("enrich")
+    process_err = task.Task.default("process_err")
+    aggregate = task.Task.default("aggregate")
+    cleanup = task.Task.default("cleanup")
+
+    ingest_chain = task.TaskChain(validate, ingest, on_failure=ingest_err)
+    process_chain = task.TaskChain(transform, enrich, on_failure=process_err)
+
+    graph = (
+        task.TaskGraphBuilder()
+        .add_chain(ingest_chain, depends_on=None)
+        .add_chain(process_chain, depends_on=None)
+        .then(aggregate, on_failure=cleanup)
+        .build()
+    )
+    # aggregate depends on both chain tails
+    assert aggregate.task_id in graph.edges[ingest.task_id]
+    assert aggregate.task_id in graph.edges[enrich.task_id]
+    # ingest chain internal deps
+    assert ingest.task_id in graph.edges[validate.task_id]
+    # failure handlers registered
+    assert ingest_err.task_id in graph.fail_children
+    assert process_err.task_id in graph.fail_children
+    assert cleanup.task_id in graph.fail_children

--- a/tests/task/test_graph.py
+++ b/tests/task/test_graph.py
@@ -988,6 +988,9 @@ def test_task_graph_builder_parallel():
     task_c = task.Task.default("task_c")
     tasks = [task_a, task_b, task_c]
 
+    with pytest.raises(ValueError, match="parallel requires at least one task"):
+        builder.parallel()
+
     # Add parallel tasks (variadic)
     result = builder.parallel(task_a, task_b, task_c)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -501,6 +501,12 @@ async def test_publish_task_sets_sequence_number(app, mockservicebus):
     assert await app.publish_task(task) is task
     assert mockservicebus._sender.send_message.call_count == 1
 
+    # Requirement to pass unique_msg_id to send_message so that ServiceBus can dedupe / idempotently
+    # schedule the message
+    call = mockservicebus._sender.send_message.call_args
+    assert call.kwargs["unique_msg_id"] == str(task.task_id)
+    assert call.args[0] == task.model_dump_json()
+
 
 async def test_publish_task_error_handling(app, mockservicebus):
     """Test that publish_task raises an error when publishing fails."""

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "aio-azure-clients-toolbox"
-version = "1.0.4"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -22,9 +22,9 @@ dependencies = [
     { name = "azure-servicebus" },
     { name = "azure-storage-blob" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/ae/0c384e807fac48406b6a29795e95a5f149c74ca197c03f1966af2fe48481/aio_azure_clients_toolbox-1.0.4.tar.gz", hash = "sha256:2f9752c5fadda2d64fa80791186f22a6265be897175cd349168202cd881e3ca2", size = 46914, upload-time = "2025-10-14T16:05:57.107Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/39/ba2eb096f2335e4180483fb675e6d52556212a4bfd5b1f19d0704d32ab7a/aio_azure_clients_toolbox-1.1.0.tar.gz", hash = "sha256:8bb36893cd1efa2fff761e7214ccfb51b4a2ccc4514ff96fde631662c2b42f46", size = 47413, upload-time = "2026-04-03T19:04:38.614Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/ee/f82dce0cba021e2f1d9ffb22dbe499be347f7b53f7b9e3e02d903b9d799f/aio_azure_clients_toolbox-1.0.4-py3-none-any.whl", hash = "sha256:ad9f23613598c0119185ae99ddb2a7490cfc334aef4367745c502fd85013a166", size = 53195, upload-time = "2025-10-14T16:05:55.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/dc/2c5e4d58a5a47f55593f5a9f80141fd9d5cb0a6465ff11c8ad5be3d0ceb1/aio_azure_clients_toolbox-1.1.0-py3-none-any.whl", hash = "sha256:6e4cda155943c94b7d274d32d1116b275f268638f5c81cd42fb26c4e289c9958", size = 53635, upload-time = "2026-04-03T19:04:37.132Z" },
 ]
 
 [[package]]
@@ -387,7 +387,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aio-azure-clients-toolbox", specifier = ">=1.0.4" },
+    { name = "aio-azure-clients-toolbox", specifier = ">=1.1.0" },
     { name = "anyio", specifier = ">=4.11.0" },
     { name = "azure-core-tracing-opentelemetry", specifier = ">=1.0.0b12" },
     { name = "azure-identity", specifier = ">=1.25.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version < '3.12'",
+]
 
 [[package]]
 name = "aio-azure-clients-toolbox"
@@ -180,6 +184,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asttokens"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/a5/8e3f9b6771b0b408517c82d97aed8f2036509bc247d46114925e32fe33f0/asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7", size = 62308, upload-time = "2025-11-15T16:43:48.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a", size = 27047, upload-time = "2025-11-15T16:43:16.109Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -352,6 +365,12 @@ dependencies = [
     { name = "uuid-utils" },
 ]
 
+[package.optional-dependencies]
+repl = [
+    { name = "ipython", version = "9.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "ipython", version = "9.12.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "build" },
@@ -373,11 +392,13 @@ requires-dist = [
     { name = "azure-core-tracing-opentelemetry", specifier = ">=1.0.0b12" },
     { name = "azure-identity", specifier = ">=1.25.0" },
     { name = "azure-servicebus", specifier = ">=7.14.2" },
+    { name = "ipython", marker = "extra == 'repl'" },
     { name = "opentelemetry-api", specifier = ">=1.34.0" },
     { name = "pydantic", specifier = ">=2.12.2" },
     { name = "pydantic-settings", specifier = ">=2.11.0" },
     { name = "uuid-utils", specifier = ">=0.11.1" },
 ]
+provides-extras = ["repl"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -715,12 +736,30 @@ wheels = [
 ]
 
 [[package]]
+name = "decorator"
+version = "5.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711, upload-time = "2025-02-24T04:41:34.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190, upload-time = "2025-02-24T04:41:32.565Z" },
+]
+
+[[package]]
 name = "editorconfig"
 version = "0.17.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/88/3a/a61d9a1f319a186b05d14df17daea42fcddea63c213bcd61a929fb3a6796/editorconfig-0.17.1.tar.gz", hash = "sha256:23c08b00e8e08cc3adcddb825251c497478df1dada6aefeb01e626ad37303745", size = 14695, upload-time = "2025-06-09T08:21:37.097Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/96/fd/a40c621ff207f3ce8e484aa0fc8ba4eb6e3ecf52e15b42ba764b457a9550/editorconfig-0.17.1-py3-none-any.whl", hash = "sha256:1eda9c2c0db8c16dbd50111b710572a5e6de934e39772de1959d41f64fc17c82", size = 16360, upload-time = "2025-06-09T08:21:35.654Z" },
+]
+
+[[package]]
+name = "executing"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
 ]
 
 [[package]]
@@ -883,12 +922,85 @@ wheels = [
 ]
 
 [[package]]
+name = "ipython"
+version = "9.10.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version < '3.12'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version < '3.12'" },
+    { name = "jedi", marker = "python_full_version < '3.12'" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.12'" },
+    { name = "pexpect", marker = "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.12'" },
+    { name = "pygments", marker = "python_full_version < '3.12'" },
+    { name = "stack-data", marker = "python_full_version < '3.12'" },
+    { name = "traitlets", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/25/daae0e764047b0a2480c7bbb25d48f4f509b5818636562eeac145d06dfee/ipython-9.10.1.tar.gz", hash = "sha256:e170e9b2a44312484415bdb750492699bf329233b03f2557a9692cce6466ada4", size = 4426663, upload-time = "2026-03-27T09:53:26.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/09/ba70f8d662d5671687da55ad2cc0064cf795b15e1eea70907532202e7c97/ipython-9.10.1-py3-none-any.whl", hash = "sha256:82d18ae9fb9164ded080c71ef92a182ee35ee7db2395f67616034bebb020a232", size = 622827, upload-time = "2026-03-27T09:53:24.566Z" },
+]
+
+[[package]]
+name = "ipython"
+version = "9.12.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version >= '3.12'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.12'" },
+    { name = "jedi", marker = "python_full_version >= '3.12'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.12'" },
+    { name = "pexpect", marker = "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.12'" },
+    { name = "pygments", marker = "python_full_version >= '3.12'" },
+    { name = "stack-data", marker = "python_full_version >= '3.12'" },
+    { name = "traitlets", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/73/7114f80a8f9cabdb13c27732dce24af945b2923dcab80723602f7c8bc2d8/ipython-9.12.0.tar.gz", hash = "sha256:01daa83f504b693ba523b5a407246cabde4eb4513285a3c6acaff11a66735ee4", size = 4428879, upload-time = "2026-03-27T09:42:45.312Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/22/906c8108974c673ebef6356c506cebb6870d48cedea3c41e949e2dd556bb/ipython-9.12.0-py3-none-any.whl", hash = "sha256:0f2701e8ee86e117e37f50563205d36feaa259d2e08d4a6bc6b6d74b18ce128d", size = 625661, upload-time = "2026-03-27T09:42:42.831Z" },
+]
+
+[[package]]
+name = "ipython-pygments-lexers"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074, upload-time = "2025-01-17T11:24:33.271Z" },
+]
+
+[[package]]
 name = "isodate"
 version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
+]
+
+[[package]]
+name = "jedi"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parso" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287, upload-time = "2024-11-11T01:41:42.873Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9", size = 1572278, upload-time = "2024-11-11T01:41:40.175Z" },
 ]
 
 [[package]]
@@ -997,6 +1109,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "matplotlib-inline"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/74/97e72a36efd4ae2bccb3463284300f8953f199b5ffbc04cbbb0ec78f74b1/matplotlib_inline-0.2.1.tar.gz", hash = "sha256:e1ee949c340d771fc39e241ea75683deb94762c8fa5f2927ec57c83c4dffa9fe", size = 8110, upload-time = "2025-10-23T09:00:22.126Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/33/ee4519fa02ed11a94aef9559552f3b17bb863f2ecfe1a35dc7f548cde231/matplotlib_inline-0.2.1-py3-none-any.whl", hash = "sha256:d56ce5156ba6085e00a9d54fead6ed29a9c47e215cd1bba2e976ef39f5710a76", size = 9516, upload-time = "2025-10-23T09:00:20.675Z" },
 ]
 
 [[package]]
@@ -1319,12 +1443,33 @@ wheels = [
 ]
 
 [[package]]
+name = "parso"
+version = "0.8.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/76/a1e769043c0c0c9fe391b702539d594731a4362334cdf4dc25d0c09761e7/parso-0.8.6.tar.gz", hash = "sha256:2b9a0332696df97d454fa67b81618fd69c35a7b90327cbe6ba5c92d2c68a7bfd", size = 401621, upload-time = "2026-02-09T15:45:24.425Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/61/fae042894f4296ec49e3f193aff5d7c18440da9e48102c3315e1bc4519a7/parso-0.8.6-py2.py3-none-any.whl", hash = "sha256:2c549f800b70a5c4952197248825584cb00f033b29c692671d3bf08bf380baff", size = 106894, upload-time = "2026-02-09T15:45:21.391Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "1.0.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
+]
+
+[[package]]
+name = "pexpect"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
 ]
 
 [[package]]
@@ -1343,6 +1488,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
 ]
 
 [[package]]
@@ -1416,6 +1573,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/4c/b0fe775a2bdd01e176b14b574be679d84fc83958335790f7c9a686c1f468/propcache-0.3.2-cp313-cp313t-win32.whl", hash = "sha256:f86e5d7cd03afb3a1db8e9f9f6eff15794e79e791350ac48a8c924e6f439f394", size = 41175, upload-time = "2025-06-09T22:55:38.436Z" },
     { url = "https://files.pythonhosted.org/packages/a4/ff/47f08595e3d9b5e149c150f88d9714574f1a7cbd89fe2817158a952674bf/propcache-0.3.2-cp313-cp313t-win_amd64.whl", hash = "sha256:9704bedf6e7cbe3c65eca4379a9b53ee6a83749f047808cbb5044d40d7d72198", size = 44857, upload-time = "2025-06-09T22:55:39.687Z" },
     { url = "https://files.pythonhosted.org/packages/cc/35/cc0aaecf278bb4575b8555f2b137de5ab821595ddae9da9d3cd1da4072c7/propcache-0.3.2-py3-none-any.whl", hash = "sha256:98f1ec44fb675f5052cccc8e609c46ed23a35a1cfd18545ad4e29002d858a43f", size = 12663, upload-time = "2025-06-09T22:56:04.484Z" },
+]
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
+]
+
+[[package]]
+name = "pure-eval"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
 ]
 
 [[package]]
@@ -1802,6 +1977,20 @@ wheels = [
 ]
 
 [[package]]
+name = "stack-data"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens" },
+    { name = "executing" },
+    { name = "pure-eval" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1838,6 +2027,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload-time = "2024-11-27T22:38:32.837Z" },
     { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload-time = "2024-11-27T22:38:34.455Z" },
     { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
+]
+
+[[package]]
+name = "traitlets"
+version = "5.14.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
 ]
 
 [[package]]
@@ -1939,6 +2137,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -338,7 +338,7 @@ wheels = [
 
 [[package]]
 name = "boilermaker-servicebus"
-version = "1.0.0rc1"
+version = "1.0.0.dev4"
 source = { editable = "." }
 dependencies = [
     { name = "aio-azure-clients-toolbox" },
@@ -359,12 +359,11 @@ dev = [
     { name = "mkdocs-material" },
     { name = "mkdocs-mermaid2-plugin" },
     { name = "mkdocstrings", extra = ["python"] },
-    { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
-    { name = "pytest-mypy" },
     { name = "ruff" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -387,12 +386,11 @@ dev = [
     { name = "mkdocs-material", specifier = ">=9.7.6" },
     { name = "mkdocs-mermaid2-plugin", specifier = ">=1.2.3" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0.3" },
-    { name = "mypy", specifier = ">=1.20.0" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
-    { name = "pytest-mypy", specifier = ">=1.0.1" },
     { name = "ruff", specifier = ">=0.15.8" },
+    { name = "ty", specifier = ">=0.0.27" },
 ]
 
 [[package]]
@@ -726,15 +724,6 @@ wheels = [
 ]
 
 [[package]]
-name = "filelock"
-version = "3.20.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/46/0028a82567109b5ef6e4d2a1f04a583fb513e6cf9527fcdd09afd817deeb/filelock-3.20.0.tar.gz", hash = "sha256:711e943b4ec6be42e1d4e6690b48dc175c822967466bb31c0c293f34334c13f4", size = 18922, upload-time = "2025-10-08T18:03:50.056Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/91/7216b27286936c16f5b4d0c530087e4a54eead683e6b0b73dd0c64844af6/filelock-3.20.0-py3-none-any.whl", hash = "sha256:339b4732ffda5cd79b13f4e2711a31b0365ce445d95d243bb996273d072546a2", size = 16054, upload-time = "2025-10-08T18:03:48.35Z" },
-]
-
-[[package]]
 name = "frozenlist"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -925,79 +914,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ea/98/d6cadf4d5a1c03b2136837a435682418c29fdeb66be137128544cecc5b7a/jsbeautifier-1.15.4.tar.gz", hash = "sha256:5bb18d9efb9331d825735fbc5360ee8f1aac5e52780042803943aa7f854f7592", size = 75257, upload-time = "2025-02-27T17:53:53.252Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2d/14/1c65fccf8413d5f5c6e8425f84675169654395098000d8bddc4e9d3390e1/jsbeautifier-1.15.4-py3-none-any.whl", hash = "sha256:72f65de312a3f10900d7685557f84cb61a9733c50dcc27271a39f5b0051bf528", size = 94707, upload-time = "2025-02-27T17:53:46.152Z" },
-]
-
-[[package]]
-name = "librt"
-version = "0.8.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/56/9c/b4b0c54d84da4a94b37bd44151e46d5e583c9534c7e02250b961b1b6d8a8/librt-0.8.1.tar.gz", hash = "sha256:be46a14693955b3bd96014ccbdb8339ee8c9346fbe11c1b78901b55125f14c73", size = 177471, upload-time = "2026-02-17T16:13:06.101Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/01/0e748af5e4fee180cf7cd12bd12b0513ad23b045dccb2a83191bde82d168/librt-0.8.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:681dc2451d6d846794a828c16c22dc452d924e9f700a485b7ecb887a30aad1fd", size = 65315, upload-time = "2026-02-17T16:11:25.152Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/4d/7184806efda571887c798d573ca4134c80ac8642dcdd32f12c31b939c595/librt-0.8.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3b4350b13cc0e6f5bec8fa7caf29a8fb8cdc051a3bae45cfbfd7ce64f009965", size = 68021, upload-time = "2026-02-17T16:11:26.129Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/88/c3c52d2a5d5101f28d3dc89298444626e7874aa904eed498464c2af17627/librt-0.8.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ac1e7817fd0ed3d14fd7c5df91daed84c48e4c2a11ee99c0547f9f62fdae13da", size = 194500, upload-time = "2026-02-17T16:11:27.177Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/5d/6fb0a25b6a8906e85b2c3b87bee1d6ed31510be7605b06772f9374ca5cb3/librt-0.8.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:747328be0c5b7075cde86a0e09d7a9196029800ba75a1689332348e998fb85c0", size = 205622, upload-time = "2026-02-17T16:11:28.242Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/a6/8006ae81227105476a45691f5831499e4d936b1c049b0c1feb17c11b02d1/librt-0.8.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f0af2bd2bc204fa27f3d6711d0f360e6b8c684a035206257a81673ab924aa11e", size = 218304, upload-time = "2026-02-17T16:11:29.344Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/19/60e07886ad16670aae57ef44dada41912c90906a6fe9f2b9abac21374748/librt-0.8.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d480de377f5b687b6b1bc0c0407426da556e2a757633cc7e4d2e1a057aa688f3", size = 211493, upload-time = "2026-02-17T16:11:30.445Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/cf/f666c89d0e861d05600438213feeb818c7514d3315bae3648b1fc145d2b6/librt-0.8.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d0ee06b5b5291f609ddb37b9750985b27bc567791bc87c76a569b3feed8481ac", size = 219129, upload-time = "2026-02-17T16:11:32.021Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/ef/f1bea01e40b4a879364c031476c82a0dc69ce068daad67ab96302fed2d45/librt-0.8.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:9e2c6f77b9ad48ce5603b83b7da9ee3e36b3ab425353f695cba13200c5d96596", size = 213113, upload-time = "2026-02-17T16:11:33.192Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/80/cdab544370cc6bc1b72ea369525f547a59e6938ef6863a11ab3cd24759af/librt-0.8.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:439352ba9373f11cb8e1933da194dcc6206daf779ff8df0ed69c5e39113e6a99", size = 212269, upload-time = "2026-02-17T16:11:34.373Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/9c/48d6ed8dac595654f15eceab2035131c136d1ae9a1e3548e777bb6dbb95d/librt-0.8.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:82210adabbc331dbb65d7868b105185464ef13f56f7f76688565ad79f648b0fe", size = 234673, upload-time = "2026-02-17T16:11:36.063Z" },
-    { url = "https://files.pythonhosted.org/packages/16/01/35b68b1db517f27a01be4467593292eb5315def8900afad29fabf56304ba/librt-0.8.1-cp311-cp311-win32.whl", hash = "sha256:52c224e14614b750c0a6d97368e16804a98c684657c7518752c356834fff83bb", size = 54597, upload-time = "2026-02-17T16:11:37.544Z" },
-    { url = "https://files.pythonhosted.org/packages/71/02/796fe8f02822235966693f257bf2c79f40e11337337a657a8cfebba5febc/librt-0.8.1-cp311-cp311-win_amd64.whl", hash = "sha256:c00e5c884f528c9932d278d5c9cbbea38a6b81eb62c02e06ae53751a83a4d52b", size = 61733, upload-time = "2026-02-17T16:11:38.691Z" },
-    { url = "https://files.pythonhosted.org/packages/28/ad/232e13d61f879a42a4e7117d65e4984bb28371a34bb6fb9ca54ec2c8f54e/librt-0.8.1-cp311-cp311-win_arm64.whl", hash = "sha256:f7cdf7f26c2286ffb02e46d7bac56c94655540b26347673bea15fa52a6af17e9", size = 52273, upload-time = "2026-02-17T16:11:40.308Z" },
-    { url = "https://files.pythonhosted.org/packages/95/21/d39b0a87ac52fc98f621fb6f8060efb017a767ebbbac2f99fbcbc9ddc0d7/librt-0.8.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a28f2612ab566b17f3698b0da021ff9960610301607c9a5e8eaca62f5e1c350a", size = 66516, upload-time = "2026-02-17T16:11:41.604Z" },
-    { url = "https://files.pythonhosted.org/packages/69/f1/46375e71441c43e8ae335905e069f1c54febee63a146278bcee8782c84fd/librt-0.8.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:60a78b694c9aee2a0f1aaeaa7d101cf713e92e8423a941d2897f4fa37908dab9", size = 68634, upload-time = "2026-02-17T16:11:43.268Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/33/c510de7f93bf1fa19e13423a606d8189a02624a800710f6e6a0a0f0784b3/librt-0.8.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:758509ea3f1eba2a57558e7e98f4659d0ea7670bff49673b0dde18a3c7e6c0eb", size = 198941, upload-time = "2026-02-17T16:11:44.28Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/36/e725903416409a533d92398e88ce665476f275081d0d7d42f9c4951999e5/librt-0.8.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:039b9f2c506bd0ab0f8725aa5ba339c6f0cd19d3b514b50d134789809c24285d", size = 209991, upload-time = "2026-02-17T16:11:45.462Z" },
-    { url = "https://files.pythonhosted.org/packages/30/7a/8d908a152e1875c9f8eac96c97a480df425e657cdb47854b9efaa4998889/librt-0.8.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bb54f1205a3a6ab41a6fd71dfcdcbd278670d3a90ca502a30d9da583105b6f7", size = 224476, upload-time = "2026-02-17T16:11:46.542Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/b8/a22c34f2c485b8903a06f3fe3315341fe6876ef3599792344669db98fcff/librt-0.8.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:05bd41cdee35b0c59c259f870f6da532a2c5ca57db95b5f23689fcb5c9e42440", size = 217518, upload-time = "2026-02-17T16:11:47.746Z" },
-    { url = "https://files.pythonhosted.org/packages/79/6f/5c6fea00357e4f82ba44f81dbfb027921f1ab10e320d4a64e1c408d035d9/librt-0.8.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:adfab487facf03f0d0857b8710cf82d0704a309d8ffc33b03d9302b4c64e91a9", size = 225116, upload-time = "2026-02-17T16:11:49.298Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/a0/95ced4e7b1267fe1e2720a111685bcddf0e781f7e9e0ce59d751c44dcfe5/librt-0.8.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:153188fe98a72f206042be10a2c6026139852805215ed9539186312d50a8e972", size = 217751, upload-time = "2026-02-17T16:11:50.49Z" },
-    { url = "https://files.pythonhosted.org/packages/93/c2/0517281cb4d4101c27ab59472924e67f55e375bc46bedae94ac6dc6e1902/librt-0.8.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:dd3c41254ee98604b08bd5b3af5bf0a89740d4ee0711de95b65166bf44091921", size = 218378, upload-time = "2026-02-17T16:11:51.783Z" },
-    { url = "https://files.pythonhosted.org/packages/43/e8/37b3ac108e8976888e559a7b227d0ceac03c384cfd3e7a1c2ee248dbae79/librt-0.8.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e0d138c7ae532908cbb342162b2611dbd4d90c941cd25ab82084aaf71d2c0bd0", size = 241199, upload-time = "2026-02-17T16:11:53.561Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/5b/35812d041c53967fedf551a39399271bbe4257e681236a2cf1a69c8e7fa1/librt-0.8.1-cp312-cp312-win32.whl", hash = "sha256:43353b943613c5d9c49a25aaffdba46f888ec354e71e3529a00cca3f04d66a7a", size = 54917, upload-time = "2026-02-17T16:11:54.758Z" },
-    { url = "https://files.pythonhosted.org/packages/de/d1/fa5d5331b862b9775aaf2a100f5ef86854e5d4407f71bddf102f4421e034/librt-0.8.1-cp312-cp312-win_amd64.whl", hash = "sha256:ff8baf1f8d3f4b6b7257fcb75a501f2a5499d0dda57645baa09d4d0d34b19444", size = 62017, upload-time = "2026-02-17T16:11:55.748Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/7c/c614252f9acda59b01a66e2ddfd243ed1c7e1deab0293332dfbccf862808/librt-0.8.1-cp312-cp312-win_arm64.whl", hash = "sha256:0f2ae3725904f7377e11cc37722d5d401e8b3d5851fb9273d7f4fe04f6b3d37d", size = 52441, upload-time = "2026-02-17T16:11:56.801Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/3c/f614c8e4eaac7cbf2bbdf9528790b21d89e277ee20d57dc6e559c626105f/librt-0.8.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7e6bad1cd94f6764e1e21950542f818a09316645337fd5ab9a7acc45d99a8f35", size = 66529, upload-time = "2026-02-17T16:11:57.809Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/96/5836544a45100ae411eda07d29e3d99448e5258b6e9c8059deb92945f5c2/librt-0.8.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cf450f498c30af55551ba4f66b9123b7185362ec8b625a773b3d39aa1a717583", size = 68669, upload-time = "2026-02-17T16:11:58.843Z" },
-    { url = "https://files.pythonhosted.org/packages/06/53/f0b992b57af6d5531bf4677d75c44f095f2366a1741fb695ee462ae04b05/librt-0.8.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:eca45e982fa074090057132e30585a7e8674e9e885d402eae85633e9f449ce6c", size = 199279, upload-time = "2026-02-17T16:11:59.862Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/ad/4848cc16e268d14280d8168aee4f31cea92bbd2b79ce33d3e166f2b4e4fc/librt-0.8.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c3811485fccfda840861905b8c70bba5ec094e02825598bb9d4ca3936857a04", size = 210288, upload-time = "2026-02-17T16:12:00.954Z" },
-    { url = "https://files.pythonhosted.org/packages/52/05/27fdc2e95de26273d83b96742d8d3b7345f2ea2bdbd2405cc504644f2096/librt-0.8.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e4af413908f77294605e28cfd98063f54b2c790561383971d2f52d113d9c363", size = 224809, upload-time = "2026-02-17T16:12:02.108Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/d0/78200a45ba3240cb042bc597d6f2accba9193a2c57d0356268cbbe2d0925/librt-0.8.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5212a5bd7fae98dae95710032902edcd2ec4dc994e883294f75c857b83f9aba0", size = 218075, upload-time = "2026-02-17T16:12:03.631Z" },
-    { url = "https://files.pythonhosted.org/packages/af/72/a210839fa74c90474897124c064ffca07f8d4b347b6574d309686aae7ca6/librt-0.8.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e692aa2d1d604e6ca12d35e51fdc36f4cda6345e28e36374579f7ef3611b3012", size = 225486, upload-time = "2026-02-17T16:12:04.725Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/c1/a03cc63722339ddbf087485f253493e2b013039f5b707e8e6016141130fa/librt-0.8.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4be2a5c926b9770c9e08e717f05737a269b9d0ebc5d2f0060f0fe3fe9ce47acb", size = 218219, upload-time = "2026-02-17T16:12:05.828Z" },
-    { url = "https://files.pythonhosted.org/packages/58/f5/fff6108af0acf941c6f274a946aea0e484bd10cd2dc37610287ce49388c5/librt-0.8.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:fd1a720332ea335ceb544cf0a03f81df92abd4bb887679fd1e460976b0e6214b", size = 218750, upload-time = "2026-02-17T16:12:07.09Z" },
-    { url = "https://files.pythonhosted.org/packages/71/67/5a387bfef30ec1e4b4f30562c8586566faf87e47d696768c19feb49e3646/librt-0.8.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:93c2af9e01e0ef80d95ae3c720be101227edae5f2fe7e3dc63d8857fadfc5a1d", size = 241624, upload-time = "2026-02-17T16:12:08.43Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/be/24f8502db11d405232ac1162eb98069ca49c3306c1d75c6ccc61d9af8789/librt-0.8.1-cp313-cp313-win32.whl", hash = "sha256:086a32dbb71336627e78cc1d6ee305a68d038ef7d4c39aaff41ae8c9aa46e91a", size = 54969, upload-time = "2026-02-17T16:12:09.633Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/73/c9fdf6cb2a529c1a092ce769a12d88c8cca991194dfe641b6af12fa964d2/librt-0.8.1-cp313-cp313-win_amd64.whl", hash = "sha256:e11769a1dbda4da7b00a76cfffa67aa47cfa66921d2724539eee4b9ede780b79", size = 62000, upload-time = "2026-02-17T16:12:10.632Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/97/68f80ca3ac4924f250cdfa6e20142a803e5e50fca96ef5148c52ee8c10ea/librt-0.8.1-cp313-cp313-win_arm64.whl", hash = "sha256:924817ab3141aca17893386ee13261f1d100d1ef410d70afe4389f2359fea4f0", size = 52495, upload-time = "2026-02-17T16:12:11.633Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/6a/907ef6800f7bca71b525a05f1839b21f708c09043b1c6aa77b6b827b3996/librt-0.8.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:6cfa7fe54fd4d1f47130017351a959fe5804bda7a0bc7e07a2cdbc3fdd28d34f", size = 66081, upload-time = "2026-02-17T16:12:12.766Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/18/25e991cd5640c9fb0f8d91b18797b29066b792f17bf8493da183bf5caabe/librt-0.8.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:228c2409c079f8c11fb2e5d7b277077f694cb93443eb760e00b3b83cb8b3176c", size = 68309, upload-time = "2026-02-17T16:12:13.756Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/36/46820d03f058cfb5a9de5940640ba03165ed8aded69e0733c417bb04df34/librt-0.8.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7aae78ab5e3206181780e56912d1b9bb9f90a7249ce12f0e8bf531d0462dd0fc", size = 196804, upload-time = "2026-02-17T16:12:14.818Z" },
-    { url = "https://files.pythonhosted.org/packages/59/18/5dd0d3b87b8ff9c061849fbdb347758d1f724b9a82241aa908e0ec54ccd0/librt-0.8.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:172d57ec04346b047ca6af181e1ea4858086c80bdf455f61994c4aa6fc3f866c", size = 206907, upload-time = "2026-02-17T16:12:16.513Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/96/ef04902aad1424fd7299b62d1890e803e6ab4018c3044dca5922319c4b97/librt-0.8.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6b1977c4ea97ce5eb7755a78fae68d87e4102e4aaf54985e8b56806849cc06a3", size = 221217, upload-time = "2026-02-17T16:12:17.906Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/ff/7e01f2dda84a8f5d280637a2e5827210a8acca9a567a54507ef1c75b342d/librt-0.8.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10c42e1f6fd06733ef65ae7bebce2872bcafd8d6e6b0a08fe0a05a23b044fb14", size = 214622, upload-time = "2026-02-17T16:12:19.108Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/8c/5b093d08a13946034fed57619742f790faf77058558b14ca36a6e331161e/librt-0.8.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4c8dfa264b9193c4ee19113c985c95f876fae5e51f731494fc4e0cf594990ba7", size = 221987, upload-time = "2026-02-17T16:12:20.331Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/cc/86b0b3b151d40920ad45a94ce0171dec1aebba8a9d72bb3fa00c73ab25dd/librt-0.8.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:01170b6729a438f0dedc4a26ed342e3dc4f02d1000b4b19f980e1877f0c297e6", size = 215132, upload-time = "2026-02-17T16:12:21.54Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/be/8588164a46edf1e69858d952654e216a9a91174688eeefb9efbb38a9c799/librt-0.8.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:7b02679a0d783bdae30d443025b94465d8c3dc512f32f5b5031f93f57ac32071", size = 215195, upload-time = "2026-02-17T16:12:23.073Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/f2/0b9279bea735c734d69344ecfe056c1ba211694a72df10f568745c899c76/librt-0.8.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:190b109bb69592a3401fe1ffdea41a2e73370ace2ffdc4a0e8e2b39cdea81b78", size = 237946, upload-time = "2026-02-17T16:12:24.275Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/cc/5f2a34fbc8aeb35314a3641f9956fa9051a947424652fad9882be7a97949/librt-0.8.1-cp314-cp314-win32.whl", hash = "sha256:e70a57ecf89a0f64c24e37f38d3fe217a58169d2fe6ed6d70554964042474023", size = 50689, upload-time = "2026-02-17T16:12:25.766Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/76/cd4d010ab2147339ca2b93e959c3686e964edc6de66ddacc935c325883d7/librt-0.8.1-cp314-cp314-win_amd64.whl", hash = "sha256:7e2f3edca35664499fbb36e4770650c4bd4a08abc1f4458eab9df4ec56389730", size = 57875, upload-time = "2026-02-17T16:12:27.465Z" },
-    { url = "https://files.pythonhosted.org/packages/84/0f/2143cb3c3ca48bd3379dcd11817163ca50781927c4537345d608b5045998/librt-0.8.1-cp314-cp314-win_arm64.whl", hash = "sha256:0d2f82168e55ddefd27c01c654ce52379c0750ddc31ee86b4b266bcf4d65f2a3", size = 48058, upload-time = "2026-02-17T16:12:28.556Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/0e/9b23a87e37baf00311c3efe6b48d6b6c168c29902dfc3f04c338372fd7db/librt-0.8.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2c74a2da57a094bd48d03fa5d196da83d2815678385d2978657499063709abe1", size = 68313, upload-time = "2026-02-17T16:12:29.659Z" },
-    { url = "https://files.pythonhosted.org/packages/db/9a/859c41e5a4f1c84200a7d2b92f586aa27133c8243b6cac9926f6e54d01b9/librt-0.8.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a355d99c4c0d8e5b770313b8b247411ed40949ca44e33e46a4789b9293a907ee", size = 70994, upload-time = "2026-02-17T16:12:31.516Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/28/10605366ee599ed34223ac2bf66404c6fb59399f47108215d16d5ad751a8/librt-0.8.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:2eb345e8b33fb748227409c9f1233d4df354d6e54091f0e8fc53acdb2ffedeb7", size = 220770, upload-time = "2026-02-17T16:12:33.294Z" },
-    { url = "https://files.pythonhosted.org/packages/af/8d/16ed8fd452dafae9c48d17a6bc1ee3e818fd40ef718d149a8eff2c9f4ea2/librt-0.8.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9be2f15e53ce4e83cc08adc29b26fb5978db62ef2a366fbdf716c8a6c8901040", size = 235409, upload-time = "2026-02-17T16:12:35.443Z" },
-    { url = "https://files.pythonhosted.org/packages/89/1b/7bdf3e49349c134b25db816e4a3db6b94a47ac69d7d46b1e682c2c4949be/librt-0.8.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:785ae29c1f5c6e7c2cde2c7c0e148147f4503da3abc5d44d482068da5322fd9e", size = 246473, upload-time = "2026-02-17T16:12:36.656Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/8a/91fab8e4fd2a24930a17188c7af5380eb27b203d72101c9cc000dbdfd95a/librt-0.8.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1d3a7da44baf692f0c6aeb5b2a09c5e6fc7a703bca9ffa337ddd2e2da53f7732", size = 238866, upload-time = "2026-02-17T16:12:37.849Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/e0/c45a098843fc7c07e18a7f8a24ca8496aecbf7bdcd54980c6ca1aaa79a8e/librt-0.8.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5fc48998000cbc39ec0d5311312dda93ecf92b39aaf184c5e817d5d440b29624", size = 250248, upload-time = "2026-02-17T16:12:39.445Z" },
-    { url = "https://files.pythonhosted.org/packages/82/30/07627de23036640c952cce0c1fe78972e77d7d2f8fd54fa5ef4554ff4a56/librt-0.8.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e96baa6820280077a78244b2e06e416480ed859bbd8e5d641cf5742919d8beb4", size = 240629, upload-time = "2026-02-17T16:12:40.889Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/c1/55bfe1ee3542eba055616f9098eaf6eddb966efb0ca0f44eaa4aba327307/librt-0.8.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:31362dbfe297b23590530007062c32c6f6176f6099646bb2c95ab1b00a57c382", size = 239615, upload-time = "2026-02-17T16:12:42.446Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/39/191d3d28abc26c9099b19852e6c99f7f6d400b82fa5a4e80291bd3803e19/librt-0.8.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cc3656283d11540ab0ea01978378e73e10002145117055e03722417aeab30994", size = 263001, upload-time = "2026-02-17T16:12:43.627Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/eb/7697f60fbe7042ab4e88f4ee6af496b7f222fffb0a4e3593ef1f29f81652/librt-0.8.1-cp314-cp314t-win32.whl", hash = "sha256:738f08021b3142c2918c03692608baed43bc51144c29e35807682f8070ee2a3a", size = 51328, upload-time = "2026-02-17T16:12:45.148Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/72/34bf2eb7a15414a23e5e70ecb9440c1d3179f393d9349338a91e2781c0fb/librt-0.8.1-cp314-cp314t-win_amd64.whl", hash = "sha256:89815a22daf9c51884fb5dbe4f1ef65ee6a146e0b6a8df05f753e2e4a9359bf4", size = 58722, upload-time = "2026-02-17T16:12:46.85Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/c8/d148e041732d631fc76036f8b30fae4e77b027a1e95b7a84bb522481a940/librt-0.8.1-cp314-cp314t-win_arm64.whl", hash = "sha256:bf512a71a23504ed08103a13c941f763db13fb11177beb3d9244c98c29fb4a61", size = 48755, upload-time = "2026-02-17T16:12:47.943Z" },
 ]
 
 [[package]]
@@ -1372,65 +1288,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mypy"
-version = "1.20.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "mypy-extensions" },
-    { name = "pathspec" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/b0089fe7fef0a994ae5ee07029ced0526082c6cfaaa4c10d40a10e33b097/mypy-1.20.0.tar.gz", hash = "sha256:eb96c84efcc33f0b5e0e04beacf00129dd963b67226b01c00b9dfc8affb464c3", size = 3815028, upload-time = "2026-03-31T16:55:14.959Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/1c/74cb1d9993236910286865679d1c616b136b2eae468493aa939431eda410/mypy-1.20.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4525e7010b1b38334516181c5b81e16180b8e149e6684cee5a727c78186b4e3b", size = 14343972, upload-time = "2026-03-31T16:49:04.887Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/0d/01399515eca280386e308cf57901e68d3a52af18691941b773b3380c1df8/mypy-1.20.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a17c5d0bdcca61ce24a35beb828a2d0d323d3fcf387d7512206888c900193367", size = 13225007, upload-time = "2026-03-31T16:50:08.151Z" },
-    { url = "https://files.pythonhosted.org/packages/56/ac/b4ba5094fb2d7fe9d2037cd8d18bbe02bcf68fd22ab9ff013f55e57ba095/mypy-1.20.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f75ff57defcd0f1d6e006d721ccdec6c88d4f6a7816eb92f1c4890d979d9ee62", size = 13663752, upload-time = "2026-03-31T16:49:26.064Z" },
-    { url = "https://files.pythonhosted.org/packages/db/a7/460678d3cf7da252d2288dad0c602294b6ec22a91932ec368cc11e44bb6e/mypy-1.20.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b503ab55a836136b619b5fc21c8803d810c5b87551af8600b72eecafb0059cb0", size = 14532265, upload-time = "2026-03-31T16:53:55.077Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/3e/051cca8166cf0438ae3ea80e0e7c030d7a8ab98dffc93f80a1aa3f23c1a2/mypy-1.20.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1973868d2adbb4584a3835780b27436f06d1dc606af5be09f187aaa25be1070f", size = 14768476, upload-time = "2026-03-31T16:50:34.587Z" },
-    { url = "https://files.pythonhosted.org/packages/be/66/8e02ec184f852ed5c4abb805583305db475930854e09964b55e107cdcbc4/mypy-1.20.0-cp311-cp311-win_amd64.whl", hash = "sha256:2fcedb16d456106e545b2bfd7ef9d24e70b38ec252d2a629823a4d07ebcdb69e", size = 10818226, upload-time = "2026-03-31T16:53:15.624Z" },
-    { url = "https://files.pythonhosted.org/packages/13/4b/383ad1924b28f41e4879a74151e7a5451123330d45652da359f9183bcd45/mypy-1.20.0-cp311-cp311-win_arm64.whl", hash = "sha256:379edf079ce44ac8d2805bcf9b3dd7340d4f97aad3a5e0ebabbf9d125b84b442", size = 9750091, upload-time = "2026-03-31T16:54:12.162Z" },
-    { url = "https://files.pythonhosted.org/packages/be/dd/3afa29b58c2e57c79116ed55d700721c3c3b15955e2b6251dd165d377c0e/mypy-1.20.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:002b613ae19f4ac7d18b7e168ffe1cb9013b37c57f7411984abbd3b817b0a214", size = 14509525, upload-time = "2026-03-31T16:55:01.824Z" },
-    { url = "https://files.pythonhosted.org/packages/54/eb/227b516ab8cad9f2a13c5e7a98d28cd6aa75e9c83e82776ae6c1c4c046c7/mypy-1.20.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a9336b5e6712f4adaf5afc3203a99a40b379049104349d747eb3e5a3aa23ac2e", size = 13326469, upload-time = "2026-03-31T16:51:41.23Z" },
-    { url = "https://files.pythonhosted.org/packages/57/d4/1ddb799860c1b5ac6117ec307b965f65deeb47044395ff01ab793248a591/mypy-1.20.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f13b3e41bce9d257eded794c0f12878af3129d80aacd8a3ee0dee51f3a978651", size = 13705953, upload-time = "2026-03-31T16:48:55.69Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/b7/54a720f565a87b893182a2a393370289ae7149e4715859e10e1c05e49154/mypy-1.20.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9804c3ad27f78e54e58b32e7cb532d128b43dbfb9f3f9f06262b821a0f6bd3f5", size = 14710363, upload-time = "2026-03-31T16:53:26.948Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/2a/74810274848d061f8a8ea4ac23aaad43bd3d8c1882457999c2e568341c57/mypy-1.20.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:697f102c5c1d526bdd761a69f17c6070f9892eebcb94b1a5963d679288c09e78", size = 14947005, upload-time = "2026-03-31T16:50:17.591Z" },
-    { url = "https://files.pythonhosted.org/packages/77/91/21b8ba75f958bcda75690951ce6fa6b7138b03471618959529d74b8544e2/mypy-1.20.0-cp312-cp312-win_amd64.whl", hash = "sha256:0ecd63f75fdd30327e4ad8b5704bd6d91fc6c1b2e029f8ee14705e1207212489", size = 10880616, upload-time = "2026-03-31T16:52:19.986Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/15/3d8198ef97c1ca03aea010cce4f1d4f3bc5d9849e8c0140111ca2ead9fdd/mypy-1.20.0-cp312-cp312-win_arm64.whl", hash = "sha256:f194db59657c58593a3c47c6dfd7bad4ef4ac12dbc94d01b3a95521f78177e33", size = 9813091, upload-time = "2026-03-31T16:53:44.385Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/a7/f64ea7bd592fa431cb597418b6dec4a47f7d0c36325fec7ac67bc8402b94/mypy-1.20.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b20c8b0fd5877abdf402e79a3af987053de07e6fb208c18df6659f708b535134", size = 14485344, upload-time = "2026-03-31T16:49:16.78Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/72/8927d84cfc90c6abea6e96663576e2e417589347eb538749a464c4c218a0/mypy-1.20.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:367e5c993ba34d5054d11937d0485ad6dfc60ba760fa326c01090fc256adf15c", size = 13327400, upload-time = "2026-03-31T16:53:08.02Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/4a/11ab99f9afa41aa350178d24a7d2da17043228ea10f6456523f64b5a6cf6/mypy-1.20.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f799d9db89fc00446f03281f84a221e50018fc40113a3ba9864b132895619ebe", size = 13706384, upload-time = "2026-03-31T16:52:28.577Z" },
-    { url = "https://files.pythonhosted.org/packages/42/79/694ca73979cfb3535ebfe78733844cd5aff2e63304f59bf90585110d975a/mypy-1.20.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:555658c611099455b2da507582ea20d2043dfdfe7f5ad0add472b1c6238b433f", size = 14700378, upload-time = "2026-03-31T16:48:45.527Z" },
-    { url = "https://files.pythonhosted.org/packages/84/24/a022ccab3a46e3d2cdf2e0e260648633640eb396c7e75d5a42818a8d3971/mypy-1.20.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:efe8d70949c3023698c3fca1e94527e7e790a361ab8116f90d11221421cd8726", size = 14932170, upload-time = "2026-03-31T16:49:36.038Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/9b/549228d88f574d04117e736f55958bd4908f980f9f5700a07aeb85df005b/mypy-1.20.0-cp313-cp313-win_amd64.whl", hash = "sha256:f49590891d2c2f8a9de15614e32e459a794bcba84693c2394291a2038bbaaa69", size = 10888526, upload-time = "2026-03-31T16:50:59.827Z" },
-    { url = "https://files.pythonhosted.org/packages/91/17/15095c0e54a8bc04d22d4ff06b2139d5f142c2e87520b4e39010c4862771/mypy-1.20.0-cp313-cp313-win_arm64.whl", hash = "sha256:76a70bf840495729be47510856b978f1b0ec7d08f257ca38c9d932720bf6b43e", size = 9816456, upload-time = "2026-03-31T16:49:59.537Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/0e/6ca4a84cbed9e62384bc0b2974c90395ece5ed672393e553996501625fc5/mypy-1.20.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0f42dfaab7ec1baff3b383ad7af562ab0de573c5f6edb44b2dab016082b89948", size = 14483331, upload-time = "2026-03-31T16:52:57.999Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/c5/5fe9d8a729dd9605064691816243ae6c49fde0bd28f6e5e17f6a24203c43/mypy-1.20.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:31b5dbb55293c1bd27c0fc813a0d2bb5ceef9d65ac5afa2e58f829dab7921fd5", size = 13342047, upload-time = "2026-03-31T16:54:21.555Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/33/e18bcfa338ca4e6b2771c85d4c5203e627d0c69d9de5c1a2cf2ba13320ba/mypy-1.20.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49d11c6f573a5a08f77fad13faff2139f6d0730ebed2cfa9b3d2702671dd7188", size = 13719585, upload-time = "2026-03-31T16:51:53.89Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/8d/93491ff7b79419edc7eabf95cb3b3f7490e2e574b2855c7c7e7394ff933f/mypy-1.20.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d3243c406773185144527f83be0e0aefc7bf4601b0b2b956665608bf7c98a83", size = 14685075, upload-time = "2026-03-31T16:54:04.464Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/9d/d924b38a4923f8d164bf2b4ec98bf13beaf6e10a5348b4b137eadae40a6e/mypy-1.20.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a79c1eba7ac4209f2d850f0edd0a2f8bba88cbfdfefe6fb76a19e9d4fe5e71a2", size = 14919141, upload-time = "2026-03-31T16:54:51.785Z" },
-    { url = "https://files.pythonhosted.org/packages/59/98/1da9977016678c0b99d43afe52ed00bb3c1a0c4c995d3e6acca1a6ebb9b4/mypy-1.20.0-cp314-cp314-win_amd64.whl", hash = "sha256:00e047c74d3ec6e71a2eb88e9ea551a2edb90c21f993aefa9e0d2a898e0bb732", size = 11050925, upload-time = "2026-03-31T16:51:30.758Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/e3/ba0b7a3143e49a9c4f5967dde6ea4bf8e0b10ecbbcca69af84027160ee89/mypy-1.20.0-cp314-cp314-win_arm64.whl", hash = "sha256:931a7630bba591593dcf6e97224a21ff80fb357e7982628d25e3c618e7f598ef", size = 10001089, upload-time = "2026-03-31T16:49:43.632Z" },
-    { url = "https://files.pythonhosted.org/packages/12/28/e617e67b3be9d213cda7277913269c874eb26472489f95d09d89765ce2d8/mypy-1.20.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:26c8b52627b6552f47ff11adb4e1509605f094e29815323e487fc0053ebe93d1", size = 15534710, upload-time = "2026-03-31T16:52:12.506Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/0c/3b5f2d3e45dc7169b811adce8451679d9430399d03b168f9b0489f43adaa/mypy-1.20.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:39362cdb4ba5f916e7976fccecaab1ba3a83e35f60fa68b64e9a70e221bb2436", size = 14393013, upload-time = "2026-03-31T16:54:41.186Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/49/edc8b0aa145cc09c1c74f7ce2858eead9329931dcbbb26e2ad40906daa4e/mypy-1.20.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34506397dbf40c15dc567635d18a21d33827e9ab29014fb83d292a8f4f8953b6", size = 15047240, upload-time = "2026-03-31T16:54:31.955Z" },
-    { url = "https://files.pythonhosted.org/packages/42/37/a946bb416e37a57fa752b3100fd5ede0e28df94f92366d1716555d47c454/mypy-1.20.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:555493c44a4f5a1b58d611a43333e71a9981c6dbe26270377b6f8174126a0526", size = 15858565, upload-time = "2026-03-31T16:53:36.997Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/99/7690b5b5b552db1bd4ff362e4c0eb3107b98d680835e65823fbe888c8b78/mypy-1.20.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2721f0ce49cb74a38f00c50da67cb7d36317b5eda38877a49614dc018e91c787", size = 16087874, upload-time = "2026-03-31T16:52:48.313Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/76/53e893a498138066acd28192b77495c9357e5a58cc4be753182846b43315/mypy-1.20.0-cp314-cp314t-win_amd64.whl", hash = "sha256:47781555a7aa5fedcc2d16bcd72e0dc83eb272c10dd657f9fb3f9cc08e2e6abb", size = 12572380, upload-time = "2026-03-31T16:49:52.454Z" },
-    { url = "https://files.pythonhosted.org/packages/76/9c/6dbdae21f01b7aacddc2c0bbf3c5557aa547827fdf271770fe1e521e7093/mypy-1.20.0-cp314-cp314t-win_arm64.whl", hash = "sha256:c70380fe5d64010f79fb863b9081c7004dd65225d2277333c219d93a10dad4dd", size = 10381174, upload-time = "2026-03-31T16:51:20.179Z" },
-    { url = "https://files.pythonhosted.org/packages/21/66/4d734961ce167f0fd8380769b3b7c06dbdd6ff54c2190f3f2ecd22528158/mypy-1.20.0-py3-none-any.whl", hash = "sha256:a6e0641147cbfa7e4e94efdb95c2dab1aff8cfc159ded13e07f308ddccc8c48e", size = 2636365, upload-time = "2026-03-31T16:51:44.911Z" },
-]
-
-[[package]]
-name = "mypy-extensions"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
-]
-
-[[package]]
 name = "opentelemetry-api"
 version = "1.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1781,20 +1638,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pytest-mypy"
-version = "1.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "filelock" },
-    { name = "mypy" },
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b0/50/3ce149b469e27848c1dc354553b17774f9dde0140625f5a4130bd21e1052/pytest_mypy-1.0.1.tar.gz", hash = "sha256:3f5fcaff75c80dccc6b68cf5ecc28e1bbe71e95309469eb7a28bf408ce55c074", size = 15975, upload-time = "2025-04-02T19:31:16.151Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/93/25ed3c02e15c4ef1b04cbda7c708ffc5da755986aaacfb48db1f9e84a996/pytest_mypy-1.0.1-py3-none-any.whl", hash = "sha256:ad7133c9b92c802e032f2596590ebede7eea7c418e61d60d5cdd571b55c72056", size = 8701, upload-time = "2025-04-02T19:31:14.914Z" },
-]
-
-[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1995,6 +1838,30 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload-time = "2024-11-27T22:38:32.837Z" },
     { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload-time = "2024-11-27T22:38:34.455Z" },
     { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.27"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/de/e5cf1f151cf52fe1189e42d03d90909d7d1354fdc0c1847cbb63a0baa3da/ty-0.0.27.tar.gz", hash = "sha256:d7a8de3421d92420b40c94fe7e7d4816037560621903964dd035cf9bd0204a73", size = 5424130, upload-time = "2026-03-31T19:07:20.806Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/20/2a9ea661758bd67f2bfd54ce9daacb5a26c56c5f8b49fbd9a43b365a8a7d/ty-0.0.27-py3-none-linux_armv6l.whl", hash = "sha256:eb14456b8611c9e8287aa9b633f4d2a0d9f3082a31796969e0b50bdda8930281", size = 10571211, upload-time = "2026-03-31T19:07:23.28Z" },
+    { url = "https://files.pythonhosted.org/packages/da/b2/8887a51f705d075ddbe78ae7f0d4755ef48d0a90235f67aee289e9cee950/ty-0.0.27-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:02e662184703db7586118df611cf24a000d35dae38d950053d1dd7b6736fd2c4", size = 10427576, upload-time = "2026-03-31T19:07:15.499Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/c3/79d88163f508fb709ce19bc0b0a66c7c64b53d372d4caa56172c3d9b3ae8/ty-0.0.27-py3-none-macosx_11_0_arm64.whl", hash = "sha256:be5fc2899441f7f8f7ef40f9ffd006075a5ff6b06c44e8d2aa30e1b900c12f51", size = 9870359, upload-time = "2026-03-31T19:07:36.852Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/4d/ed1b0db0e1e46b5ed4976bbfe0d1825faf003b4e3774ef28c785ed73e4bb/ty-0.0.27-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30231e652b14742a76b64755e54bf0cb1cd4c128bcaf625222e0ca92a2094887", size = 10380488, upload-time = "2026-03-31T19:07:31.268Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/20372f6d510b01570028433064880adec2f8abe68bf0c4603be61a560bef/ty-0.0.27-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5a119b1168f64261b3205a37e40b5b6c4aac8fd58e4587988f4e4b22c3c79847", size = 10390248, upload-time = "2026-03-31T19:07:28.345Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/46b31a7311306be1a560f7f20fdc37b5bf718787f60626cd265d9b637554/ty-0.0.27-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e38f4e187b6975d2cbebf0f1eb1221f8f64f6e509bad14d7bb2a91afc97e4956", size = 10878479, upload-time = "2026-03-31T19:07:39.393Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ba/5231a2a1fb1cebe053a25de8fded95e1a30a1e77d3628a9e58487297bafc/ty-0.0.27-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a07b1a8fbb23844f6d22091275430d9ac617175f34aa99159b268193de210389", size = 11461232, upload-time = "2026-03-31T19:07:02.518Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/37/558abab3e1f6670493524f61280b4dfcc3219555f13889223e733381dfab/ty-0.0.27-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d3ec4033031f240836bb0337274bac5c49dde312c7c6d7575451ed719bf8ffa3", size = 11133002, upload-time = "2026-03-31T19:07:18.371Z" },
+    { url = "https://files.pythonhosted.org/packages/32/38/188c14a57f52160407ce62c6abb556011718fd0bcbe1dca690529ce84c46/ty-0.0.27-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:924a8849afd500d260bf5b7296165a05b7424fbb6b19113f30f3b999d682873f", size = 10986624, upload-time = "2026-03-31T19:07:13.066Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/f1/667a71393f47d2cd6ba9ed07541b8df3eb63aab1f2ee658e77d91b8362fa/ty-0.0.27-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d8270026c07e7423a1b3a3fd065b46ed1478748f0662518b523b57744f3fa025", size = 10366721, upload-time = "2026-03-31T19:07:00.131Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/aa/8edafe41be898bda774249abc5be6edd733e53fb1777d59ea9331e38537d/ty-0.0.27-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e26e9735d3bdfd95d881111ad1cf570eab8188d8c3be36d6bcaad044d38984d8", size = 10412239, upload-time = "2026-03-31T19:07:05.297Z" },
+    { url = "https://files.pythonhosted.org/packages/53/ff/8bafaed4a18d38264f46bdfc427de7ea2974cf9064e4e0bdb1b6e6c724e3/ty-0.0.27-py3-none-musllinux_1_2_i686.whl", hash = "sha256:7c09cc9a699810609acc0090af8d0db68adaee6e60a7c3e05ab80cc954a83db7", size = 10573507, upload-time = "2026-03-31T19:06:57.064Z" },
+    { url = "https://files.pythonhosted.org/packages/16/2e/63a8284a2fefd08ab56ecbad0fde7dd4b2d4045a31cf24c1d1fcd9643227/ty-0.0.27-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2d3e02853bb037221a456e034b1898aaa573e6374fbb53884e33cb7513ccb85a", size = 11090233, upload-time = "2026-03-31T19:07:34.139Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d3/d6fa1cafdfa2b34dbfa304fc6833af8e1669fc34e24d214fa76d2a2e5a25/ty-0.0.27-py3-none-win32.whl", hash = "sha256:34e7377f2047c14dbbb7bf5322e84114db7a5f2cb470db6bee63f8f3550cfc1e", size = 9984415, upload-time = "2026-03-31T19:07:07.98Z" },
+    { url = "https://files.pythonhosted.org/packages/85/e6/dd4e27da9632b3472d5711ca49dbd3709dbd3e8c73f3af6db9c254235ca9/ty-0.0.27-py3-none-win_amd64.whl", hash = "sha256:3f7e4145aad8b815ed69b324c93b5b773eb864dda366ca16ab8693ff88ce6f36", size = 10961535, upload-time = "2026-03-31T19:07:10.566Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/1a/824b3496d66852ed7d5d68d9787711131552b68dce8835ce9410db32e618/ty-0.0.27-py3-none-win_arm64.whl", hash = "sha256:95bf8d01eb96bb2ba3ffc39faff19da595176448e80871a7b362f4d2de58476c", size = 10376689, upload-time = "2026-03-31T19:07:25.732Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -338,7 +338,7 @@ wheels = [
 
 [[package]]
 name = "boilermaker-servicebus"
-version = "1.0.0.dev2"
+version = "1.0.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "aio-azure-clients-toolbox" },
@@ -382,31 +382,31 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "build", specifier = ">=1.3.0" },
+    { name = "build", specifier = ">=1.4.2" },
     { name = "mkdocs", specifier = ">=1.5.0" },
-    { name = "mkdocs-material", specifier = ">=9.6.21" },
-    { name = "mkdocs-mermaid2-plugin", specifier = ">=1.1.0" },
-    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.24.0" },
-    { name = "mypy", specifier = ">=1.18.2" },
-    { name = "pytest", specifier = ">=8.4.2" },
-    { name = "pytest-asyncio", specifier = ">=1.2.0" },
-    { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "mkdocs-material", specifier = ">=9.7.6" },
+    { name = "mkdocs-mermaid2-plugin", specifier = ">=1.2.3" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0.3" },
+    { name = "mypy", specifier = ">=1.20.0" },
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-mypy", specifier = ">=1.0.1" },
-    { name = "ruff", specifier = ">=0.14.0" },
+    { name = "ruff", specifier = ">=0.15.8" },
 ]
 
 [[package]]
 name = "build"
-version = "1.3.0"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "os_name == 'nt'" },
     { name = "packaging" },
     { name = "pyproject-hooks" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/1c/23e33405a7c9eac261dff640926b8b5adaed6a6eb3e1767d441ed611d0c0/build-1.3.0.tar.gz", hash = "sha256:698edd0ea270bde950f53aed21f3a0135672206f3911e0176261a31e0e07b397", size = 48544, upload-time = "2025-08-01T21:27:09.268Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/1d/ab15c8ac57f4ee8778d7633bc6685f808ab414437b8644f555389cdc875e/build-1.4.2.tar.gz", hash = "sha256:35b14e1ee329c186d3f08466003521ed7685ec15ecffc07e68d706090bf161d1", size = 83433, upload-time = "2026-03-25T14:20:27.659Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/8c/2b30c12155ad8de0cf641d76a8b396a16d2c36bc6d50b621a62b7c4567c1/build-1.3.0-py3-none-any.whl", hash = "sha256:7145f0b5061ba90a1500d60bd1b13ca0a8a4cebdd0cc16ed8adf1c0e739f43b4", size = 23382, upload-time = "2025-08-01T21:27:07.844Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/57/3b7d4dd193ade4641c865bc2b93aeeb71162e81fc348b8dad020215601ed/build-1.4.2-py3-none-any.whl", hash = "sha256:7a4d8651ea877cb2a89458b1b198f2e69f536c95e89129dbf5d448045d60db88", size = 24643, upload-time = "2026-03-25T14:20:26.568Z" },
 ]
 
 [[package]]
@@ -928,6 +928,79 @@ wheels = [
 ]
 
 [[package]]
+name = "librt"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/9c/b4b0c54d84da4a94b37bd44151e46d5e583c9534c7e02250b961b1b6d8a8/librt-0.8.1.tar.gz", hash = "sha256:be46a14693955b3bd96014ccbdb8339ee8c9346fbe11c1b78901b55125f14c73", size = 177471, upload-time = "2026-02-17T16:13:06.101Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/01/0e748af5e4fee180cf7cd12bd12b0513ad23b045dccb2a83191bde82d168/librt-0.8.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:681dc2451d6d846794a828c16c22dc452d924e9f700a485b7ecb887a30aad1fd", size = 65315, upload-time = "2026-02-17T16:11:25.152Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/4d/7184806efda571887c798d573ca4134c80ac8642dcdd32f12c31b939c595/librt-0.8.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3b4350b13cc0e6f5bec8fa7caf29a8fb8cdc051a3bae45cfbfd7ce64f009965", size = 68021, upload-time = "2026-02-17T16:11:26.129Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/88/c3c52d2a5d5101f28d3dc89298444626e7874aa904eed498464c2af17627/librt-0.8.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ac1e7817fd0ed3d14fd7c5df91daed84c48e4c2a11ee99c0547f9f62fdae13da", size = 194500, upload-time = "2026-02-17T16:11:27.177Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5d/6fb0a25b6a8906e85b2c3b87bee1d6ed31510be7605b06772f9374ca5cb3/librt-0.8.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:747328be0c5b7075cde86a0e09d7a9196029800ba75a1689332348e998fb85c0", size = 205622, upload-time = "2026-02-17T16:11:28.242Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a6/8006ae81227105476a45691f5831499e4d936b1c049b0c1feb17c11b02d1/librt-0.8.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f0af2bd2bc204fa27f3d6711d0f360e6b8c684a035206257a81673ab924aa11e", size = 218304, upload-time = "2026-02-17T16:11:29.344Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/19/60e07886ad16670aae57ef44dada41912c90906a6fe9f2b9abac21374748/librt-0.8.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d480de377f5b687b6b1bc0c0407426da556e2a757633cc7e4d2e1a057aa688f3", size = 211493, upload-time = "2026-02-17T16:11:30.445Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/cf/f666c89d0e861d05600438213feeb818c7514d3315bae3648b1fc145d2b6/librt-0.8.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d0ee06b5b5291f609ddb37b9750985b27bc567791bc87c76a569b3feed8481ac", size = 219129, upload-time = "2026-02-17T16:11:32.021Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/ef/f1bea01e40b4a879364c031476c82a0dc69ce068daad67ab96302fed2d45/librt-0.8.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:9e2c6f77b9ad48ce5603b83b7da9ee3e36b3ab425353f695cba13200c5d96596", size = 213113, upload-time = "2026-02-17T16:11:33.192Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/80/cdab544370cc6bc1b72ea369525f547a59e6938ef6863a11ab3cd24759af/librt-0.8.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:439352ba9373f11cb8e1933da194dcc6206daf779ff8df0ed69c5e39113e6a99", size = 212269, upload-time = "2026-02-17T16:11:34.373Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9c/48d6ed8dac595654f15eceab2035131c136d1ae9a1e3548e777bb6dbb95d/librt-0.8.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:82210adabbc331dbb65d7868b105185464ef13f56f7f76688565ad79f648b0fe", size = 234673, upload-time = "2026-02-17T16:11:36.063Z" },
+    { url = "https://files.pythonhosted.org/packages/16/01/35b68b1db517f27a01be4467593292eb5315def8900afad29fabf56304ba/librt-0.8.1-cp311-cp311-win32.whl", hash = "sha256:52c224e14614b750c0a6d97368e16804a98c684657c7518752c356834fff83bb", size = 54597, upload-time = "2026-02-17T16:11:37.544Z" },
+    { url = "https://files.pythonhosted.org/packages/71/02/796fe8f02822235966693f257bf2c79f40e11337337a657a8cfebba5febc/librt-0.8.1-cp311-cp311-win_amd64.whl", hash = "sha256:c00e5c884f528c9932d278d5c9cbbea38a6b81eb62c02e06ae53751a83a4d52b", size = 61733, upload-time = "2026-02-17T16:11:38.691Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ad/232e13d61f879a42a4e7117d65e4984bb28371a34bb6fb9ca54ec2c8f54e/librt-0.8.1-cp311-cp311-win_arm64.whl", hash = "sha256:f7cdf7f26c2286ffb02e46d7bac56c94655540b26347673bea15fa52a6af17e9", size = 52273, upload-time = "2026-02-17T16:11:40.308Z" },
+    { url = "https://files.pythonhosted.org/packages/95/21/d39b0a87ac52fc98f621fb6f8060efb017a767ebbbac2f99fbcbc9ddc0d7/librt-0.8.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a28f2612ab566b17f3698b0da021ff9960610301607c9a5e8eaca62f5e1c350a", size = 66516, upload-time = "2026-02-17T16:11:41.604Z" },
+    { url = "https://files.pythonhosted.org/packages/69/f1/46375e71441c43e8ae335905e069f1c54febee63a146278bcee8782c84fd/librt-0.8.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:60a78b694c9aee2a0f1aaeaa7d101cf713e92e8423a941d2897f4fa37908dab9", size = 68634, upload-time = "2026-02-17T16:11:43.268Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/33/c510de7f93bf1fa19e13423a606d8189a02624a800710f6e6a0a0f0784b3/librt-0.8.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:758509ea3f1eba2a57558e7e98f4659d0ea7670bff49673b0dde18a3c7e6c0eb", size = 198941, upload-time = "2026-02-17T16:11:44.28Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/36/e725903416409a533d92398e88ce665476f275081d0d7d42f9c4951999e5/librt-0.8.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:039b9f2c506bd0ab0f8725aa5ba339c6f0cd19d3b514b50d134789809c24285d", size = 209991, upload-time = "2026-02-17T16:11:45.462Z" },
+    { url = "https://files.pythonhosted.org/packages/30/7a/8d908a152e1875c9f8eac96c97a480df425e657cdb47854b9efaa4998889/librt-0.8.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bb54f1205a3a6ab41a6fd71dfcdcbd278670d3a90ca502a30d9da583105b6f7", size = 224476, upload-time = "2026-02-17T16:11:46.542Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b8/a22c34f2c485b8903a06f3fe3315341fe6876ef3599792344669db98fcff/librt-0.8.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:05bd41cdee35b0c59c259f870f6da532a2c5ca57db95b5f23689fcb5c9e42440", size = 217518, upload-time = "2026-02-17T16:11:47.746Z" },
+    { url = "https://files.pythonhosted.org/packages/79/6f/5c6fea00357e4f82ba44f81dbfb027921f1ab10e320d4a64e1c408d035d9/librt-0.8.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:adfab487facf03f0d0857b8710cf82d0704a309d8ffc33b03d9302b4c64e91a9", size = 225116, upload-time = "2026-02-17T16:11:49.298Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a0/95ced4e7b1267fe1e2720a111685bcddf0e781f7e9e0ce59d751c44dcfe5/librt-0.8.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:153188fe98a72f206042be10a2c6026139852805215ed9539186312d50a8e972", size = 217751, upload-time = "2026-02-17T16:11:50.49Z" },
+    { url = "https://files.pythonhosted.org/packages/93/c2/0517281cb4d4101c27ab59472924e67f55e375bc46bedae94ac6dc6e1902/librt-0.8.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:dd3c41254ee98604b08bd5b3af5bf0a89740d4ee0711de95b65166bf44091921", size = 218378, upload-time = "2026-02-17T16:11:51.783Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e8/37b3ac108e8976888e559a7b227d0ceac03c384cfd3e7a1c2ee248dbae79/librt-0.8.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e0d138c7ae532908cbb342162b2611dbd4d90c941cd25ab82084aaf71d2c0bd0", size = 241199, upload-time = "2026-02-17T16:11:53.561Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/5b/35812d041c53967fedf551a39399271bbe4257e681236a2cf1a69c8e7fa1/librt-0.8.1-cp312-cp312-win32.whl", hash = "sha256:43353b943613c5d9c49a25aaffdba46f888ec354e71e3529a00cca3f04d66a7a", size = 54917, upload-time = "2026-02-17T16:11:54.758Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d1/fa5d5331b862b9775aaf2a100f5ef86854e5d4407f71bddf102f4421e034/librt-0.8.1-cp312-cp312-win_amd64.whl", hash = "sha256:ff8baf1f8d3f4b6b7257fcb75a501f2a5499d0dda57645baa09d4d0d34b19444", size = 62017, upload-time = "2026-02-17T16:11:55.748Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7c/c614252f9acda59b01a66e2ddfd243ed1c7e1deab0293332dfbccf862808/librt-0.8.1-cp312-cp312-win_arm64.whl", hash = "sha256:0f2ae3725904f7377e11cc37722d5d401e8b3d5851fb9273d7f4fe04f6b3d37d", size = 52441, upload-time = "2026-02-17T16:11:56.801Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/3c/f614c8e4eaac7cbf2bbdf9528790b21d89e277ee20d57dc6e559c626105f/librt-0.8.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7e6bad1cd94f6764e1e21950542f818a09316645337fd5ab9a7acc45d99a8f35", size = 66529, upload-time = "2026-02-17T16:11:57.809Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/96/5836544a45100ae411eda07d29e3d99448e5258b6e9c8059deb92945f5c2/librt-0.8.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cf450f498c30af55551ba4f66b9123b7185362ec8b625a773b3d39aa1a717583", size = 68669, upload-time = "2026-02-17T16:11:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/06/53/f0b992b57af6d5531bf4677d75c44f095f2366a1741fb695ee462ae04b05/librt-0.8.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:eca45e982fa074090057132e30585a7e8674e9e885d402eae85633e9f449ce6c", size = 199279, upload-time = "2026-02-17T16:11:59.862Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ad/4848cc16e268d14280d8168aee4f31cea92bbd2b79ce33d3e166f2b4e4fc/librt-0.8.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c3811485fccfda840861905b8c70bba5ec094e02825598bb9d4ca3936857a04", size = 210288, upload-time = "2026-02-17T16:12:00.954Z" },
+    { url = "https://files.pythonhosted.org/packages/52/05/27fdc2e95de26273d83b96742d8d3b7345f2ea2bdbd2405cc504644f2096/librt-0.8.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e4af413908f77294605e28cfd98063f54b2c790561383971d2f52d113d9c363", size = 224809, upload-time = "2026-02-17T16:12:02.108Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d0/78200a45ba3240cb042bc597d6f2accba9193a2c57d0356268cbbe2d0925/librt-0.8.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5212a5bd7fae98dae95710032902edcd2ec4dc994e883294f75c857b83f9aba0", size = 218075, upload-time = "2026-02-17T16:12:03.631Z" },
+    { url = "https://files.pythonhosted.org/packages/af/72/a210839fa74c90474897124c064ffca07f8d4b347b6574d309686aae7ca6/librt-0.8.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e692aa2d1d604e6ca12d35e51fdc36f4cda6345e28e36374579f7ef3611b3012", size = 225486, upload-time = "2026-02-17T16:12:04.725Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/c1/a03cc63722339ddbf087485f253493e2b013039f5b707e8e6016141130fa/librt-0.8.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4be2a5c926b9770c9e08e717f05737a269b9d0ebc5d2f0060f0fe3fe9ce47acb", size = 218219, upload-time = "2026-02-17T16:12:05.828Z" },
+    { url = "https://files.pythonhosted.org/packages/58/f5/fff6108af0acf941c6f274a946aea0e484bd10cd2dc37610287ce49388c5/librt-0.8.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:fd1a720332ea335ceb544cf0a03f81df92abd4bb887679fd1e460976b0e6214b", size = 218750, upload-time = "2026-02-17T16:12:07.09Z" },
+    { url = "https://files.pythonhosted.org/packages/71/67/5a387bfef30ec1e4b4f30562c8586566faf87e47d696768c19feb49e3646/librt-0.8.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:93c2af9e01e0ef80d95ae3c720be101227edae5f2fe7e3dc63d8857fadfc5a1d", size = 241624, upload-time = "2026-02-17T16:12:08.43Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/be/24f8502db11d405232ac1162eb98069ca49c3306c1d75c6ccc61d9af8789/librt-0.8.1-cp313-cp313-win32.whl", hash = "sha256:086a32dbb71336627e78cc1d6ee305a68d038ef7d4c39aaff41ae8c9aa46e91a", size = 54969, upload-time = "2026-02-17T16:12:09.633Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/73/c9fdf6cb2a529c1a092ce769a12d88c8cca991194dfe641b6af12fa964d2/librt-0.8.1-cp313-cp313-win_amd64.whl", hash = "sha256:e11769a1dbda4da7b00a76cfffa67aa47cfa66921d2724539eee4b9ede780b79", size = 62000, upload-time = "2026-02-17T16:12:10.632Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/97/68f80ca3ac4924f250cdfa6e20142a803e5e50fca96ef5148c52ee8c10ea/librt-0.8.1-cp313-cp313-win_arm64.whl", hash = "sha256:924817ab3141aca17893386ee13261f1d100d1ef410d70afe4389f2359fea4f0", size = 52495, upload-time = "2026-02-17T16:12:11.633Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/6a/907ef6800f7bca71b525a05f1839b21f708c09043b1c6aa77b6b827b3996/librt-0.8.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:6cfa7fe54fd4d1f47130017351a959fe5804bda7a0bc7e07a2cdbc3fdd28d34f", size = 66081, upload-time = "2026-02-17T16:12:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/18/25e991cd5640c9fb0f8d91b18797b29066b792f17bf8493da183bf5caabe/librt-0.8.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:228c2409c079f8c11fb2e5d7b277077f694cb93443eb760e00b3b83cb8b3176c", size = 68309, upload-time = "2026-02-17T16:12:13.756Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/36/46820d03f058cfb5a9de5940640ba03165ed8aded69e0733c417bb04df34/librt-0.8.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7aae78ab5e3206181780e56912d1b9bb9f90a7249ce12f0e8bf531d0462dd0fc", size = 196804, upload-time = "2026-02-17T16:12:14.818Z" },
+    { url = "https://files.pythonhosted.org/packages/59/18/5dd0d3b87b8ff9c061849fbdb347758d1f724b9a82241aa908e0ec54ccd0/librt-0.8.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:172d57ec04346b047ca6af181e1ea4858086c80bdf455f61994c4aa6fc3f866c", size = 206907, upload-time = "2026-02-17T16:12:16.513Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/96/ef04902aad1424fd7299b62d1890e803e6ab4018c3044dca5922319c4b97/librt-0.8.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6b1977c4ea97ce5eb7755a78fae68d87e4102e4aaf54985e8b56806849cc06a3", size = 221217, upload-time = "2026-02-17T16:12:17.906Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ff/7e01f2dda84a8f5d280637a2e5827210a8acca9a567a54507ef1c75b342d/librt-0.8.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10c42e1f6fd06733ef65ae7bebce2872bcafd8d6e6b0a08fe0a05a23b044fb14", size = 214622, upload-time = "2026-02-17T16:12:19.108Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/8c/5b093d08a13946034fed57619742f790faf77058558b14ca36a6e331161e/librt-0.8.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4c8dfa264b9193c4ee19113c985c95f876fae5e51f731494fc4e0cf594990ba7", size = 221987, upload-time = "2026-02-17T16:12:20.331Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/cc/86b0b3b151d40920ad45a94ce0171dec1aebba8a9d72bb3fa00c73ab25dd/librt-0.8.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:01170b6729a438f0dedc4a26ed342e3dc4f02d1000b4b19f980e1877f0c297e6", size = 215132, upload-time = "2026-02-17T16:12:21.54Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/be/8588164a46edf1e69858d952654e216a9a91174688eeefb9efbb38a9c799/librt-0.8.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:7b02679a0d783bdae30d443025b94465d8c3dc512f32f5b5031f93f57ac32071", size = 215195, upload-time = "2026-02-17T16:12:23.073Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/f2/0b9279bea735c734d69344ecfe056c1ba211694a72df10f568745c899c76/librt-0.8.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:190b109bb69592a3401fe1ffdea41a2e73370ace2ffdc4a0e8e2b39cdea81b78", size = 237946, upload-time = "2026-02-17T16:12:24.275Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/cc/5f2a34fbc8aeb35314a3641f9956fa9051a947424652fad9882be7a97949/librt-0.8.1-cp314-cp314-win32.whl", hash = "sha256:e70a57ecf89a0f64c24e37f38d3fe217a58169d2fe6ed6d70554964042474023", size = 50689, upload-time = "2026-02-17T16:12:25.766Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/76/cd4d010ab2147339ca2b93e959c3686e964edc6de66ddacc935c325883d7/librt-0.8.1-cp314-cp314-win_amd64.whl", hash = "sha256:7e2f3edca35664499fbb36e4770650c4bd4a08abc1f4458eab9df4ec56389730", size = 57875, upload-time = "2026-02-17T16:12:27.465Z" },
+    { url = "https://files.pythonhosted.org/packages/84/0f/2143cb3c3ca48bd3379dcd11817163ca50781927c4537345d608b5045998/librt-0.8.1-cp314-cp314-win_arm64.whl", hash = "sha256:0d2f82168e55ddefd27c01c654ce52379c0750ddc31ee86b4b266bcf4d65f2a3", size = 48058, upload-time = "2026-02-17T16:12:28.556Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/0e/9b23a87e37baf00311c3efe6b48d6b6c168c29902dfc3f04c338372fd7db/librt-0.8.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2c74a2da57a094bd48d03fa5d196da83d2815678385d2978657499063709abe1", size = 68313, upload-time = "2026-02-17T16:12:29.659Z" },
+    { url = "https://files.pythonhosted.org/packages/db/9a/859c41e5a4f1c84200a7d2b92f586aa27133c8243b6cac9926f6e54d01b9/librt-0.8.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a355d99c4c0d8e5b770313b8b247411ed40949ca44e33e46a4789b9293a907ee", size = 70994, upload-time = "2026-02-17T16:12:31.516Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/28/10605366ee599ed34223ac2bf66404c6fb59399f47108215d16d5ad751a8/librt-0.8.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:2eb345e8b33fb748227409c9f1233d4df354d6e54091f0e8fc53acdb2ffedeb7", size = 220770, upload-time = "2026-02-17T16:12:33.294Z" },
+    { url = "https://files.pythonhosted.org/packages/af/8d/16ed8fd452dafae9c48d17a6bc1ee3e818fd40ef718d149a8eff2c9f4ea2/librt-0.8.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9be2f15e53ce4e83cc08adc29b26fb5978db62ef2a366fbdf716c8a6c8901040", size = 235409, upload-time = "2026-02-17T16:12:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1b/7bdf3e49349c134b25db816e4a3db6b94a47ac69d7d46b1e682c2c4949be/librt-0.8.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:785ae29c1f5c6e7c2cde2c7c0e148147f4503da3abc5d44d482068da5322fd9e", size = 246473, upload-time = "2026-02-17T16:12:36.656Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/8a/91fab8e4fd2a24930a17188c7af5380eb27b203d72101c9cc000dbdfd95a/librt-0.8.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1d3a7da44baf692f0c6aeb5b2a09c5e6fc7a703bca9ffa337ddd2e2da53f7732", size = 238866, upload-time = "2026-02-17T16:12:37.849Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e0/c45a098843fc7c07e18a7f8a24ca8496aecbf7bdcd54980c6ca1aaa79a8e/librt-0.8.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5fc48998000cbc39ec0d5311312dda93ecf92b39aaf184c5e817d5d440b29624", size = 250248, upload-time = "2026-02-17T16:12:39.445Z" },
+    { url = "https://files.pythonhosted.org/packages/82/30/07627de23036640c952cce0c1fe78972e77d7d2f8fd54fa5ef4554ff4a56/librt-0.8.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e96baa6820280077a78244b2e06e416480ed859bbd8e5d641cf5742919d8beb4", size = 240629, upload-time = "2026-02-17T16:12:40.889Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c1/55bfe1ee3542eba055616f9098eaf6eddb966efb0ca0f44eaa4aba327307/librt-0.8.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:31362dbfe297b23590530007062c32c6f6176f6099646bb2c95ab1b00a57c382", size = 239615, upload-time = "2026-02-17T16:12:42.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/39/191d3d28abc26c9099b19852e6c99f7f6d400b82fa5a4e80291bd3803e19/librt-0.8.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cc3656283d11540ab0ea01978378e73e10002145117055e03722417aeab30994", size = 263001, upload-time = "2026-02-17T16:12:43.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/eb/7697f60fbe7042ab4e88f4ee6af496b7f222fffb0a4e3593ef1f29f81652/librt-0.8.1-cp314-cp314t-win32.whl", hash = "sha256:738f08021b3142c2918c03692608baed43bc51144c29e35807682f8070ee2a3a", size = 51328, upload-time = "2026-02-17T16:12:45.148Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/72/34bf2eb7a15414a23e5e70ecb9440c1d3179f393d9349338a91e2781c0fb/librt-0.8.1-cp314-cp314t-win_amd64.whl", hash = "sha256:89815a22daf9c51884fb5dbe4f1ef65ee6a146e0b6a8df05f753e2e4a9359bf4", size = 58722, upload-time = "2026-02-17T16:12:46.85Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c8/d148e041732d631fc76036f8b30fae4e77b027a1e95b7a84bb522481a940/librt-0.8.1-cp314-cp314t-win_arm64.whl", hash = "sha256:bf512a71a23504ed08103a13c941f763db13fb11177beb3d9244c98c29fb4a61", size = 48755, upload-time = "2026-02-17T16:12:47.943Z" },
+]
+
+[[package]]
 name = "markdown"
 version = "3.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1073,7 +1146,7 @@ wheels = [
 
 [[package]]
 name = "mkdocs-material"
-version = "9.6.21"
+version = "9.7.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
@@ -1088,9 +1161,9 @@ dependencies = [
     { name = "pymdown-extensions" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/d5/ab83ca9aa314954b0a9e8849780bdd01866a3cfcb15ffb7e3a61ca06ff0b/mkdocs_material-9.6.21.tar.gz", hash = "sha256:b01aa6d2731322438056f360f0e623d3faae981f8f2d8c68b1b973f4f2657870", size = 4043097, upload-time = "2025-09-30T19:11:27.517Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/4f/98681c2030375fe9b057dbfb9008b68f46c07dddf583f4df09bf8075e37f/mkdocs_material-9.6.21-py3-none-any.whl", hash = "sha256:aa6a5ab6fb4f6d381588ac51da8782a4d3757cb3d1b174f81a2ec126e1f22c92", size = 9203097, upload-time = "2025-09-30T19:11:24.063Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z" },
 ]
 
 [[package]]
@@ -1104,7 +1177,7 @@ wheels = [
 
 [[package]]
 name = "mkdocs-mermaid2-plugin"
-version = "1.2.2"
+version = "1.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -1114,14 +1187,14 @@ dependencies = [
     { name = "requests" },
     { name = "setuptools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3c/d4/efbabe9d04252b3007bc79b0d6db2206b40b74e20619cbed23c1e1d03b2a/mkdocs_mermaid2_plugin-1.2.2.tar.gz", hash = "sha256:20a44440d32cf5fd1811b3e261662adb3e1b98be272e6f6fb9a476f3e28fd507", size = 16209, upload-time = "2025-08-27T23:51:51.078Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/6d/308f443a558b6a97ce55782658174c0d07c414405cfc0a44d36ad37e36f9/mkdocs_mermaid2_plugin-1.2.3.tar.gz", hash = "sha256:fb6f901d53e5191e93db78f93f219cad926ccc4d51e176271ca5161b6cc5368c", size = 16220, upload-time = "2025-10-17T19:38:53.047Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/d5/15f6eeeb755e57a501fad6dcfb3fe406dea5f6a6347a77c3be114294f7bb/mkdocs_mermaid2_plugin-1.2.2-py3-none-any.whl", hash = "sha256:a003dddd6346ecc0ad530f48f577fe6f8b21ea23fbee09eabf0172bbc1f23df8", size = 17300, upload-time = "2025-08-27T23:51:49.988Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/4b/6fd6dd632019b7f522f1b1f794ab6115cd79890330986614be56fd18f0eb/mkdocs_mermaid2_plugin-1.2.3-py3-none-any.whl", hash = "sha256:33f60c582be623ed53829a96e19284fc7f1b74a1dbae78d4d2e47fe00c3e190d", size = 17299, upload-time = "2025-10-17T19:38:51.874Z" },
 ]
 
 [[package]]
 name = "mkdocstrings"
-version = "0.30.1"
+version = "1.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
@@ -1131,9 +1204,9 @@ dependencies = [
     { name = "mkdocs-autorefs" },
     { name = "pymdown-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/33/2fa3243439f794e685d3e694590d28469a9b8ea733af4b48c250a3ffc9a0/mkdocstrings-0.30.1.tar.gz", hash = "sha256:84a007aae9b707fb0aebfc9da23db4b26fc9ab562eb56e335e9ec480cb19744f", size = 106350, upload-time = "2025-09-19T10:49:26.446Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/62/0dfc5719514115bf1781f44b1d7f2a0923fcc01e9c5d7990e48a05c9ae5d/mkdocstrings-1.0.3.tar.gz", hash = "sha256:ab670f55040722b49bb45865b2e93b824450fb4aef638b00d7acb493a9020434", size = 100946, upload-time = "2026-02-07T14:31:40.973Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/2c/f0dc4e1ee7f618f5bff7e05898d20bf8b6e7fa612038f768bfa295f136a4/mkdocstrings-0.30.1-py3-none-any.whl", hash = "sha256:41bd71f284ca4d44a668816193e4025c950b002252081e387433656ae9a70a82", size = 36704, upload-time = "2025-09-19T10:49:24.805Z" },
+    { url = "https://files.pythonhosted.org/packages/04/41/1cf02e3df279d2dd846a1bf235a928254eba9006dd22b4a14caa71aed0f7/mkdocstrings-1.0.3-py3-none-any.whl", hash = "sha256:0d66d18430c2201dc7fe85134277382baaa15e6b30979f3f3bdbabd6dbdb6046", size = 35523, upload-time = "2026-02-07T14:31:39.27Z" },
 ]
 
 [package.optional-dependencies]
@@ -1300,40 +1373,52 @@ wheels = [
 
 [[package]]
 name = "mypy"
-version = "1.18.2"
+version = "1.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
     { name = "mypy-extensions" },
     { name = "pathspec" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/77/8f0d0001ffad290cef2f7f216f96c814866248a0b92a722365ed54648e7e/mypy-1.18.2.tar.gz", hash = "sha256:06a398102a5f203d7477b2923dda3634c36727fa5c237d8f859ef90c42a9924b", size = 3448846, upload-time = "2025-09-19T00:11:10.519Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/b0089fe7fef0a994ae5ee07029ced0526082c6cfaaa4c10d40a10e33b097/mypy-1.20.0.tar.gz", hash = "sha256:eb96c84efcc33f0b5e0e04beacf00129dd963b67226b01c00b9dfc8affb464c3", size = 3815028, upload-time = "2026-03-31T16:55:14.959Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/87/cafd3ae563f88f94eec33f35ff722d043e09832ea8530ef149ec1efbaf08/mypy-1.18.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:807d9315ab9d464125aa9fcf6d84fde6e1dc67da0b6f80e7405506b8ac72bc7f", size = 12731198, upload-time = "2025-09-19T00:09:44.857Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/e0/1e96c3d4266a06d4b0197ace5356d67d937d8358e2ee3ffac71faa843724/mypy-1.18.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:776bb00de1778caf4db739c6e83919c1d85a448f71979b6a0edd774ea8399341", size = 11817879, upload-time = "2025-09-19T00:09:47.131Z" },
-    { url = "https://files.pythonhosted.org/packages/72/ef/0c9ba89eb03453e76bdac5a78b08260a848c7bfc5d6603634774d9cd9525/mypy-1.18.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1379451880512ffce14505493bd9fe469e0697543717298242574882cf8cdb8d", size = 12427292, upload-time = "2025-09-19T00:10:22.472Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/52/ec4a061dd599eb8179d5411d99775bec2a20542505988f40fc2fee781068/mypy-1.18.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1331eb7fd110d60c24999893320967594ff84c38ac6d19e0a76c5fd809a84c86", size = 13163750, upload-time = "2025-09-19T00:09:51.472Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/5f/2cf2ceb3b36372d51568f2208c021870fe7834cf3186b653ac6446511839/mypy-1.18.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3ca30b50a51e7ba93b00422e486cbb124f1c56a535e20eff7b2d6ab72b3b2e37", size = 13351827, upload-time = "2025-09-19T00:09:58.311Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/7d/2697b930179e7277529eaaec1513f8de622818696857f689e4a5432e5e27/mypy-1.18.2-cp311-cp311-win_amd64.whl", hash = "sha256:664dc726e67fa54e14536f6e1224bcfce1d9e5ac02426d2326e2bb4e081d1ce8", size = 9757983, upload-time = "2025-09-19T00:10:09.071Z" },
-    { url = "https://files.pythonhosted.org/packages/07/06/dfdd2bc60c66611dd8335f463818514733bc763e4760dee289dcc33df709/mypy-1.18.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:33eca32dd124b29400c31d7cf784e795b050ace0e1f91b8dc035672725617e34", size = 12908273, upload-time = "2025-09-19T00:10:58.321Z" },
-    { url = "https://files.pythonhosted.org/packages/81/14/6a9de6d13a122d5608e1a04130724caf9170333ac5a924e10f670687d3eb/mypy-1.18.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a3c47adf30d65e89b2dcd2fa32f3aeb5e94ca970d2c15fcb25e297871c8e4764", size = 11920910, upload-time = "2025-09-19T00:10:20.043Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/a9/b29de53e42f18e8cc547e38daa9dfa132ffdc64f7250e353f5c8cdd44bee/mypy-1.18.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d6c838e831a062f5f29d11c9057c6009f60cb294fea33a98422688181fe2893", size = 12465585, upload-time = "2025-09-19T00:10:33.005Z" },
-    { url = "https://files.pythonhosted.org/packages/77/ae/6c3d2c7c61ff21f2bee938c917616c92ebf852f015fb55917fd6e2811db2/mypy-1.18.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01199871b6110a2ce984bde85acd481232d17413868c9807e95c1b0739a58914", size = 13348562, upload-time = "2025-09-19T00:10:11.51Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/31/aec68ab3b4aebdf8f36d191b0685d99faa899ab990753ca0fee60fb99511/mypy-1.18.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a2afc0fa0b0e91b4599ddfe0f91e2c26c2b5a5ab263737e998d6817874c5f7c8", size = 13533296, upload-time = "2025-09-19T00:10:06.568Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/83/abcb3ad9478fca3ebeb6a5358bb0b22c95ea42b43b7789c7fb1297ca44f4/mypy-1.18.2-cp312-cp312-win_amd64.whl", hash = "sha256:d8068d0afe682c7c4897c0f7ce84ea77f6de953262b12d07038f4d296d547074", size = 9828828, upload-time = "2025-09-19T00:10:28.203Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/04/7f462e6fbba87a72bc8097b93f6842499c428a6ff0c81dd46948d175afe8/mypy-1.18.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:07b8b0f580ca6d289e69209ec9d3911b4a26e5abfde32228a288eb79df129fcc", size = 12898728, upload-time = "2025-09-19T00:10:01.33Z" },
-    { url = "https://files.pythonhosted.org/packages/99/5b/61ed4efb64f1871b41fd0b82d29a64640f3516078f6c7905b68ab1ad8b13/mypy-1.18.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ed4482847168439651d3feee5833ccedbf6657e964572706a2adb1f7fa4dfe2e", size = 11910758, upload-time = "2025-09-19T00:10:42.607Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/46/d297d4b683cc89a6e4108c4250a6a6b717f5fa96e1a30a7944a6da44da35/mypy-1.18.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c3ad2afadd1e9fea5cf99a45a822346971ede8685cc581ed9cd4d42eaf940986", size = 12475342, upload-time = "2025-09-19T00:11:00.371Z" },
-    { url = "https://files.pythonhosted.org/packages/83/45/4798f4d00df13eae3bfdf726c9244bcb495ab5bd588c0eed93a2f2dd67f3/mypy-1.18.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a431a6f1ef14cf8c144c6b14793a23ec4eae3db28277c358136e79d7d062f62d", size = 13338709, upload-time = "2025-09-19T00:11:03.358Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/09/479f7358d9625172521a87a9271ddd2441e1dab16a09708f056e97007207/mypy-1.18.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7ab28cc197f1dd77a67e1c6f35cd1f8e8b73ed2217e4fc005f9e6a504e46e7ba", size = 13529806, upload-time = "2025-09-19T00:10:26.073Z" },
-    { url = "https://files.pythonhosted.org/packages/71/cf/ac0f2c7e9d0ea3c75cd99dff7aec1c9df4a1376537cb90e4c882267ee7e9/mypy-1.18.2-cp313-cp313-win_amd64.whl", hash = "sha256:0e2785a84b34a72ba55fb5daf079a1003a34c05b22238da94fcae2bbe46f3544", size = 9833262, upload-time = "2025-09-19T00:10:40.035Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/0c/7d5300883da16f0063ae53996358758b2a2df2a09c72a5061fa79a1f5006/mypy-1.18.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:62f0e1e988ad41c2a110edde6c398383a889d95b36b3e60bcf155f5164c4fdce", size = 12893775, upload-time = "2025-09-19T00:10:03.814Z" },
-    { url = "https://files.pythonhosted.org/packages/50/df/2cffbf25737bdb236f60c973edf62e3e7b4ee1c25b6878629e88e2cde967/mypy-1.18.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8795a039bab805ff0c1dfdb8cd3344642c2b99b8e439d057aba30850b8d3423d", size = 11936852, upload-time = "2025-09-19T00:10:51.631Z" },
-    { url = "https://files.pythonhosted.org/packages/be/50/34059de13dd269227fb4a03be1faee6e2a4b04a2051c82ac0a0b5a773c9a/mypy-1.18.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6ca1e64b24a700ab5ce10133f7ccd956a04715463d30498e64ea8715236f9c9c", size = 12480242, upload-time = "2025-09-19T00:11:07.955Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/11/040983fad5132d85914c874a2836252bbc57832065548885b5bb5b0d4359/mypy-1.18.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d924eef3795cc89fecf6bedc6ed32b33ac13e8321344f6ddbf8ee89f706c05cb", size = 13326683, upload-time = "2025-09-19T00:09:55.572Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/ba/89b2901dd77414dd7a8c8729985832a5735053be15b744c18e4586e506ef/mypy-1.18.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:20c02215a080e3a2be3aa50506c67242df1c151eaba0dcbc1e4e557922a26075", size = 13514749, upload-time = "2025-09-19T00:10:44.827Z" },
-    { url = "https://files.pythonhosted.org/packages/25/bc/cc98767cffd6b2928ba680f3e5bc969c4152bf7c2d83f92f5a504b92b0eb/mypy-1.18.2-cp314-cp314-win_amd64.whl", hash = "sha256:749b5f83198f1ca64345603118a6f01a4e99ad4bf9d103ddc5a3200cc4614adf", size = 9982959, upload-time = "2025-09-19T00:10:37.344Z" },
-    { url = "https://files.pythonhosted.org/packages/87/e3/be76d87158ebafa0309946c4a73831974d4d6ab4f4ef40c3b53a385a66fd/mypy-1.18.2-py3-none-any.whl", hash = "sha256:22a1748707dd62b58d2ae53562ffc4d7f8bcc727e8ac7cbc69c053ddc874d47e", size = 2352367, upload-time = "2025-09-19T00:10:15.489Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/1c/74cb1d9993236910286865679d1c616b136b2eae468493aa939431eda410/mypy-1.20.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4525e7010b1b38334516181c5b81e16180b8e149e6684cee5a727c78186b4e3b", size = 14343972, upload-time = "2026-03-31T16:49:04.887Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/0d/01399515eca280386e308cf57901e68d3a52af18691941b773b3380c1df8/mypy-1.20.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a17c5d0bdcca61ce24a35beb828a2d0d323d3fcf387d7512206888c900193367", size = 13225007, upload-time = "2026-03-31T16:50:08.151Z" },
+    { url = "https://files.pythonhosted.org/packages/56/ac/b4ba5094fb2d7fe9d2037cd8d18bbe02bcf68fd22ab9ff013f55e57ba095/mypy-1.20.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f75ff57defcd0f1d6e006d721ccdec6c88d4f6a7816eb92f1c4890d979d9ee62", size = 13663752, upload-time = "2026-03-31T16:49:26.064Z" },
+    { url = "https://files.pythonhosted.org/packages/db/a7/460678d3cf7da252d2288dad0c602294b6ec22a91932ec368cc11e44bb6e/mypy-1.20.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b503ab55a836136b619b5fc21c8803d810c5b87551af8600b72eecafb0059cb0", size = 14532265, upload-time = "2026-03-31T16:53:55.077Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/3e/051cca8166cf0438ae3ea80e0e7c030d7a8ab98dffc93f80a1aa3f23c1a2/mypy-1.20.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1973868d2adbb4584a3835780b27436f06d1dc606af5be09f187aaa25be1070f", size = 14768476, upload-time = "2026-03-31T16:50:34.587Z" },
+    { url = "https://files.pythonhosted.org/packages/be/66/8e02ec184f852ed5c4abb805583305db475930854e09964b55e107cdcbc4/mypy-1.20.0-cp311-cp311-win_amd64.whl", hash = "sha256:2fcedb16d456106e545b2bfd7ef9d24e70b38ec252d2a629823a4d07ebcdb69e", size = 10818226, upload-time = "2026-03-31T16:53:15.624Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4b/383ad1924b28f41e4879a74151e7a5451123330d45652da359f9183bcd45/mypy-1.20.0-cp311-cp311-win_arm64.whl", hash = "sha256:379edf079ce44ac8d2805bcf9b3dd7340d4f97aad3a5e0ebabbf9d125b84b442", size = 9750091, upload-time = "2026-03-31T16:54:12.162Z" },
+    { url = "https://files.pythonhosted.org/packages/be/dd/3afa29b58c2e57c79116ed55d700721c3c3b15955e2b6251dd165d377c0e/mypy-1.20.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:002b613ae19f4ac7d18b7e168ffe1cb9013b37c57f7411984abbd3b817b0a214", size = 14509525, upload-time = "2026-03-31T16:55:01.824Z" },
+    { url = "https://files.pythonhosted.org/packages/54/eb/227b516ab8cad9f2a13c5e7a98d28cd6aa75e9c83e82776ae6c1c4c046c7/mypy-1.20.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a9336b5e6712f4adaf5afc3203a99a40b379049104349d747eb3e5a3aa23ac2e", size = 13326469, upload-time = "2026-03-31T16:51:41.23Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d4/1ddb799860c1b5ac6117ec307b965f65deeb47044395ff01ab793248a591/mypy-1.20.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f13b3e41bce9d257eded794c0f12878af3129d80aacd8a3ee0dee51f3a978651", size = 13705953, upload-time = "2026-03-31T16:48:55.69Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b7/54a720f565a87b893182a2a393370289ae7149e4715859e10e1c05e49154/mypy-1.20.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9804c3ad27f78e54e58b32e7cb532d128b43dbfb9f3f9f06262b821a0f6bd3f5", size = 14710363, upload-time = "2026-03-31T16:53:26.948Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/2a/74810274848d061f8a8ea4ac23aaad43bd3d8c1882457999c2e568341c57/mypy-1.20.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:697f102c5c1d526bdd761a69f17c6070f9892eebcb94b1a5963d679288c09e78", size = 14947005, upload-time = "2026-03-31T16:50:17.591Z" },
+    { url = "https://files.pythonhosted.org/packages/77/91/21b8ba75f958bcda75690951ce6fa6b7138b03471618959529d74b8544e2/mypy-1.20.0-cp312-cp312-win_amd64.whl", hash = "sha256:0ecd63f75fdd30327e4ad8b5704bd6d91fc6c1b2e029f8ee14705e1207212489", size = 10880616, upload-time = "2026-03-31T16:52:19.986Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/15/3d8198ef97c1ca03aea010cce4f1d4f3bc5d9849e8c0140111ca2ead9fdd/mypy-1.20.0-cp312-cp312-win_arm64.whl", hash = "sha256:f194db59657c58593a3c47c6dfd7bad4ef4ac12dbc94d01b3a95521f78177e33", size = 9813091, upload-time = "2026-03-31T16:53:44.385Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a7/f64ea7bd592fa431cb597418b6dec4a47f7d0c36325fec7ac67bc8402b94/mypy-1.20.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b20c8b0fd5877abdf402e79a3af987053de07e6fb208c18df6659f708b535134", size = 14485344, upload-time = "2026-03-31T16:49:16.78Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/72/8927d84cfc90c6abea6e96663576e2e417589347eb538749a464c4c218a0/mypy-1.20.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:367e5c993ba34d5054d11937d0485ad6dfc60ba760fa326c01090fc256adf15c", size = 13327400, upload-time = "2026-03-31T16:53:08.02Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/4a/11ab99f9afa41aa350178d24a7d2da17043228ea10f6456523f64b5a6cf6/mypy-1.20.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f799d9db89fc00446f03281f84a221e50018fc40113a3ba9864b132895619ebe", size = 13706384, upload-time = "2026-03-31T16:52:28.577Z" },
+    { url = "https://files.pythonhosted.org/packages/42/79/694ca73979cfb3535ebfe78733844cd5aff2e63304f59bf90585110d975a/mypy-1.20.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:555658c611099455b2da507582ea20d2043dfdfe7f5ad0add472b1c6238b433f", size = 14700378, upload-time = "2026-03-31T16:48:45.527Z" },
+    { url = "https://files.pythonhosted.org/packages/84/24/a022ccab3a46e3d2cdf2e0e260648633640eb396c7e75d5a42818a8d3971/mypy-1.20.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:efe8d70949c3023698c3fca1e94527e7e790a361ab8116f90d11221421cd8726", size = 14932170, upload-time = "2026-03-31T16:49:36.038Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/9b/549228d88f574d04117e736f55958bd4908f980f9f5700a07aeb85df005b/mypy-1.20.0-cp313-cp313-win_amd64.whl", hash = "sha256:f49590891d2c2f8a9de15614e32e459a794bcba84693c2394291a2038bbaaa69", size = 10888526, upload-time = "2026-03-31T16:50:59.827Z" },
+    { url = "https://files.pythonhosted.org/packages/91/17/15095c0e54a8bc04d22d4ff06b2139d5f142c2e87520b4e39010c4862771/mypy-1.20.0-cp313-cp313-win_arm64.whl", hash = "sha256:76a70bf840495729be47510856b978f1b0ec7d08f257ca38c9d932720bf6b43e", size = 9816456, upload-time = "2026-03-31T16:49:59.537Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/0e/6ca4a84cbed9e62384bc0b2974c90395ece5ed672393e553996501625fc5/mypy-1.20.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0f42dfaab7ec1baff3b383ad7af562ab0de573c5f6edb44b2dab016082b89948", size = 14483331, upload-time = "2026-03-31T16:52:57.999Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/c5/5fe9d8a729dd9605064691816243ae6c49fde0bd28f6e5e17f6a24203c43/mypy-1.20.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:31b5dbb55293c1bd27c0fc813a0d2bb5ceef9d65ac5afa2e58f829dab7921fd5", size = 13342047, upload-time = "2026-03-31T16:54:21.555Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/33/e18bcfa338ca4e6b2771c85d4c5203e627d0c69d9de5c1a2cf2ba13320ba/mypy-1.20.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49d11c6f573a5a08f77fad13faff2139f6d0730ebed2cfa9b3d2702671dd7188", size = 13719585, upload-time = "2026-03-31T16:51:53.89Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8d/93491ff7b79419edc7eabf95cb3b3f7490e2e574b2855c7c7e7394ff933f/mypy-1.20.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d3243c406773185144527f83be0e0aefc7bf4601b0b2b956665608bf7c98a83", size = 14685075, upload-time = "2026-03-31T16:54:04.464Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9d/d924b38a4923f8d164bf2b4ec98bf13beaf6e10a5348b4b137eadae40a6e/mypy-1.20.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a79c1eba7ac4209f2d850f0edd0a2f8bba88cbfdfefe6fb76a19e9d4fe5e71a2", size = 14919141, upload-time = "2026-03-31T16:54:51.785Z" },
+    { url = "https://files.pythonhosted.org/packages/59/98/1da9977016678c0b99d43afe52ed00bb3c1a0c4c995d3e6acca1a6ebb9b4/mypy-1.20.0-cp314-cp314-win_amd64.whl", hash = "sha256:00e047c74d3ec6e71a2eb88e9ea551a2edb90c21f993aefa9e0d2a898e0bb732", size = 11050925, upload-time = "2026-03-31T16:51:30.758Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e3/ba0b7a3143e49a9c4f5967dde6ea4bf8e0b10ecbbcca69af84027160ee89/mypy-1.20.0-cp314-cp314-win_arm64.whl", hash = "sha256:931a7630bba591593dcf6e97224a21ff80fb357e7982628d25e3c618e7f598ef", size = 10001089, upload-time = "2026-03-31T16:49:43.632Z" },
+    { url = "https://files.pythonhosted.org/packages/12/28/e617e67b3be9d213cda7277913269c874eb26472489f95d09d89765ce2d8/mypy-1.20.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:26c8b52627b6552f47ff11adb4e1509605f094e29815323e487fc0053ebe93d1", size = 15534710, upload-time = "2026-03-31T16:52:12.506Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0c/3b5f2d3e45dc7169b811adce8451679d9430399d03b168f9b0489f43adaa/mypy-1.20.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:39362cdb4ba5f916e7976fccecaab1ba3a83e35f60fa68b64e9a70e221bb2436", size = 14393013, upload-time = "2026-03-31T16:54:41.186Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/49/edc8b0aa145cc09c1c74f7ce2858eead9329931dcbbb26e2ad40906daa4e/mypy-1.20.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34506397dbf40c15dc567635d18a21d33827e9ab29014fb83d292a8f4f8953b6", size = 15047240, upload-time = "2026-03-31T16:54:31.955Z" },
+    { url = "https://files.pythonhosted.org/packages/42/37/a946bb416e37a57fa752b3100fd5ede0e28df94f92366d1716555d47c454/mypy-1.20.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:555493c44a4f5a1b58d611a43333e71a9981c6dbe26270377b6f8174126a0526", size = 15858565, upload-time = "2026-03-31T16:53:36.997Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/99/7690b5b5b552db1bd4ff362e4c0eb3107b98d680835e65823fbe888c8b78/mypy-1.20.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2721f0ce49cb74a38f00c50da67cb7d36317b5eda38877a49614dc018e91c787", size = 16087874, upload-time = "2026-03-31T16:52:48.313Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/76/53e893a498138066acd28192b77495c9357e5a58cc4be753182846b43315/mypy-1.20.0-cp314-cp314t-win_amd64.whl", hash = "sha256:47781555a7aa5fedcc2d16bcd72e0dc83eb272c10dd657f9fb3f9cc08e2e6abb", size = 12572380, upload-time = "2026-03-31T16:49:52.454Z" },
+    { url = "https://files.pythonhosted.org/packages/76/9c/6dbdae21f01b7aacddc2c0bbf3c5557aa547827fdf271770fe1e521e7093/mypy-1.20.0-cp314-cp314t-win_arm64.whl", hash = "sha256:c70380fe5d64010f79fb863b9081c7004dd65225d2277333c219d93a10dad4dd", size = 10381174, upload-time = "2026-03-31T16:51:20.179Z" },
+    { url = "https://files.pythonhosted.org/packages/21/66/4d734961ce167f0fd8380769b3b7c06dbdd6ff54c2190f3f2ecd22528158/mypy-1.20.0-py3-none-any.whl", hash = "sha256:a6e0641147cbfa7e4e94efdb95c2dab1aff8cfc159ded13e07f308ddccc8c48e", size = 2636365, upload-time = "2026-03-31T16:51:44.911Z" },
 ]
 
 [[package]]
@@ -1378,11 +1463,11 @@ wheels = [
 
 [[package]]
 name = "pathspec"
-version = "0.12.1"
+version = "1.0.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
 ]
 
 [[package]]
@@ -1654,7 +1739,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1663,36 +1748,36 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]
 name = "pytest-asyncio"
-version = "1.2.0"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/86/9e3c5f48f7b7b638b216e4b9e645f54d199d7abbbab7a64a13b4e12ba10f/pytest_asyncio-1.2.0.tar.gz", hash = "sha256:c609a64a2a8768462d0c99811ddb8bd2583c33fd33cf7f21af1c142e824ffb57", size = 50119, upload-time = "2025-09-12T07:33:53.816Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/93/2fa34714b7a4ae72f2f8dad66ba17dd9a2c793220719e736dda28b7aec27/pytest_asyncio-1.2.0-py3-none-any.whl", hash = "sha256:8e17ae5e46d8e7efe51ab6494dd2010f4ca8dae51652aa3c8d55acf50bfb2e99", size = 15095, upload-time = "2025-09-12T07:33:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]
 name = "pytest-cov"
-version = "7.0.0"
+version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coverage", extra = ["toml"] },
     { name = "pluggy" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]
@@ -1814,28 +1899,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.14.0"
+version = "0.15.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/41/b9/9bd84453ed6dd04688de9b3f3a4146a1698e8faae2ceeccce4e14c67ae17/ruff-0.14.0.tar.gz", hash = "sha256:62ec8969b7510f77945df916de15da55311fade8d6050995ff7f680afe582c57", size = 5452071, upload-time = "2025-10-07T18:21:55.763Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/b0/73cf7550861e2b4824950b8b52eebdcc5adc792a00c514406556c5b80817/ruff-0.15.8.tar.gz", hash = "sha256:995f11f63597ee362130d1d5a327a87cb6f3f5eae3094c620bcc632329a4d26e", size = 4610921, upload-time = "2026-03-26T18:39:38.675Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/4e/79d463a5f80654e93fa653ebfb98e0becc3f0e7cf6219c9ddedf1e197072/ruff-0.14.0-py3-none-linux_armv6l.whl", hash = "sha256:58e15bffa7054299becf4bab8a1187062c6f8cafbe9f6e39e0d5aface455d6b3", size = 12494532, upload-time = "2025-10-07T18:21:00.373Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/40/e2392f445ed8e02aa6105d49db4bfff01957379064c30f4811c3bf38aece/ruff-0.14.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:838d1b065f4df676b7c9957992f2304e41ead7a50a568185efd404297d5701e8", size = 13160768, upload-time = "2025-10-07T18:21:04.73Z" },
-    { url = "https://files.pythonhosted.org/packages/75/da/2a656ea7c6b9bd14c7209918268dd40e1e6cea65f4bb9880eaaa43b055cd/ruff-0.14.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:703799d059ba50f745605b04638fa7e9682cc3da084b2092feee63500ff3d9b8", size = 12363376, upload-time = "2025-10-07T18:21:07.833Z" },
-    { url = "https://files.pythonhosted.org/packages/42/e2/1ffef5a1875add82416ff388fcb7ea8b22a53be67a638487937aea81af27/ruff-0.14.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3ba9a8925e90f861502f7d974cc60e18ca29c72bb0ee8bfeabb6ade35a3abde7", size = 12608055, upload-time = "2025-10-07T18:21:10.72Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/32/986725199d7cee510d9f1dfdf95bf1efc5fa9dd714d0d85c1fb1f6be3bc3/ruff-0.14.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e41f785498bd200ffc276eb9e1570c019c1d907b07cfb081092c8ad51975bbe7", size = 12318544, upload-time = "2025-10-07T18:21:13.741Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/ed/4969cefd53315164c94eaf4da7cfba1f267dc275b0abdd593d11c90829a3/ruff-0.14.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30a58c087aef4584c193aebf2700f0fbcfc1e77b89c7385e3139956fa90434e2", size = 14001280, upload-time = "2025-10-07T18:21:16.411Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/ad/96c1fc9f8854c37681c9613d825925c7f24ca1acfc62a4eb3896b50bacd2/ruff-0.14.0-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:f8d07350bc7af0a5ce8812b7d5c1a7293cf02476752f23fdfc500d24b79b783c", size = 15027286, upload-time = "2025-10-07T18:21:19.577Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/00/1426978f97df4fe331074baf69615f579dc4e7c37bb4c6f57c2aad80c87f/ruff-0.14.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:eec3bbbf3a7d5482b5c1f42d5fc972774d71d107d447919fca620b0be3e3b75e", size = 14451506, upload-time = "2025-10-07T18:21:22.779Z" },
-    { url = "https://files.pythonhosted.org/packages/58/d5/9c1cea6e493c0cf0647674cca26b579ea9d2a213b74b5c195fbeb9678e15/ruff-0.14.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:16b68e183a0e28e5c176d51004aaa40559e8f90065a10a559176713fcf435206", size = 13437384, upload-time = "2025-10-07T18:21:25.758Z" },
-    { url = "https://files.pythonhosted.org/packages/29/b4/4cd6a4331e999fc05d9d77729c95503f99eae3ba1160469f2b64866964e3/ruff-0.14.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb732d17db2e945cfcbbc52af0143eda1da36ca8ae25083dd4f66f1542fdf82e", size = 13447976, upload-time = "2025-10-07T18:21:28.83Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/c0/ac42f546d07e4f49f62332576cb845d45c67cf5610d1851254e341d563b6/ruff-0.14.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:c958f66ab884b7873e72df38dcabee03d556a8f2ee1b8538ee1c2bbd619883dd", size = 13682850, upload-time = "2025-10-07T18:21:31.842Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/c4/4b0c9bcadd45b4c29fe1af9c5d1dc0ca87b4021665dfbe1c4688d407aa20/ruff-0.14.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7eb0499a2e01f6e0c285afc5bac43ab380cbfc17cd43a2e1dd10ec97d6f2c42d", size = 12449825, upload-time = "2025-10-07T18:21:35.074Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/a8/e2e76288e6c16540fa820d148d83e55f15e994d852485f221b9524514730/ruff-0.14.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:4c63b2d99fafa05efca0ab198fd48fa6030d57e4423df3f18e03aa62518c565f", size = 12272599, upload-time = "2025-10-07T18:21:38.08Z" },
-    { url = "https://files.pythonhosted.org/packages/18/14/e2815d8eff847391af632b22422b8207704222ff575dec8d044f9ab779b2/ruff-0.14.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:668fce701b7a222f3f5327f86909db2bbe99c30877c8001ff934c5413812ac02", size = 13193828, upload-time = "2025-10-07T18:21:41.216Z" },
-    { url = "https://files.pythonhosted.org/packages/44/c6/61ccc2987cf0aecc588ff8f3212dea64840770e60d78f5606cd7dc34de32/ruff-0.14.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a86bf575e05cb68dcb34e4c7dfe1064d44d3f0c04bbc0491949092192b515296", size = 13628617, upload-time = "2025-10-07T18:21:44.04Z" },
-    { url = "https://files.pythonhosted.org/packages/73/e6/03b882225a1b0627e75339b420883dc3c90707a8917d2284abef7a58d317/ruff-0.14.0-py3-none-win32.whl", hash = "sha256:7450a243d7125d1c032cb4b93d9625dea46c8c42b4f06c6b709baac168e10543", size = 12367872, upload-time = "2025-10-07T18:21:46.67Z" },
-    { url = "https://files.pythonhosted.org/packages/41/77/56cf9cf01ea0bfcc662de72540812e5ba8e9563f33ef3d37ab2174892c47/ruff-0.14.0-py3-none-win_amd64.whl", hash = "sha256:ea95da28cd874c4d9c922b39381cbd69cb7e7b49c21b8152b014bd4f52acddc2", size = 13464628, upload-time = "2025-10-07T18:21:50.318Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/2a/65880dfd0e13f7f13a775998f34703674a4554906167dce02daf7865b954/ruff-0.14.0-py3-none-win_arm64.whl", hash = "sha256:f42c9495f5c13ff841b1da4cb3c2a42075409592825dada7c5885c2c844ac730", size = 12565142, upload-time = "2025-10-07T18:21:53.577Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/92/c445b0cd6da6e7ae51e954939cb69f97e008dbe750cfca89b8cedc081be7/ruff-0.15.8-py3-none-linux_armv6l.whl", hash = "sha256:cbe05adeba76d58162762d6b239c9056f1a15a55bd4b346cfd21e26cd6ad7bc7", size = 10527394, upload-time = "2026-03-26T18:39:41.566Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/92/f1c662784d149ad1414cae450b082cf736430c12ca78367f20f5ed569d65/ruff-0.15.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:d3e3d0b6ba8dca1b7ef9ab80a28e840a20070c4b62e56d675c24f366ef330570", size = 10905693, upload-time = "2026-03-26T18:39:30.364Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f2/7a631a8af6d88bcef997eb1bf87cc3da158294c57044aafd3e17030613de/ruff-0.15.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6ee3ae5c65a42f273f126686353f2e08ff29927b7b7e203b711514370d500de3", size = 10323044, upload-time = "2026-03-26T18:39:33.37Z" },
+    { url = "https://files.pythonhosted.org/packages/67/18/1bf38e20914a05e72ef3b9569b1d5c70a7ef26cd188d69e9ca8ef588d5bf/ruff-0.15.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fdce027ada77baa448077ccc6ebb2fa9c3c62fd110d8659d601cf2f475858d94", size = 10629135, upload-time = "2026-03-26T18:39:44.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/e9/138c150ff9af60556121623d41aba18b7b57d95ac032e177b6a53789d279/ruff-0.15.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12e617fc01a95e5821648a6df341d80456bd627bfab8a829f7cfc26a14a4b4a3", size = 10348041, upload-time = "2026-03-26T18:39:52.178Z" },
+    { url = "https://files.pythonhosted.org/packages/02/f1/5bfb9298d9c323f842c5ddeb85f1f10ef51516ac7a34ba446c9347d898df/ruff-0.15.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:432701303b26416d22ba696c39f2c6f12499b89093b61360abc34bcc9bf07762", size = 11121987, upload-time = "2026-03-26T18:39:55.195Z" },
+    { url = "https://files.pythonhosted.org/packages/10/11/6da2e538704e753c04e8d86b1fc55712fdbdcc266af1a1ece7a51fff0d10/ruff-0.15.8-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d910ae974b7a06a33a057cb87d2a10792a3b2b3b35e33d2699fdf63ec8f6b17a", size = 11951057, upload-time = "2026-03-26T18:39:19.18Z" },
+    { url = "https://files.pythonhosted.org/packages/83/f0/c9208c5fd5101bf87002fed774ff25a96eea313d305f1e5d5744698dc314/ruff-0.15.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2033f963c43949d51e6fdccd3946633c6b37c484f5f98c3035f49c27395a8ab8", size = 11464613, upload-time = "2026-03-26T18:40:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/22/d7f2fabdba4fae9f3b570e5605d5eb4500dcb7b770d3217dca4428484b17/ruff-0.15.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f29b989a55572fb885b77464cf24af05500806ab4edf9a0fd8977f9759d85b1", size = 11257557, upload-time = "2026-03-26T18:39:57.972Z" },
+    { url = "https://files.pythonhosted.org/packages/71/8c/382a9620038cf6906446b23ce8632ab8c0811b8f9d3e764f58bedd0c9a6f/ruff-0.15.8-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:ac51d486bf457cdc985a412fb1801b2dfd1bd8838372fc55de64b1510eff4bec", size = 11169440, upload-time = "2026-03-26T18:39:22.205Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/0d/0994c802a7eaaf99380085e4e40c845f8e32a562e20a38ec06174b52ef24/ruff-0.15.8-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c9861eb959edab053c10ad62c278835ee69ca527b6dcd72b47d5c1e5648964f6", size = 10605963, upload-time = "2026-03-26T18:39:46.682Z" },
+    { url = "https://files.pythonhosted.org/packages/19/aa/d624b86f5b0aad7cef6bbf9cd47a6a02dfdc4f72c92a337d724e39c9d14b/ruff-0.15.8-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8d9a5b8ea13f26ae90838afc33f91b547e61b794865374f114f349e9036835fb", size = 10357484, upload-time = "2026-03-26T18:39:49.176Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c3/e0b7835d23001f7d999f3895c6b569927c4d39912286897f625736e1fd04/ruff-0.15.8-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c2a33a529fb3cbc23a7124b5c6ff121e4d6228029cba374777bd7649cc8598b8", size = 10830426, upload-time = "2026-03-26T18:40:03.702Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/51/ab20b322f637b369383adc341d761eaaa0f0203d6b9a7421cd6e783d81b9/ruff-0.15.8-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:75e5cd06b1cf3f47a3996cfc999226b19aa92e7cce682dcd62f80d7035f98f49", size = 11345125, upload-time = "2026-03-26T18:39:27.799Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e6/90b2b33419f59d0f2c4c8a48a4b74b460709a557e8e0064cf33ad894f983/ruff-0.15.8-py3-none-win32.whl", hash = "sha256:bc1f0a51254ba21767bfa9a8b5013ca8149dcf38092e6a9eb704d876de94dc34", size = 10571959, upload-time = "2026-03-26T18:39:36.117Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/a2/ef467cb77099062317154c63f234b8a7baf7cb690b99af760c5b68b9ee7f/ruff-0.15.8-py3-none-win_amd64.whl", hash = "sha256:04f79eff02a72db209d47d665ba7ebcad609d8918a134f86cb13dd132159fc89", size = 11743893, upload-time = "2026-03-26T18:39:25.01Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e2/77be4fff062fa78d9b2a4dea85d14785dac5f1d0c1fb58ed52331f0ebe28/ruff-0.15.8-py3-none-win_arm64.whl", hash = "sha256:cf891fa8e3bb430c0e7fac93851a5978fc99c8fa2c053b57b118972866f8e5f2", size = 11048175, upload-time = "2026-03-26T18:40:01.06Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request addresses problems in TaskGraphBuilder API which surfaced when I was trying to use the TaskGraphBuilder to build a more complex DAG and was not able to.

Part of the problem was that the `TaskGraphBuilder` had methods for adding tasks which _implicitly_ linked the newly added tasks the "last added" task. This was not obvious and hard to work around. So this PR tries to fix this and also make it way more obvious and intuitive to use. 

I had to battle the type-checker a bit too (which I switcehd to `ty`)

**Goals**

- Make the TaskGraphBuilder a lot easier and less confusing to use: the `depends_on=None` vs `depends_on=[]` was totally confusing adn broken as implemented (could not add later tasks _without_ a parent).
- Make the `on_failure` stuff more readily available and remove confusing after-the-fact method which allows attaching a failure task.
- COMPOSABILITY
- Surface a sentinel value `LAST_ADDED` which makes adding a task that points to the last added task a lot more obvious.
- Also Refactored `TaskGraphBuilder` methods (`add`, `parallel`, `then`, `add_chain`) to accept flexible dependency specifications (`Task`, `TaskId`, `TaskChain`), and improved internal dependency resolution logic for greater safety and clarity. 

**Type System and Task Handler Improvements:**

* Centralized the `TaskHandler` type alias in a new `boilermaker.task.types` module, enforcing that handlers are awaitable callables with a `__name__` attribute. This improves type safety and error messages for users.
* Updated imports and function signatures throughout the codebase to use the new `TaskHandler` type, ensuring consistency and clarity.

**Documentation Updates:**

* Expanded the API reference documentation to include `TaskChain` and the new dependency resolution features, providing clear usage guidance and examples for users. 

**Minor Cleanups:**

* Removed unused imports and outdated methods, and improved error messages for invalid graph construction. 

**Open questions**

I left hte existing `Boilermaker.chain` method alone here. But I think in the future it should be adapted to use TaskChain also somehow. It's confusing having two different chain things in here. This suggests that `on_success` and `on_failure` may need to be adapted too? I don't want to tear this library apart too much at this point in my efforts here to fix the DAGs. 

- Goal: fix DAGs. 
- Future improvement(s): unify `chain` concept.