### PR TITLE
TaskGraph: Rework to make sure that started result is safely written to blob storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ site/
 todo*.md
 tmp/
 .bmo/
+.claude/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
     "editor.defaultFormatter": "charliermarsh.ruff",
     "editor.formatOnSaveMode": "modifications",
     "editor.formatOnSave": true
-  }
+  },
+  "tlaplus.tlc.modelChecker.options": "-workers 1 -coverage 1"
 }

--- a/boilermaker/app.py
+++ b/boilermaker/app.py
@@ -322,9 +322,7 @@ class Boilermaker:
             await app.apply_async(cleanup_temp_files, delay=300)
         """
         task = self.create_task(fn, *args, policy=policy, **kwargs)
-        return await self.publish_task(
-            task, delay=delay, publish_attempts=publish_attempts
-        )
+        return await self.publish_task(task, delay=delay, publish_attempts=publish_attempts)
 
     @tracer.start_as_current_span("boilermaker.publish-task")
     async def publish_task(
@@ -366,9 +364,7 @@ class Boilermaker:
                 if results and len(results) == 1:
                     sequence_number = results[0]
                     task.mark_published(sequence_number)
-                    logger.debug(
-                        f"Published task {task.task_id} to queue with sequence_number={sequence_number}"
-                    )
+                    logger.debug(f"Published task {task.task_id} to queue with sequence_number={sequence_number}")
                 return task
 
             except (
@@ -407,6 +403,13 @@ class Boilermaker:
                     [f"Expected graph_id={graph.graph_id}, found {task.graph_id=}"],
                 )
 
+        for task in graph.fail_children.values():
+            if task.graph_id != graph.graph_id:
+                raise BoilermakerAppException(
+                    "All failure callback tasks must have graph_id matching graph",
+                    [f"Expected graph_id={graph.graph_id}, found {task.graph_id=}"],
+                )
+
         # Store the graph definition and all pending task results
         # If this graph has already been stored, this should fail.
         try:
@@ -414,8 +417,34 @@ class Boilermaker:
         except BoilermakerStorageError as exc:
             raise BoilermakerAppException("Error storing TaskGraph to storage", [str(exc)]) from exc
 
-        # Publish all ready tasks (should be root nodes with no dependencies)
-        for task in graph.generate_ready_tasks():
+        # Reload to get ETags on pending result blobs (required for ETag-guarded Scheduled writes)
+        try:
+            loaded_graph = await self.results_storage.load_graph(graph.graph_id)
+        except BoilermakerStorageError as exc:
+            raise BoilermakerAppException("Error loading TaskGraph after storage", [str(exc)]) from exc
+
+        if not loaded_graph:
+            raise BoilermakerAppException("TaskGraph not found after storing — this should not happen", [])
+
+        # Publish root tasks with ETag-guarded Scheduled write (same protocol as continue_graph)
+        for task in loaded_graph.generate_ready_tasks():
+            try:
+                result = loaded_graph.schedule_task(task.task_id)
+                await self.results_storage.store_task_result(result, etag=result.etag)
+            except BoilermakerStorageError:
+                logger.error(
+                    f"Failed to write Scheduled status for root task {task.task_id} in graph "
+                    f"{graph.graph_id}. Not publishing to avoid inconsistent state.",
+                    exc_info=True,
+                )
+                continue
+            except ValueError:
+                logger.error(
+                    f"schedule_task raised ValueError for root task {task.task_id} in graph "
+                    f"{graph.graph_id}. Skipping.",
+                    exc_info=True,
+                )
+                continue
             await self.publish_task(task)
 
         return graph

--- a/boilermaker/evaluators/common.py
+++ b/boilermaker/evaluators/common.py
@@ -50,9 +50,7 @@ class MessageActions:
     """
 
     @classmethod
-    async def task_decoder(
-        cls, msg: ServiceBusReceivedMessage, receiver: ServiceBusReceiver
-    ) -> Task | None:
+    async def task_decoder(cls, msg: ServiceBusReceivedMessage, receiver: ServiceBusReceiver) -> Task | None:
         """Decode a ServiceBusReceivedMessage into a Task."""
         try:
             task = Task.model_validate_json(str(msg))
@@ -60,10 +58,7 @@ class MessageActions:
             return task
         except (JSONDecodeError, ValidationError):
             # This task is not parseable
-            log_err_msg = (
-                f"Invalid task sequence_number={msg.sequence_number} "
-                f"exc_info={traceback.format_exc()}"
-            )
+            log_err_msg = f"Invalid task sequence_number={msg.sequence_number} exc_info={traceback.format_exc()}"
             logger.error(log_err_msg)
             await receiver.dead_letter_message(
                 msg,
@@ -73,17 +68,13 @@ class MessageActions:
             return None
 
     @staticmethod
-    async def abandon_message(
-        msg: ServiceBusReceivedMessage, receiver: ServiceBusReceiver
-    ) -> None:
+    async def abandon_message(msg: ServiceBusReceivedMessage, receiver: ServiceBusReceiver) -> None:
         """Abandon the message being processed."""
         if msg is not None:
             sequence_number = msg.sequence_number
             try:
                 await receiver.abandon_message(msg)
-                logger.warning(
-                    f"Abandoning message: returned to queue {sequence_number=}"
-                )
+                logger.warning(f"Abandoning message: returned to queue {sequence_number=}")
             except (
                 MessageAlreadySettled,
                 MessageLockLostError,
@@ -93,18 +84,13 @@ class MessageActions:
                 logger.error(err_msg)
                 raise exc.BoilermakerTaskLeaseLost(err_msg) from None
             except ServiceBusError as sb_exc:
-                err_msg = (
-                    f"ServiceBusError requeuing message {sequence_number=} "
-                    f"exc_info={traceback.format_exc()}"
-                )
+                err_msg = f"ServiceBusError requeuing message {sequence_number=} exc_info={traceback.format_exc()}"
                 logger.error(err_msg)
                 raise exc.BoilermakerServiceBusError(err_msg) from sb_exc
         return None
 
     @staticmethod
-    async def complete_message(
-        msg: ServiceBusReceivedMessage, receiver: ServiceBusReceiver
-    ):
+    async def complete_message(msg: ServiceBusReceivedMessage, receiver: ServiceBusReceiver):
         """Complete the current message being processed."""
         try:
             await receiver.complete_message(msg)
@@ -113,10 +99,7 @@ class MessageActions:
             MessageLockLostError,
             SessionLockLostError,
         ):
-            logmsg = (
-                f"Failed to settle message sequence_number={msg.sequence_number} "
-                f"exc_info={traceback.format_exc()}"
-            )
+            logmsg = f"Failed to settle message sequence_number={msg.sequence_number} exc_info={traceback.format_exc()}"
             logger.error(logmsg)
             raise exc.BoilermakerTaskLeaseLost(msg) from None
         except ServiceBusError as sb_exc:
@@ -148,8 +131,7 @@ class MessageActions:
             SessionLockLostError,
         ):
             logmsg = (
-                f"Failed to deadletter message sequence_number={msg.sequence_number} "
-                f"exc_info={traceback.format_exc()}"
+                f"Failed to deadletter message sequence_number={msg.sequence_number} exc_info={traceback.format_exc()}"
             )
             logger.error(logmsg)
             raise exc.BoilermakerTaskLeaseLost(logmsg) from None
@@ -178,8 +160,7 @@ class MessageActions:
             return await receiver.renew_message_lock(msg)
         except (MessageLockLostError, MessageAlreadySettled, SessionLockLostError):
             logmsg = (
-                f"Failed to renew message lock sequence_number={msg.sequence_number} "
-                f"exc_info={traceback.format_exc()}"
+                f"Failed to renew message lock sequence_number={msg.sequence_number} exc_info={traceback.format_exc()}"
             )
             logger.error(logmsg)
             raise exc.BoilermakerTaskLeaseLost(logmsg) from None
@@ -201,9 +182,7 @@ class MessageActions:
     ):
         """Deadletter or complete the current task based on its configuration."""
         if task.msg is None:
-            logger.warning(
-                "No current message to settle for deadletter_or_complete_task"
-            )
+            logger.warning("No current message to settle for deadletter_or_complete_task")
             return None
 
         if task.should_dead_letter:
@@ -270,22 +249,16 @@ class TaskEvaluatorBase:
     # Message handling actions
     async def abandon_current_message(self) -> None:
         if self.current_msg is not None:
-            return await MessageActions.abandon_message(
-                self.current_msg, self._receiver
-            )
+            return await MessageActions.abandon_message(self.current_msg, self._receiver)
 
     async def complete_message(self) -> None:
         if self.current_msg is not None:
-            return await MessageActions.complete_message(
-                self.current_msg, self._receiver
-            )
+            return await MessageActions.complete_message(self.current_msg, self._receiver)
 
     async def renew_message_lock(self) -> datetime.datetime | None:
         """Renew the lock on the current message being processed."""
         if self.current_msg is not None:
-            return await MessageActions.renew_message_lock(
-                self.current_msg, self._receiver
-            )
+            return await MessageActions.renew_message_lock(self.current_msg, self._receiver)
         return None
 
     async def deadletter_or_complete_task(
@@ -293,9 +266,7 @@ class TaskEvaluatorBase:
         reason: str,
         detail: Exception | str | None = None,
     ) -> None:
-        return await MessageActions.deadletter_or_complete_task(
-            self.task, self._receiver, reason, detail=detail
-        )
+        return await MessageActions.deadletter_or_complete_task(self.task, self._receiver, reason, detail=detail)
 
     async def __call__(self) -> TaskResult | None:
         """Call pre-processing hook and then `message_handler`."""
@@ -304,9 +275,7 @@ class TaskEvaluatorBase:
             if not await self.pre_process():
                 return None
         except exc.BoilermakerUnregisteredFunction:
-            await self.deadletter_or_complete_task(
-                "ExpectationFailed", detail="Pre-processing expectation failed"
-            )
+            await self.deadletter_or_complete_task("ExpectationFailed", detail="Pre-processing expectation failed")
             return TaskResult(
                 task_id=self.task.task_id,
                 graph_id=self.task.graph_id,
@@ -316,9 +285,7 @@ class TaskEvaluatorBase:
             )
         except Exception:
             logger.error("Exception in pre_process", exc_info=True)
-            await self.deadletter_or_complete_task(
-                "ProcessingError", detail="Pre-processing exception"
-            )
+            await self.deadletter_or_complete_task("ProcessingError", detail="Pre-processing exception")
             return TaskResult(
                 task_id=self.task.task_id,
                 graph_id=self.task.graph_id,
@@ -349,7 +316,5 @@ class TaskEvaluatorBase:
             return False
 
         if not self.function_registry.get(self.task.function_name):
-            raise exc.BoilermakerUnregisteredFunction(
-                f"Missing registered function {self.task.function_name}"
-            )
+            raise exc.BoilermakerUnregisteredFunction(f"Missing registered function {self.task.function_name}")
         return True

--- a/boilermaker/evaluators/eval.py
+++ b/boilermaker/evaluators/eval.py
@@ -44,9 +44,7 @@ async def eval_task(
     logger.info(f"[{task.function_name}] Begin Task {task.sequence_number=}")
 
     if function is None:
-        raise BoilermakerUnregisteredFunction(
-            f"Function {task.function_name} not found in registry"
-        )
+        raise BoilermakerUnregisteredFunction(f"Function {task.function_name} not found in registry")
 
     try:
         result = await function(
@@ -77,8 +75,7 @@ async def eval_task(
                 status=TaskStatus.Success,
             )
             logger.info(
-                f"[{task.function_name}] Completed Task {task.sequence_number=} "
-                f"in {time.monotonic() - start:.3f}s"
+                f"[{task.function_name}] Completed Task {task.sequence_number=} in {time.monotonic() - start:.3f}s"
             )
     except RetryException as retry:
         # A retry has been requested:

--- a/boilermaker/evaluators/results_store.py
+++ b/boilermaker/evaluators/results_store.py
@@ -62,9 +62,7 @@ class ResultsStorageTaskEvaluator(TaskEvaluatorBase):
                 await self.complete_message()
                 message_settled = True
             except exc.BoilermakerTaskLeaseLost:
-                logger.error(
-                    f"Lost message lease when trying to complete early for task {self.task.function_name}"
-                )
+                logger.error(f"Lost message lease when trying to complete early for task {self.task.function_name}")
                 return TaskResult(
                     task_id=self.task.task_id,
                     graph_id=self.task.graph_id,
@@ -89,8 +87,7 @@ class ResultsStorageTaskEvaluator(TaskEvaluatorBase):
                     message_settled = True
                 except exc.BoilermakerTaskLeaseLost:
                     logger.error(
-                        f"Lost message lease when trying to deadletter/complete "
-                        f" for task {self.task.function_name}"
+                        f"Lost message lease when trying to deadletter/complete  for task {self.task.function_name}"
                     )
                     return TaskResult(
                         task_id=self.task.task_id,

--- a/boilermaker/evaluators/simple.py
+++ b/boilermaker/evaluators/simple.py
@@ -45,9 +45,7 @@ class NoStorageEvaluator(TaskEvaluatorBase):
                 await self.complete_message()
                 message_settled = True
             except exc.BoilermakerTaskLeaseLost:
-                logger.error(
-                    f"Lost message lease when trying to complete early for task {self.task.function_name}"
-                )
+                logger.error(f"Lost message lease when trying to complete early for task {self.task.function_name}")
                 return TaskResult(
                     task_id=self.task.task_id,
                     graph_id=self.task.graph_id,
@@ -71,8 +69,7 @@ class NoStorageEvaluator(TaskEvaluatorBase):
                     message_settled = True
                 except exc.BoilermakerTaskLeaseLost:
                     logger.error(
-                        f"Lost message lease when trying to deadletter/complete "
-                        f" for task {self.task.function_name}"
+                        f"Lost message lease when trying to deadletter/complete  for task {self.task.function_name}"
                     )
                     return TaskResult(
                         task_id=self.task.task_id,

--- a/boilermaker/evaluators/task_graph.py
+++ b/boilermaker/evaluators/task_graph.py
@@ -45,6 +45,14 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
         if storage_interface is None:
             raise ValueError("Storage interface is required for TaskGraphEvaluator")
 
+        if task.acks_early:
+            logger.warning(
+                f"Task {task.task_id} ({task.function_name}) uses acks_early=True in a "
+                "TaskGraph context. If the worker crashes after message settlement but before "
+                "the task result is written, this task will be permanently stuck in Started "
+                "status with no recovery path. Use acks_late=True (the default) for graph tasks."
+            )
+
         super().__init__(
             receiver,
             task,
@@ -60,6 +68,51 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
     async def message_handler(self) -> TaskResult:
         """Individual message handler"""
         message_settled = False
+
+        # Idempotent redelivery guard — if this task already reached a terminal state
+        # (e.g. a prior execution succeeded before the SB lock expired and redelivered), skip
+        # re-execution entirely.  Writing Started on top of Success/Failure would regress the
+        # blob status and corrupt graph state.
+        if self.task.graph_id:
+            try:
+                _existing = await self.storage_interface.load_task_result(self.task.task_id, self.task.graph_id)
+            except exc.BoilermakerStorageError:
+                # Transient read failure — proceed normally; do NOT skip execution on a read
+                # error, as that would permanently stall the graph.
+                logger.warning(
+                    f"Failed to read current status for task {self.task.task_id} before "
+                    "writing Started; proceeding with execution",
+                    exc_info=True,
+                )
+                _existing = None
+
+            if _existing is not None and _existing.status.finished:
+                logger.info(
+                    f"Task {self.task.task_id} already in terminal state {_existing.status!r} "
+                    "(SB redelivery); skipping re-execution"
+                )
+                _terminal_result = TaskResult(
+                    task_id=self.task.task_id,
+                    graph_id=self.task.graph_id,
+                    status=_existing.status,
+                )
+                try:
+                    await self.continue_graph(_terminal_result)
+                except exc.ContinueGraphError:
+                    logger.error(
+                        f"continue_graph failed on redelivery for task {self.task.task_id}; "
+                        "suppressing settlement to allow redelivery",
+                        exc_info=True,
+                    )
+                    return _terminal_result
+                try:
+                    await self.complete_message()
+                except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
+                    logger.warning(
+                        f"Failed to complete message on redelivery for task {self.task.task_id}; SB will redeliver",
+                        exc_info=True,
+                    )
+                return _terminal_result
 
         start_result = TaskResult(
             task_id=self.task.task_id,
@@ -78,9 +131,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 await self.complete_message()
                 message_settled = True
             except exc.BoilermakerTaskLeaseLost:
-                logger.error(
-                    f"Lost message lease when trying to complete early for task {self.task.function_name}"
-                )
+                logger.error(f"Lost message lease when trying to complete early for task {self.task.function_name}")
                 return TaskResult(
                     task_id=self.task.task_id,
                     graph_id=self.task.graph_id,
@@ -104,8 +155,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                     message_settled = True
                 except exc.BoilermakerTaskLeaseLost:
                     logger.error(
-                        f"Lost message lease when trying to deadletter/complete "
-                        f" for task {self.task.function_name}"
+                        f"Lost message lease when trying to deadletter/complete  for task {self.task.function_name}"
                     )
                     return TaskResult(
                         task_id=self.task.task_id,
@@ -266,8 +316,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                         exc_info=True,
                     )
                     raise exc.ContinueGraphError(
-                        f"load_graph failed for graph {graph_id} after "
-                        f"{_LOAD_GRAPH_RETRY_POLICY.max_tries} attempts"
+                        f"load_graph failed for graph {graph_id} after {_LOAD_GRAPH_RETRY_POLICY.max_tries} attempts"
                     ) from last_exc
         else:
             # Should only be reached if max_tries == 0 (not expected).
@@ -289,9 +338,12 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
             logger.error(
                 f"Task status mismatch in continue_graph for graph {graph_id}: "
                 f"expected {completed_task_result.task_id} to be {completed_task_result.status}, "
-                f"but got {loaded_task_status}"
+                f"but got {loaded_task_status}. Suppressing settlement to allow redelivery."
             )
-            return None
+            raise exc.ContinueGraphError(
+                f"Status mismatch for task {completed_task_result.task_id} in graph {graph_id}: "
+                f"expected {completed_task_result.status}, got {loaded_task_status}"
+            )
 
         # Snapshot tasks already in Scheduled status BEFORE the first pass.
         # The second pass uses this snapshot so that tasks freshly scheduled
@@ -322,14 +374,19 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 )
                 continue
 
-            ready_count += 1
-            await self.publish_task(ready_task)
-            logger.info(f"Publishing ready task {ready_task.task_id} in graph {graph_id} total={ready_count}")
+            try:
+                await self.publish_task(ready_task)
+                ready_count += 1
+                logger.info(f"Publishing ready task {ready_task.task_id} in graph {graph_id} total={ready_count}")
+            except Exception:
+                logger.error(
+                    f"Failed to publish ready task {ready_task.task_id} in graph {graph_id}; "
+                    "task is in Scheduled status in blob and will be recovered by crash-recovery pass on redelivery.",
+                    exc_info=True,
+                )
 
         if ready_count == 0:
-            logger.info(
-                f"No new tasks ready in graph {graph_id} after task {completed_task_result.task_id}"
-            )
+            logger.info(f"No new tasks ready in graph {graph_id} after task {completed_task_result.task_id}")
 
         # Second pass: re-publish tasks that were ALREADY in Scheduled status when the
         # graph was loaded (crash-recovery).

--- a/boilermaker/exc.py
+++ b/boilermaker/exc.py
@@ -33,9 +33,7 @@ class BoilermakerStorageError(Exception):
     def __getattr__(self, item):
         if self.details.get(item, None):
             return self.details[item]
-        raise AttributeError(
-            f"BoilermakerStorageError object has no attribute '{item}'"
-        )
+        raise AttributeError(f"BoilermakerStorageError object has no attribute '{item}'")
 
 
 class BoilermakerUnregisteredFunction(ValueError):

--- a/boilermaker/retries.py
+++ b/boilermaker/retries.py
@@ -138,7 +138,7 @@ class RetryPolicy(BaseModel):
             case RetryMode.Fixed:
                 return min(self.delay, self.delay_max)
             case RetryMode.Linear:
-                return min(self.delay * attempts_so_far, self.delay_max)
+                return min(self.delay * (attempts_so_far + 1), self.delay_max)
             case RetryMode.Exponential:
                 # Jitter is added so that a lot of work doesn't get bunched up at the
                 # end and eventually hurt throughput.

--- a/boilermaker/storage/base.py
+++ b/boilermaker/storage/base.py
@@ -1,7 +1,7 @@
 import logging
 from abc import ABC, abstractmethod
 
-from boilermaker.task import GraphId, TaskGraph, TaskResult, TaskResultSlim
+from boilermaker.task import GraphId, TaskGraph, TaskId, TaskResult, TaskResultSlim
 
 logger = logging.getLogger(__name__)
 
@@ -38,5 +38,24 @@ class StorageInterface(ABC):
 
         Args:
             task_result: The TaskResult instance to storage.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def load_task_result(self, task_id: TaskId, graph_id: GraphId) -> TaskResultSlim | None:
+        """Load a single task result from storage.
+
+        Used by the idempotent redelivery guard in TaskGraphEvaluator to check whether
+        a task has already reached a terminal state before writing Started on redelivery.
+
+        Args:
+            task_id: The TaskId of the task result to load.
+            graph_id: The GraphId the task belongs to.
+
+        Returns:
+            The TaskResultSlim instance, or None if not found.
+
+        Raises:
+            BoilermakerStorageError: If the result cannot be loaded for reasons other than not found.
         """
         raise NotImplementedError

--- a/boilermaker/storage/blob_storage.py
+++ b/boilermaker/storage/blob_storage.py
@@ -16,7 +16,7 @@ from pydantic import ValidationError
 
 from boilermaker.exc import BoilermakerStorageError
 from boilermaker.storage import StorageInterface
-from boilermaker.task import GraphId, TaskGraph, TaskResult, TaskResultSlim
+from boilermaker.task import GraphId, TaskGraph, TaskId, TaskResult, TaskResultSlim
 
 logger = logging.getLogger(__name__)
 
@@ -160,6 +160,40 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
                 if lease is not None:
                     await lease.release()
         return graph
+
+    async def load_task_result(self, task_id: TaskId, graph_id: GraphId) -> TaskResultSlim | None:
+        """Load a single task result from Azure Blob Storage.
+
+        Returns None if the blob does not exist (404). Raises BoilermakerStorageError
+        for any other failure. Used by the idempotent redelivery guard in
+        TaskGraphEvaluator to check terminal status before writing Started.
+
+        Args:
+            task_id: The TaskId of the task result to load.
+            graph_id: The GraphId the task belongs to.
+        """
+        fname = f"{self.task_result_prefix}/{graph_id}/{task_id}.json"
+        try:
+            contents = await self.download_blob(fname)
+        except AzureBlobError as exc:
+            if exc.status_code == 404:
+                return None
+            raise BoilermakerStorageError(
+                f"Failed to load task result {task_id}",
+                task_id=task_id,
+                graph_id=graph_id,
+                status_code=exc.status_code,
+                reason=exc.reason,
+            ) from exc
+        if contents is None:
+            return None
+        try:
+            return TaskResultSlim.model_validate_json(contents)
+        except ValidationError as e:
+            raise BoilermakerStorageError(
+                f"Failed to deserialize task result {task_id}: {e}",
+                status_code=None,
+            ) from e
 
     async def store_task_result(self, task_result: TaskResult | TaskResultSlim, etag: str | None = None) -> None:
         """Stores a TaskResult to Azure Blob Storage.

--- a/boilermaker/storage/blob_storage.py
+++ b/boilermaker/storage/blob_storage.py
@@ -16,7 +16,7 @@ from pydantic import ValidationError
 
 from boilermaker.exc import BoilermakerStorageError
 from boilermaker.storage import StorageInterface
-from boilermaker.task import GraphId, TaskGraph, TaskId, TaskResult, TaskResultSlim, task_id
+from boilermaker.task import GraphId, TaskGraph, TaskId, TaskResult, TaskResultSlim
 
 logger = logging.getLogger(__name__)
 
@@ -176,7 +176,12 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
             graph_id: The GraphId the task belongs to.
         """
         fname = f"{self.task_result_prefix}/{graph_id}/{task_id}.json"
+        blob_etag = None
         try:
+            # We need to make sure we load the etag
+            async with self.get_blob_client(fname) as blob_client:
+                blob_properties = await blob_client.get_blob_properties()
+                blob_etag = blob_properties.etag if blob_properties and blob_properties.etag is not None else None
             contents = await self.download_blob(fname)
         except AzureBlobError as exc:
             if exc.status_code == 404:
@@ -191,7 +196,9 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
         if contents is None:
             return None
         try:
-            return TaskResultSlim.model_validate_json(contents)
+            result = TaskResultSlim.model_validate_json(contents)
+            result.etag = blob_etag
+            return result
         except ValidationError as e:
             raise BoilermakerStorageError(
                 f"Failed to deserialize task result {task_id}: {e}",

--- a/boilermaker/storage/blob_storage.py
+++ b/boilermaker/storage/blob_storage.py
@@ -16,7 +16,7 @@ from pydantic import ValidationError
 
 from boilermaker.exc import BoilermakerStorageError
 from boilermaker.storage import StorageInterface
-from boilermaker.task import GraphId, TaskGraph, TaskId, TaskResult, TaskResultSlim
+from boilermaker.task import GraphId, TaskGraph, TaskId, TaskResult, TaskResultSlim, task_id
 
 logger = logging.getLogger(__name__)
 
@@ -89,7 +89,10 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
             except ValidationError as e:
                 raise BoilermakerStorageError(
                     f"Failed to deserialize task result in graph {graph_id}: {e}",
+                    name=blob.name,
+                    graph_id=graph_id,
                     status_code=None,
+                    reason="DeserializationError",
                 ) from e
             tr.etag = blob.etag
             if tr.graph_id == graph_id:
@@ -192,7 +195,10 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
         except ValidationError as e:
             raise BoilermakerStorageError(
                 f"Failed to deserialize task result {task_id}: {e}",
+                task_id=task_id,
+                graph_id=graph_id,
                 status_code=None,
+                reason="DeserializationError",
             ) from e
 
     async def store_task_result(self, task_result: TaskResult | TaskResultSlim, etag: str | None = None) -> None:

--- a/boilermaker/task/graph.py
+++ b/boilermaker/task/graph.py
@@ -1,4 +1,5 @@
 import itertools
+import logging
 import typing
 from collections import defaultdict
 from collections.abc import Generator
@@ -9,6 +10,8 @@ from pydantic import BaseModel, ConfigDict, Field
 from .result import TaskResult, TaskResultSlim, TaskStatus
 from .task import Task
 from .task_id import GraphId, ident_field, TaskId
+
+logger = logging.getLogger("boilermaker.app")
 
 
 class TaskGraph(BaseModel):
@@ -171,7 +174,9 @@ class TaskGraph(BaseModel):
                     if not self.edges[parent_id]:  # Remove empty set
                         del self.edges[parent_id]
                 del self.children[task.task_id]
-                raise ValueError(f"Adding task {task.task_id} with parent {parent_id} would create a cycle in the DAG")
+                raise ValueError(
+                    f"Adding task {task.task_id} with parents {parent_ids} would create a cycle in the DAG"
+                )
 
         # If we leave `on_success` and `on_failure` it's potentially confusing for both callers
         # and our own evaluation. It also has the potential to create cycles inadvertently, so we
@@ -294,12 +299,14 @@ class TaskGraph(BaseModel):
     def generate_ready_tasks(self) -> Generator[Task]:
         """Get a list of tasks that are ready to be executed (not started and all antecedents succeeded)."""
         for task_id in self.children.keys():
-            # Task is ready if:
-            # 1. It has no result yet (never started) OR it has Pending status
-            # 2. All its antecedents have succeeded
             task_result = self.results.get(task_id)
-            is_not_started = task_result is None or task_result.status == TaskStatus.Pending
-            if is_not_started and self.task_is_ready(task_id):
+            if task_result is None:
+                logger.warning(
+                    f"Task {task_id} has no result blob in graph {self.graph_id}; "
+                    "skipping. This may indicate a partial store_graph failure."
+                )
+                continue
+            if task_result.status == TaskStatus.Pending and self.task_is_ready(task_id):
                 yield self.children[task_id]
 
     def generate_failure_ready_tasks(self) -> Generator[Task]:

--- a/boilermaker/task/result.py
+++ b/boilermaker/task/result.py
@@ -19,7 +19,6 @@ class TaskStatus(enum.StrEnum):
     RetriesExhausted = "retries_exhausted"
     Deadlettered = "deadlettered"
 
-
     @classmethod
     def default(cls) -> "TaskStatus":
         """Get the default task status.

--- a/boilermaker/tracing.py
+++ b/boilermaker/tracing.py
@@ -44,9 +44,7 @@ async def start_span_from_parent_event_async(
     """
     if otel_enabled:
         tracectx = extract(get_traceparent_context(event))
-        with tracer.start_as_current_span(
-            name, context=tracectx, kind=trace.SpanKind.CONSUMER
-        ) as current_span:
+        with tracer.start_as_current_span(name, context=tracectx, kind=trace.SpanKind.CONSUMER) as current_span:
             yield current_span
     else:
         yield None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boilermaker-servicebus"
-version = "1.0.0-dev4"
+version = "1.0.0-dev5"
 description = "An async python Background task system using Azure Service Bus Queues"
 authors = [{ "name" = "Erik Aker", "email" = "eaker@mulliganfunding.com" }]
 license = { file = "LICENSE" }
@@ -26,17 +26,17 @@ Issues = "https://github.com/MulliganFunding/boilermaker-servicebus/issues"
 
 [dependency-groups]
 dev = [
-    "build>=1.4.2",
-    "pytest>=9.0.2",
+    "build>=1.4.3",
+    "pytest>=9.0.3",
     "pytest-asyncio>=1.3.0",
     "pytest-cov>=7.1.0",
-    "ruff>=0.15.8",
+    "ruff>=0.15.10",
     # Documentation dependencies
     "mkdocs>=1.5.0",
     "mkdocs-material>=9.7.6",
     "mkdocstrings[python]>=1.0.3",
     "mkdocs-mermaid2-plugin>=1.2.3",
-    "ty>=0.0.27",
+    "ty>=0.0.29",
 ]
 
 [project.optional-dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,4 +83,8 @@ def mock_storage():
     storage.store_task_result = mock.AsyncMock()
     storage.load_graph = mock.AsyncMock(return_value=None)
     storage.store_graph = mock.AsyncMock()
+    # Default to None so the idempotent redelivery guard in TaskGraphEvaluator
+    # treats every task as not-yet-terminal and proceeds with normal execution.
+    # Individual tests override this to exercise the redelivery path.
+    storage.load_task_result = mock.AsyncMock(return_value=None)
     return storage

--- a/tests/evaluators/test_common.py
+++ b/tests/evaluators/test_common.py
@@ -86,9 +86,7 @@ async def test_task_decoder_invalid_json(mockservicebus):
 
 
 # Tests moved from test_base.py that test MessageHandler functionality
-async def test_message_handler_complete_message_integration(
-    mockservicebus, dummy_task, no_storage_evaluator
-):
+async def test_message_handler_complete_message_integration(mockservicebus, dummy_task, no_storage_evaluator):
     """Test that MessageHandler complete_message works through NoStorageEvaluator interface."""
 
     await no_storage_evaluator.complete_message()
@@ -122,9 +120,7 @@ async def test_message_handler_complete_message_with_error_integration(
     mockservicebus._receiver.complete_message.assert_called_once_with(dummy_task.msg)
 
 
-async def test_message_handler_renew_message_lock_integration(
-    mockservicebus, dummy_task, state, no_storage_evaluator
-):
+async def test_message_handler_renew_message_lock_integration(mockservicebus, dummy_task, state, no_storage_evaluator):
     """Test that MessageHandler renew_message_lock works through NoStorageEvaluator interface."""
 
     expected_time = Mock()
@@ -161,9 +157,7 @@ async def test_message_handler_renew_message_lock_errors_integration(
     mockservicebus._receiver.renew_message_lock.assert_called_once_with(dummy_task.msg)
 
 
-async def test_message_handler_renew_message_lock_missing_integration(
-    mockservicebus, dummy_task, no_storage_evaluator
-):
+async def test_message_handler_renew_message_lock_missing_integration(mockservicebus, dummy_task, no_storage_evaluator):
     """
     Test that MessageHandler renew_message_lock handles
     missing receiver/message through NoStorageEvaluator.
@@ -305,9 +299,7 @@ async def test_renew_message_lock_none_message(mockservicebus):
 
 async def test_dead_letter_message_success(mockservicebus, dummy_msg):
     """Test that dead_letter_message successfully deadletters a message."""
-    await MessageActions.dead_letter_message(
-        dummy_msg, mockservicebus._receiver, "TestReason", "Test description"
-    )
+    await MessageActions.dead_letter_message(dummy_msg, mockservicebus._receiver, "TestReason", "Test description")
 
     mockservicebus._receiver.dead_letter_message.assert_called_once_with(
         dummy_msg,
@@ -450,9 +442,7 @@ async def test_message_handler_call_with_pre_process_exception(message_handler, 
     )
 
 
-async def test_message_handler_current_msg_property(
-    message_handler, dummy_task, make_message
-):
+async def test_message_handler_current_msg_property(message_handler, dummy_task, make_message):
     """Test MessageHandler current_msg property."""
     # Set a message on the task
     msg = make_message(dummy_task)
@@ -465,9 +455,7 @@ async def test_message_handler_current_msg_property(
     assert message_handler.current_msg is msg
 
 
-async def test_message_handler_sequence_number_property(
-    message_handler, dummy_task, make_message
-):
+async def test_message_handler_sequence_number_property(message_handler, dummy_task, make_message):
     """Test MessageHandler sequence_number property."""
     # Set sequence number on task
     msg = make_message(dummy_task, sequence_number=123)
@@ -585,9 +573,7 @@ async def test_message_handler_pre_process_debug_task_service_bus_error(message_
     sample.debug_task = AsyncMock()
 
     # Mock complete_message to raise service bus error
-    mockservicebus._receiver.complete_message.side_effect = exc.BoilermakerServiceBusError(
-        "service bus error"
-    )
+    mockservicebus._receiver.complete_message.side_effect = exc.BoilermakerServiceBusError("service bus error")
 
     try:
         assert await message_handler.pre_process() is False

--- a/tests/evaluators/test_eval.py
+++ b/tests/evaluators/test_eval.py
@@ -23,9 +23,7 @@ async def raiseretry(state, x):
 
 
 async def raiseretry_custom_policy(state, x):
-    raise RetryExceptionDefaultExponential(
-        "Intentional retry for testing", max_tries=99, delay_max=1000
-    )
+    raise RetryExceptionDefaultExponential("Intentional retry for testing", max_tries=99, delay_max=1000)
 
 
 REGISTRY = {
@@ -130,4 +128,3 @@ async def test_task_handler_retry_custom_policy(retry_custom_policy_task):
     assert result.task_id == retry_custom_policy_task.task_id
     assert result.graph_id is None
     assert retry_custom_policy_task.policy.max_tries == 99
-

--- a/tests/evaluators/test_simple.py
+++ b/tests/evaluators/test_simple.py
@@ -17,9 +17,7 @@ def evaluator(app, mockservicebus, make_message):
     task.payload["args"] = (21,)
     task.msg = make_message(task)
 
-    return NoStorageEvaluator(
-        mockservicebus._receiver, task, app.publish_task, app.function_registry, state=app.state
-    )
+    return NoStorageEvaluator(mockservicebus._receiver, task, app.publish_task, app.function_registry, state=app.state)
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -61,9 +59,7 @@ async def test_task_handler_debug_task(evaluator):
 # # # # # # # # # # # # # # # # # # # # # # # # # # #
 @pytest.mark.parametrize("acks_late", [True, False])
 @pytest.mark.parametrize("has_on_success", [True, False])
-async def test_task_success(
-    has_on_success, acks_late, app, mockservicebus, evaluator, make_message
-):
+async def test_task_success(has_on_success, acks_late, app, mockservicebus, evaluator, make_message):
     """Test successful task execution and optional on_success callback."""
 
     async def oktask(state):
@@ -282,9 +278,7 @@ async def test_task_retries_with_onfail(
 # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # test task retries with new retry policy
 # # # # # # # # # # # # # # # # # # # # # # # # # # #
-async def test_task_retries_with_new_policy(
-    app, mockservicebus, evaluator, make_message
-):
+async def test_task_retries_with_new_policy(app, mockservicebus, evaluator, make_message):
     """Test retry logic with a new policy from RetryExceptionDefaultExponential."""
 
     async def retrytask(state):
@@ -514,9 +508,7 @@ async def test_early_ack_service_bus_error_exception(app, make_message, evaluato
     evaluator.complete_message.assert_called_once()
 
 
-async def test_retries_exhausted_task_lease_lost_exception(
-    app, make_message, evaluator
-):
+async def test_retries_exhausted_task_lease_lost_exception(app, make_message, evaluator):
     """Test BoilermakerTaskLeaseLost exception when settling message for exhausted retries."""
 
     async def oktask(state):
@@ -539,14 +531,10 @@ async def test_retries_exhausted_task_lease_lost_exception(
     assert "Lost message lease" in result.errors[0]
 
     # Should return None when lease is lost during exhausted retries settlement
-    evaluator.deadletter_or_complete_task.assert_called_once_with(
-        "ProcessingError", detail="Retries exhausted"
-    )
+    evaluator.deadletter_or_complete_task.assert_called_once_with("ProcessingError", detail="Retries exhausted")
 
 
-async def test_retries_exhausted_service_bus_error_exception(
-    app, make_message, evaluator
-):
+async def test_retries_exhausted_service_bus_error_exception(app, make_message, evaluator):
     """Test BoilermakerServiceBusError exception when settling message for exhausted retries."""
 
     async def oktask(state):
@@ -561,9 +549,7 @@ async def test_retries_exhausted_service_bus_error_exception(
     evaluator.task = task
 
     # Mock deadletter_or_complete_task to raise BoilermakerServiceBusError
-    evaluator.deadletter_or_complete_task = AsyncMock(
-        side_effect=exc.BoilermakerServiceBusError("Service bus error")
-    )
+    evaluator.deadletter_or_complete_task = AsyncMock(side_effect=exc.BoilermakerServiceBusError("Service bus error"))
 
     result = await evaluator.message_handler()
 
@@ -571,14 +557,10 @@ async def test_retries_exhausted_service_bus_error_exception(
     assert isinstance(result, TaskResult)
     assert result.status == TaskStatus.Failure
     assert "ServiceBus error" in result.errors[0]
-    evaluator.deadletter_or_complete_task.assert_called_once_with(
-        "ProcessingError", detail="Retries exhausted"
-    )
+    evaluator.deadletter_or_complete_task.assert_called_once_with("ProcessingError", detail="Retries exhausted")
 
 
-async def test_late_settlement_task_lease_lost_exception_success(
-    app, make_message, evaluator
-):
+async def test_late_settlement_task_lease_lost_exception_success(app, make_message, evaluator):
     """Test BoilermakerTaskLeaseLost exception during late message settlement for successful task."""
 
     async def oktask(state):
@@ -602,9 +584,7 @@ async def test_late_settlement_task_lease_lost_exception_success(
     evaluator.complete_message.assert_called_once()
 
 
-async def test_late_settlement_task_lease_lost_exception_failure(
-    app, make_message, evaluator
-):
+async def test_late_settlement_task_lease_lost_exception_failure(app, make_message, evaluator):
     """Test BoilermakerTaskLeaseLost exception during late message settlement for failed task."""
 
     async def failtask(state):
@@ -627,9 +607,7 @@ async def test_late_settlement_task_lease_lost_exception_failure(
     evaluator.deadletter_or_complete_task.assert_called_once_with("TaskFailed")
 
 
-async def test_late_settlement_service_bus_error_exception_success(
-    app, make_message, evaluator
-):
+async def test_late_settlement_service_bus_error_exception_success(app, make_message, evaluator):
     """Test BoilermakerServiceBusError exception during late message settlement for successful task."""
 
     async def oktask(state):
@@ -653,9 +631,7 @@ async def test_late_settlement_service_bus_error_exception_success(
     evaluator.complete_message.assert_called_once()
 
 
-async def test_late_settlement_service_bus_error_exception_failure(
-    app, make_message, evaluator
-):
+async def test_late_settlement_service_bus_error_exception_failure(app, make_message, evaluator):
     """Test BoilermakerServiceBusError exception during late message settlement for failed task."""
 
     async def failtask(state):
@@ -668,9 +644,7 @@ async def test_late_settlement_service_bus_error_exception_failure(
     evaluator.task = task
 
     # Mock deadletter_or_complete_task to raise BoilermakerServiceBusError
-    evaluator.deadletter_or_complete_task = AsyncMock(
-        side_effect=exc.BoilermakerServiceBusError("Service bus error")
-    )
+    evaluator.deadletter_or_complete_task = AsyncMock(side_effect=exc.BoilermakerServiceBusError("Service bus error"))
 
     result = await evaluator.message_handler()
 

--- a/tests/evaluators/test_task_graphs.py
+++ b/tests/evaluators/test_task_graphs.py
@@ -369,6 +369,8 @@ async def test_late_settlement_task_lease_lost_exception_success(evaluator_conte
     task.graph_id = "test-graph-id"
     evaluator_context.current_task = task
 
+    # Mock continue_graph so the test focuses on settlement behavior, not graph loading.
+    evaluator_context.evaluator.continue_graph = AsyncMock(return_value=0)
     # Mock complete_message to raise BoilermakerTaskLeaseLost
     evaluator_context.evaluator.complete_message = AsyncMock(side_effect=exc.BoilermakerTaskLeaseLost("Lease lost"))
 
@@ -397,6 +399,8 @@ async def test_late_settlement_task_lease_lost_exception_failure(evaluator_conte
     task.msg = make_message(task)
     evaluator_context.current_task = task
 
+    # Mock continue_graph so the test focuses on settlement behavior, not graph loading.
+    evaluator_context.evaluator.continue_graph = AsyncMock(return_value=0)
     # Mock deadletter_or_complete_task to raise BoilermakerTaskLeaseLost
     evaluator_context.evaluator.deadletter_or_complete_task = AsyncMock(
         side_effect=exc.BoilermakerTaskLeaseLost("Lease lost")
@@ -425,6 +429,8 @@ async def test_late_settlement_service_bus_error_exception_success(evaluator_con
     task.graph_id = "test-graph-id"
     evaluator_context.current_task = task
 
+    # Mock continue_graph so the test focuses on settlement behavior, not graph loading.
+    evaluator_context.evaluator.continue_graph = AsyncMock(return_value=0)
     # Mock complete_message to raise BoilermakerServiceBusError
     evaluator_context.evaluator.complete_message = AsyncMock(
         side_effect=exc.BoilermakerServiceBusError("Service bus error")
@@ -455,6 +461,8 @@ async def test_late_settlement_service_bus_error_exception_failure(evaluator_con
     task.msg = make_message(task)
     evaluator_context.current_task = task
 
+    # Mock continue_graph so the test focuses on settlement behavior, not graph loading.
+    evaluator_context.evaluator.continue_graph = AsyncMock(return_value=0)
     # Mock deadletter_or_complete_task to raise BoilermakerServiceBusError
     evaluator_context.evaluator.deadletter_or_complete_task = AsyncMock(
         side_effect=exc.BoilermakerServiceBusError("Service bus error")
@@ -539,9 +547,7 @@ async def test_continue_graph_graph_not_found(evaluator_context):
         result=42,
     )
 
-    evaluator_context.mock_storage.load_graph.side_effect = exc.BoilermakerStorageError(
-        "Not found", status_code=404
-    )
+    evaluator_context.mock_storage.load_graph.side_effect = exc.BoilermakerStorageError("Not found", status_code=404)
 
     # Should not raise errors, just log CRITICAL and return None
     result = await evaluator_context.evaluator.continue_graph(result)
@@ -573,6 +579,9 @@ async def test_continue_graph_no_ready_tasks(evaluator_context):
         status=TaskStatus.Success,
         result=42,
     )
+    # continue_graph checks that the loaded graph's status matches completed_task_result.status.
+    # Populate the graph's results so get_status() returns Success for the completing task.
+    evaluator_context.graph.add_result(child_result)
     evaluator_context.evaluator.task_publisher = mock_publish_task
     await evaluator_context.evaluator.continue_graph(child_result)
 
@@ -831,9 +840,7 @@ async def test_bmo10_load_graph_storage_error_no_settlement(evaluator_context, m
     )
 
     # No downstream tasks must be published
-    assert evaluator_context.get_scheduled_messages() == [], (
-        "task_publisher must not be called when load_graph fails"
-    )
+    assert evaluator_context.get_scheduled_messages() == [], "task_publisher must not be called when load_graph fails"
 
 
 async def test_bmo10_load_graph_not_found_settles_and_logs_critical(evaluator_context, mock_storage, caplog):
@@ -872,9 +879,7 @@ async def test_bmo10_no_publish_when_load_graph_fails(evaluator_context, mock_st
     with patch("asyncio.sleep"):
         await evaluator_context()
 
-    assert evaluator_context.get_scheduled_messages() == [], (
-        "task_publisher must not be called when load_graph raises"
-    )
+    assert evaluator_context.get_scheduled_messages() == [], "task_publisher must not be called when load_graph raises"
 
 
 async def test_bmo10_non404_storage_error_retried_raises_continue_graph_error_no_settlement(
@@ -890,9 +895,7 @@ async def test_bmo10_non404_storage_error_retried_raises_continue_graph_error_no
     from boilermaker.evaluators.task_graph import _LOAD_GRAPH_RETRY_POLICY
 
     # Simulate a 503 (transient) storage error on every attempt
-    mock_storage.load_graph.side_effect = exc.BoilermakerStorageError(
-        "503 Service Unavailable", status_code=503
-    )
+    mock_storage.load_graph.side_effect = exc.BoilermakerStorageError("503 Service Unavailable", status_code=503)
 
     with patch("asyncio.sleep"):
         result = await evaluator_context()
@@ -903,8 +906,7 @@ async def test_bmo10_non404_storage_error_retried_raises_continue_graph_error_no
 
     # load_graph must have been retried the full number of times
     assert mock_storage.load_graph.call_count == _LOAD_GRAPH_RETRY_POLICY.max_tries, (
-        f"Expected {_LOAD_GRAPH_RETRY_POLICY.max_tries} load_graph attempts, "
-        f"got {mock_storage.load_graph.call_count}"
+        f"Expected {_LOAD_GRAPH_RETRY_POLICY.max_tries} load_graph attempts, got {mock_storage.load_graph.call_count}"
     )
 
     # Message must NOT be settled — Service Bus should redeliver
@@ -941,23 +943,18 @@ async def test_bmo10_retries_exhausted_continue_graph_error_does_not_propagate(
 
     # ContinueGraphError must NOT propagate — message_handler must return cleanly
     assert result is not None, "message_handler must return a result, not raise ContinueGraphError"
-    assert result.status == TaskStatus.RetriesExhausted, (
-        f"Expected RetriesExhausted status, got {result.status}"
-    )
+    assert result.status == TaskStatus.RetriesExhausted, f"Expected RetriesExhausted status, got {result.status}"
 
     # load_graph should have been attempted (and exhausted the retry policy)
     assert mock_storage.load_graph.call_count == _LOAD_GRAPH_RETRY_POLICY.max_tries, (
-        f"Expected {_LOAD_GRAPH_RETRY_POLICY.max_tries} load_graph attempts, "
-        f"got {mock_storage.load_graph.call_count}"
+        f"Expected {_LOAD_GRAPH_RETRY_POLICY.max_tries} load_graph attempts, got {mock_storage.load_graph.call_count}"
     )
 
     # The message must have been settled (deadlettered) before continue_graph was called
     retries_exhausted_scenario.assert_msg_dead_lettered()
 
 
-async def test_bmo10_validation_error_in_load_graph_raises_continue_graph_error(
-    evaluator_context, mock_storage
-):
+async def test_bmo10_validation_error_in_load_graph_raises_continue_graph_error(evaluator_context, mock_storage):
     """BMO-10: ValidationError raised by load_graph must be wrapped as BoilermakerStorageError,
     enter the retry loop, exhaust retries, and surface as ContinueGraphError — not as a raw
     ValidationError that bypasses message_handler's except clause.
@@ -974,9 +971,7 @@ async def test_bmo10_validation_error_in_load_graph_raises_continue_graph_error(
     # Simulate corrupt blob contents that fail Pydantic validation.
     # After the fix, load_graph wraps ValidationError → BoilermakerStorageError, so the
     # retry loop catches it and eventually raises ContinueGraphError.
-    mock_storage.load_graph.side_effect = exc.BoilermakerStorageError(
-        "Failed to deserialize graph: validation error"
-    )
+    mock_storage.load_graph.side_effect = exc.BoilermakerStorageError("Failed to deserialize graph: validation error")
 
     with patch("asyncio.sleep"):
         result = await evaluator_context()
@@ -987,8 +982,7 @@ async def test_bmo10_validation_error_in_load_graph_raises_continue_graph_error(
 
     # load_graph must have been retried the full configured number of times
     assert mock_storage.load_graph.call_count == _LOAD_GRAPH_RETRY_POLICY.max_tries, (
-        f"Expected {_LOAD_GRAPH_RETRY_POLICY.max_tries} load_graph attempts, "
-        f"got {mock_storage.load_graph.call_count}"
+        f"Expected {_LOAD_GRAPH_RETRY_POLICY.max_tries} load_graph attempts, got {mock_storage.load_graph.call_count}"
     )
 
     # Message must NOT be settled — allow Service Bus redelivery
@@ -997,10 +991,7 @@ async def test_bmo10_validation_error_in_load_graph_raises_continue_graph_error(
     )
 
     # No downstream tasks must be published
-    assert evaluator_context.get_scheduled_messages() == [], (
-        "task_publisher must not be called when load_graph raises"
-    )
-
+    assert evaluator_context.get_scheduled_messages() == [], "task_publisher must not be called when load_graph raises"
 
 
 # BMO-9: continue_graph liveness gap — Scheduled re-publish
@@ -1086,9 +1077,7 @@ async def test_bmo9_no_double_blob_write(evaluator_context, app):
 
     # store_task_result must NOT have been called for the already-Scheduled task
     stored_ids = {
-        call.args[0].task_id
-        for call in evaluator_context.mock_storage.store_task_result.call_args_list
-        if call.args
+        call.args[0].task_id for call in evaluator_context.mock_storage.store_task_result.call_args_list if call.args
     }
     assert downstream_task.task_id not in stored_ids, (
         "store_task_result must not be called again for an already-Scheduled task (no double blob write)"
@@ -1119,8 +1108,75 @@ async def test_bmo9_is_complete_false_while_scheduled(evaluator_context, app):
     )
 
     assert not graph.is_complete(), (
-        "graph.is_complete() must return False when a task is in Scheduled status "
-        "(Scheduled is not a terminal state)"
+        "graph.is_complete() must return False when a task is in Scheduled status (Scheduled is not a terminal state)"
+    )
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Idempotent redelivery guard
+# # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+
+async def test_redelivery_guard_skips_execution_and_calls_continue_graph(evaluator_context, mock_storage):
+    """When load_task_result returns a terminal result, message_handler must skip
+    re-execution (eval_task not called) and still call continue_graph to dispatch
+    any downstream tasks that may not have been published due to the original crash.
+
+    This is the core safety property of the idempotent redelivery guard.
+    """
+    from unittest.mock import patch
+
+    from boilermaker.task import GraphId
+
+    graph = evaluator_context.graph
+    ok_task = evaluator_context.ok_task
+    ok_task.graph_id = graph.graph_id
+
+    # Arrange: the task already completed successfully in a prior invocation.
+    stored_slim = TaskResultSlim(
+        task_id=ok_task.task_id,
+        graph_id=GraphId(graph.graph_id),
+        status=TaskStatus.Success,
+    )
+    mock_storage.load_task_result.return_value = stored_slim
+
+    # The loaded graph must reflect the terminal status so the status-mismatch check passes
+    # when continue_graph is called on the redelivery path.
+    graph.add_result(
+        TaskResult(
+            task_id=ok_task.task_id,
+            graph_id=graph.graph_id,
+            status=TaskStatus.Success,
+        )
+    )
+    mock_storage.load_graph.return_value = graph
+
+    evaluator_context.evaluator.task = ok_task
+    ok_task.msg = evaluator_context.make_message(ok_task)
+
+    with patch("boilermaker.evaluators.task_graph.eval_task") as mock_eval_task:
+        result = await evaluator_context.evaluator()
+
+    # eval_task must NOT have been called — execution was skipped.
+    mock_eval_task.assert_not_called()
+
+    # continue_graph WAS called — downstream dispatch must still happen.
+    mock_storage.load_graph.assert_called_once()
+
+    # The returned result reflects the already-terminal status, not a fresh execution.
+    assert result is not None
+    assert result.status == TaskStatus.Success
+
+    # store_task_result must NOT have been called for the redelivering task itself
+    # (no Started or re-executed result blob was written). It may be called by
+    # continue_graph to write Scheduled status for newly-ready downstream tasks.
+    stored_statuses = [call.args[0].status for call in mock_storage.store_task_result.call_args_list if call.args]
+    assert TaskStatus.Started not in stored_statuses, (
+        "Started must not be stored on redelivery — that would overwrite the terminal result"
+    )
+    stored_task_ids = {call.args[0].task_id for call in mock_storage.store_task_result.call_args_list if call.args}
+    assert ok_task.task_id not in stored_task_ids, (
+        "store_task_result must not be called for the redelivering task (ok_task) itself"
     )
 
 
@@ -1167,3 +1223,272 @@ async def test_bmo9_crash_recover_failure_callback(evaluator_context, app):
         "Already-Scheduled failure callback task must be re-published on redelivery "
         "(crash recovery for fail_children — critical case from @distributed-systems-expert review)"
     )
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Per-task publish_task exception isolation
+# # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+
+async def test_publish_task_exception_on_second_task_does_not_abort_loop(app, evaluator_context):
+    """A publish_task failure for one ready task must not abort publishing of remaining tasks.
+
+    Three ready tasks are set up. publish_task raises on the second call.
+    Assert: first task is published, third task is also attempted, continue_graph does not raise,
+    and the failed task remains in Scheduled status in the graph.
+    """
+
+    async def task_b(state):
+        return "B"
+
+    async def task_c(state):
+        return "C"
+
+    app.register_many_async([task_b, task_c])
+    t_b = app.create_task(task_b)
+    t_c = app.create_task(task_c)
+
+    # Add two more parallel successors to ok_task alongside the existing ones
+    # so we have at least three ready tasks when ok_task succeeds.
+    # Use a fresh graph with just three parallel tasks to keep the test simple.
+    fresh_graph = TaskGraph()
+    root_task = evaluator_context.ok_task
+    fresh_graph.add_task(root_task)
+    fresh_graph.add_task(t_b, parent_ids=[root_task.task_id])
+    fresh_graph.add_task(t_c, parent_ids=[root_task.task_id])
+    list(fresh_graph.generate_pending_results())
+
+    # ok_task already completed successfully
+    fresh_graph.add_result(
+        TaskResult(
+            task_id=root_task.task_id,
+            graph_id=fresh_graph.graph_id,
+            status=TaskStatus.Success,
+        )
+    )
+    evaluator_context.mock_storage.load_graph.return_value = fresh_graph
+
+    publish_call_count = 0
+    published_task_ids: list[str] = []
+    attempted_task_ids: list[str] = []
+
+    async def publish_task_with_second_failure(task, *args, **kwargs):
+        nonlocal publish_call_count
+        publish_call_count += 1
+        attempted_task_ids.append(task.task_id)
+        if publish_call_count == 2:
+            raise Exception("Simulated transient SB publish failure on second task")
+        published_task_ids.append(task.task_id)
+
+    evaluator_context.evaluator.task_publisher = publish_task_with_second_failure
+
+    completed = TaskResult(
+        task_id=root_task.task_id,
+        graph_id=fresh_graph.graph_id,
+        status=TaskStatus.Success,
+    )
+
+    # continue_graph must not raise even though publish_task raises on the second call
+    ready_count = await evaluator_context.evaluator.continue_graph(completed)
+
+    # Both t_b and t_c were attempted (3 attempts including the one that failed)
+    assert len(attempted_task_ids) == 2, f"Expected both ready tasks to be attempted, got {attempted_task_ids}"
+
+    # Only one task was successfully published (the one that didn't raise)
+    assert len(published_task_ids) == 1, f"Expected exactly one successful publish, got {published_task_ids}"
+
+    # ready_count only counts successful publishes
+    assert ready_count == 1, f"Expected ready_count=1 (only successful publish), got {ready_count}"
+
+    # The failed task is in Scheduled status in the blob (CAS write succeeded before publish_task raised)
+    failed_task_id = next(tid for tid in attempted_task_ids if tid not in published_task_ids)
+    assert fresh_graph.results[failed_task_id].status == TaskStatus.Scheduled, (
+        "Failed-publish task must remain in Scheduled status in blob for crash-recovery on redelivery"
+    )
+
+
+async def test_continue_graph_does_not_raise_when_publish_fails(evaluator_context):
+    """continue_graph must not raise when publish_task raises; message_handler can proceed to settle."""
+    graph = evaluator_context.graph
+    # ok_task completed successfully
+    graph.add_result(
+        TaskResult(
+            task_id=evaluator_context.ok_task.task_id,
+            graph_id=graph.graph_id,
+            status=TaskStatus.Success,
+        )
+    )
+    evaluator_context.mock_storage.load_graph.return_value = graph
+
+    async def always_failing_publisher(task, *args, **kwargs):
+        raise Exception("Simulated persistent SB publish failure")
+
+    evaluator_context.evaluator.task_publisher = always_failing_publisher
+
+    completed = TaskResult(
+        task_id=evaluator_context.ok_task.task_id,
+        graph_id=graph.graph_id,
+        status=TaskStatus.Success,
+    )
+
+    # Must not raise — exception isolation means the loop continues and returns normally
+    ready_count = await evaluator_context.evaluator.continue_graph(completed)
+
+    # All publishes failed, so ready_count is 0
+    assert ready_count == 0
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # #
+# acks_early warning in TaskGraphEvaluator.__init__
+# # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+
+def test_acks_early_true_emits_warning_at_construction(app, mockservicebus, mock_storage, make_message, caplog):
+    """Constructing TaskGraphEvaluator with acks_early=True must emit a warning log.
+
+    The warning must contain the task ID and describe the irrecoverable-Started risk.
+    Construction must succeed — no ValueError is raised.
+
+    acks_early is a property that returns not acks_late, so acks_late=False triggers the warning.
+    """
+    import logging
+
+    async def acks_early_task_fn(state):
+        return "ok"
+
+    app.register_async(acks_early_task_fn)
+    # acks_early is a computed property: acks_early == not acks_late
+    early_task = Task.si(acks_early_task_fn, acks_late=False)
+    early_task.msg = make_message(early_task)
+
+    assert early_task.acks_early is True, "Precondition: task must have acks_early=True"
+
+    async def noop_publisher(task, *args, **kwargs):
+        pass
+
+    with caplog.at_level(logging.WARNING, logger="boilermaker.app"):
+        evaluator = TaskGraphEvaluator(
+            mockservicebus._receiver,
+            early_task,
+            noop_publisher,
+            app.function_registry,
+            state=app.state,
+            storage_interface=mock_storage,
+        )
+
+    # Construction must succeed — no ValueError
+    assert evaluator is not None
+
+    warning_messages = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any(early_task.task_id in msg for msg in warning_messages), (
+        f"Expected warning to contain task_id {early_task.task_id!r}. Got: {warning_messages}"
+    )
+    assert any("Started" in msg for msg in warning_messages), (
+        f"Expected warning to describe the irrecoverable-Started risk. Got: {warning_messages}"
+    )
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Status mismatch and fail-open error handling in continue_graph
+# # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+
+async def test_status_mismatch_raises_continue_graph_error(evaluator_context, mock_storage):
+    """When the loaded graph reports a different status than the completed TaskResult,
+    continue_graph must raise ContinueGraphError and must not publish any tasks.
+
+    This guards against the 'stale graph blob' race: a redelivered message writes a new
+    terminal result but then loads the pre-write graph blob where the status still shows
+    the old value.  Raising rather than silently continuing allows Service Bus to redeliver
+    and retry once the blob is consistent.
+    """
+    from unittest.mock import MagicMock
+
+    from boilermaker.task import GraphId, TaskGraph
+
+    graph = evaluator_context.graph
+    ok_task = evaluator_context.ok_task
+
+    # Build a mock graph whose get_status returns a status that does NOT match the
+    # completed_task_result.status we will pass to continue_graph.
+    mock_graph = MagicMock(spec=TaskGraph)
+    mock_graph.graph_id = graph.graph_id
+    # The completing task finished with Success, but the loaded blob reports Pending —
+    # a mismatch that should trigger the status guard.
+    mock_graph.get_status.return_value = TaskStatus.Pending
+    mock_graph.generate_ready_tasks.return_value = iter([])
+    mock_graph.generate_failure_ready_tasks.return_value = iter([])
+
+    mock_storage.load_graph.return_value = mock_graph
+
+    completed = TaskResult(
+        task_id=ok_task.task_id,
+        graph_id=GraphId(graph.graph_id),
+        status=TaskStatus.Success,
+    )
+
+    with pytest.raises(exc.ContinueGraphError):
+        await evaluator_context.evaluator.continue_graph(completed)
+
+    # No tasks must have been published — the mismatch guard fires before scheduling.
+    assert evaluator_context.get_scheduled_messages() == [], (
+        "publish_task must not be called when continue_graph raises on status mismatch"
+    )
+
+
+async def test_fail_open_on_load_task_result_storage_error(evaluator_context, mock_storage):
+    """When load_task_result raises BoilermakerStorageError, message_handler must
+    proceed with normal execution (fail-open) rather than skipping the task.
+
+    Fail-closed on a transient read error would permanently stall the graph: the task
+    would never run because every redelivery returns an error, so no result is ever
+    stored, so continue_graph never fires, so downstream tasks are never dispatched.
+
+    This test guards against someone accidentally changing fail-open to fail-closed.
+    """
+    from unittest.mock import patch
+
+    # Arrange: load_task_result raises a transient storage error on every call.
+    mock_storage.load_task_result.side_effect = exc.BoilermakerStorageError("503 transient error")
+
+    # The graph must have ok_task's result pre-seeded so the status-mismatch check in
+    # continue_graph passes — the loaded graph status must match what eval_task produces.
+    graph = evaluator_context.graph
+    ok_task = evaluator_context.ok_task
+    graph.add_result(
+        TaskResult(
+            task_id=ok_task.task_id,
+            graph_id=graph.graph_id,
+            status=TaskStatus.Success,
+            result="OK",
+        )
+    )
+    mock_storage.load_graph.return_value = graph
+    evaluator_context.evaluator.task = ok_task
+    ok_task.msg = evaluator_context.make_message(ok_task)
+
+    with patch("boilermaker.evaluators.task_graph.eval_task") as mock_eval_task:
+        # eval_task must be awaitable and return a plausible TaskResult so message_handler
+        # can continue past execution into the settlement/continue_graph path.
+
+        mock_eval_task.return_value = TaskResult(
+            task_id=ok_task.task_id,
+            graph_id=graph.graph_id,
+            status=TaskStatus.Success,
+            result="OK",
+        )
+        mock_eval_task.side_effect = None
+
+        result = await evaluator_context.evaluator()
+
+    # eval_task MUST have been called — fail-open means we proceed despite the read error.
+    (
+        mock_eval_task.assert_called_once(),
+        (
+            "eval_task must be called when load_task_result raises BoilermakerStorageError "
+            "(fail-open: do not stall the graph on transient read errors)"
+        ),
+    )
+
+    # Execution should have produced a result, not silently skipped.
+    assert result is not None, "message_handler must return a result on the fail-open path"

--- a/tests/graph_factories.py
+++ b/tests/graph_factories.py
@@ -27,10 +27,7 @@ class GraphBuilder:
         """Mark a task as completed with given result."""
         task_obj = self.tasks[name]
         task_result = TaskResult(
-            task_id=task_obj.task_id,
-            graph_id=self.graph.graph_id,
-            status=TaskStatus.Success,
-            result=result
+            task_id=task_obj.task_id, graph_id=self.graph.graph_id, status=TaskStatus.Success, result=result
         )
         self.graph.add_result(task_result)
         return task_result
@@ -39,10 +36,7 @@ class GraphBuilder:
         """Mark a task as failed."""
         task_obj = self.tasks[name]
         task_result = TaskResult(
-            task_id=task_obj.task_id,
-            graph_id=self.graph.graph_id,
-            status=TaskStatus.Failure,
-            errors=[error]
+            task_id=task_obj.task_id, graph_id=self.graph.graph_id, status=TaskStatus.Failure, errors=[error]
         )
         self.graph.add_result(task_result)
         return task_result
@@ -67,7 +61,7 @@ def linear_graph(num_tasks: int = 3) -> tuple[TaskGraph, list[Task]]:
     # Each subsequent task depends on the previous one
     for i in range(1, num_tasks):
         task_name = f"task_{i}"
-        parent_name = f"task_{i-1}"
+        parent_name = f"task_{i - 1}"
         t = builder.add_task(task_name, parents=[parent_name])
         tasks.append(t)
 
@@ -90,12 +84,7 @@ def diamond_graph() -> tuple[TaskGraph, dict[str, Task]]:
     t3 = builder.add_task("right", parents=["root"])
     t4 = builder.add_task("merge", parents=["left", "right"])
 
-    return builder.graph, {
-        "root": t1,
-        "left": t2,
-        "right": t3,
-        "merge": t4
-    }
+    return builder.graph, {"root": t1, "left": t2, "right": t3, "merge": t4}
 
 
 def parallel_graph(num_parallel: int = 3) -> tuple[TaskGraph, Task, list[Task]]:
@@ -152,14 +141,18 @@ def complex_graph() -> tuple[TaskGraph, dict[str, Task]]:
 
 
 def ready_task_scenario() -> tuple[TaskGraph, dict[str, Task], callable]:
-    """Create a scenario for testing ready task detection."""
+    """Create a scenario for testing ready task detection.
+
+    Pending results are pre-populated for all tasks so that generate_ready_tasks
+    can correctly identify tasks with Pending status.
+    """
     graph, tasks = diamond_graph()
+    list(graph.generate_pending_results())
 
     def assert_ready_tasks(expected_names: list[str]):
         """Helper to assert which tasks are ready."""
         ready = list(graph.generate_ready_tasks())
-        ready_names = [next(name for name, t in tasks.items()
-                           if t.task_id == r.task_id) for r in ready]
+        ready_names = [next(name for name, t in tasks.items() if t.task_id == r.task_id) for r in ready]
         assert set(ready_names) == set(expected_names), f"Expected {expected_names}, got {ready_names}"
 
     return graph, tasks, assert_ready_tasks

--- a/tests/storage/test_blob_storage.py
+++ b/tests/storage/test_blob_storage.py
@@ -28,6 +28,7 @@ def mock_credentials():
     """Mock Azure credentials for testing."""
     return MagicMock(spec=DefaultAzureCredential)
 
+
 @pytest.fixture
 def blob_storage(mock_credentials):
     """Create a BlobClientStorage instance for testing."""
@@ -72,9 +73,7 @@ def sample_task_result_slim(sample_task):
 
 
 # Tests for store_task_result method
-async def test_store_task_result_success(
-    mock_azureblob, blob_storage, sample_task_result
-):
+async def test_store_task_result_success(mock_azureblob, blob_storage, sample_task_result):
     """Test successful storage of a TaskResult."""
     _container_client, mockblobc, _ = mock_azureblob
     mockblobc.upload_blob.return_value = {"status": "success"}
@@ -96,13 +95,9 @@ async def test_store_task_result_success(
     assert tags["status"] == sample_task_result.status.value
 
 
-async def test_store_task_result_with_azure_blob_error(
-    blob_storage, sample_task_result
-):
+async def test_store_task_result_with_azure_blob_error(blob_storage, sample_task_result):
     """Test error handling when Azure blob storage fails."""
-    with patch.object(
-        blob_storage, "upload_blob", new_callable=AsyncMock
-    ) as mock_upload:
+    with patch.object(blob_storage, "upload_blob", new_callable=AsyncMock) as mock_upload:
         error = AzureBlobError(
             MagicMock(
                 **{
@@ -174,9 +169,7 @@ async def test_load_graph_success(
 
 async def test_load_graph_not_found(blob_storage):
     """Test loading a non-existent TaskGraph."""
-    with patch.object(
-        blob_storage, "download_blob", new_callable=AsyncMock
-    ) as mock_download:
+    with patch.object(blob_storage, "download_blob", new_callable=AsyncMock) as mock_download:
         error = AzureBlobError(
             MagicMock(
                 **{
@@ -203,9 +196,7 @@ async def test_load_graph_empty_graph_id(blob_storage):
 
 async def test_load_graph_returns_none_when_no_content(blob_storage):
     """Test loading returns None when download_blob returns None."""
-    with patch.object(
-        blob_storage, "download_blob", new_callable=AsyncMock
-    ) as mock_download:
+    with patch.object(blob_storage, "download_blob", new_callable=AsyncMock) as mock_download:
         mock_download.return_value = None
 
         result = await blob_storage.load_graph(GraphId("test-graph"))
@@ -226,14 +217,10 @@ async def test_load_graph_validation_error_on_graph_json_raises_storage_error(
     from pydantic import ValidationError
 
     with (
-        patch.object(
-            blob_storage, "download_blob", new_callable=AsyncMock
-        ) as mock_download,
+        patch.object(blob_storage, "download_blob", new_callable=AsyncMock) as mock_download,
         patch(
             "boilermaker.storage.blob_storage.TaskGraph.model_validate_json",
-            side_effect=ValidationError.from_exception_data(
-                "TaskGraph", [], input_type="json"
-            ),
+            side_effect=ValidationError.from_exception_data("TaskGraph", [], input_type="json"),
         ),
     ):
         mock_download.return_value = '{"corrupt": "data"}'
@@ -269,9 +256,7 @@ async def test_load_graph_validation_error_on_task_result_json_raises_storage_er
 
     with patch(
         "boilermaker.storage.blob_storage.TaskResultSlim.model_validate_json",
-        side_effect=ValidationError.from_exception_data(
-            "TaskResultSlim", [], input_type="json"
-        ),
+        side_effect=ValidationError.from_exception_data("TaskResultSlim", [], input_type="json"),
     ):
         with pytest.raises(BoilermakerStorageError) as exc_info:
             await blob_storage.load_graph(sample_task_graph.graph_id)
@@ -345,9 +330,7 @@ async def test_store_graph_success(mock_azureblob, blob_storage, sample_task_gra
     assert pending_task_res.model_dump_json() == task_result_upload_call.args[1]
 
 
-async def test_store_graph_with_resource_error(
-    mock_azureblob, blob_storage, sample_task_graph
-):
+async def test_store_graph_with_resource_error(mock_azureblob, blob_storage, sample_task_graph):
     """Test error handling when storing TaskGraph fails."""
     container_client, mockblobc, _ = mock_azureblob
     error = ResourceExistsError("YOU FAILED")
@@ -368,9 +351,7 @@ async def test_store_graph_with_resource_error(
 
 
 # Edge cases and additional tests
-async def test_store_task_result_raises_storage_error_on_etag_mismatch(
-    blob_storage, sample_task_result
-):
+async def test_store_task_result_raises_storage_error_on_etag_mismatch(blob_storage, sample_task_result):
     """
     Verifies that store_task_result raises BoilermakerStorageError when the
     underlying blob client raises AzureBlobError (e.g., HTTP 412 ETag mismatch).
@@ -379,9 +360,7 @@ async def test_store_task_result_raises_storage_error_on_etag_mismatch(
     The concurrency path (etag != None) is exercised explicitly so that the
     concurrency_kwargs are populated before the upload attempt.
     """
-    with patch.object(
-        blob_storage, "upload_blob", new_callable=AsyncMock
-    ) as mock_upload:
+    with patch.object(blob_storage, "upload_blob", new_callable=AsyncMock) as mock_upload:
         error = AzureBlobError(
             MagicMock(
                 **{
@@ -395,9 +374,7 @@ async def test_store_task_result_raises_storage_error_on_etag_mismatch(
 
         with pytest.raises(BoilermakerStorageError) as exc_info:
             # Pass a non-empty etag to exercise the ETag concurrency guard code path
-            await blob_storage.store_task_result(
-                sample_task_result, etag='"0x8DBBAF4B8A6017C"'
-            )
+            await blob_storage.store_task_result(sample_task_result, etag='"0x8DBBAF4B8A6017C"')
 
         assert "Failed to store TaskResult" in str(exc_info.value)
         assert exc_info.value.task_id == sample_task_result.task_id
@@ -420,12 +397,40 @@ async def test_store_task_result_without_graph_id(blob_storage, sample_task):
         result="test result",
     )
 
-    with patch.object(
-        blob_storage, "upload_blob", new_callable=AsyncMock
-    ) as mock_upload:
+    with patch.object(blob_storage, "upload_blob", new_callable=AsyncMock) as mock_upload:
         await blob_storage.store_task_result(task_result)
 
         # Verify tags include 'none' for missing graph_id
         call_args = mock_upload.call_args
         tags = call_args[1]["tags"]
         assert tags["graph_id"] == "none"
+
+
+async def test_store_and_load_task_result_round_trip(mock_azureblob, blob_storage, sample_task_result):
+    """Round-trip test: load_task_result reads back what store_task_result wrote.
+
+    Both methods construct the blob path as
+    ``{task_result_prefix}/{graph_id}/{task_id}.json``.  This test pins that
+    contract so that a future refactor of either path-construction site
+    produces a failing test rather than silently disabling the idempotency guard.
+
+    Acceptance criterion from TDD section 7, load_task_result row.
+    """
+    _container_client, mockblobc, set_return = mock_azureblob
+    mockblobc.upload_blob.return_value = {"status": "success"}
+
+    # Write the result through store_task_result.
+    await blob_storage.store_task_result(sample_task_result)
+
+    # Capture the JSON that was actually written to blob storage.
+    assert mockblobc.upload_blob.call_count == 1
+    uploaded_json = mockblobc.upload_blob.call_args.args[0]
+
+    # Configure the download mock to return that same JSON so load_task_result
+    # reads exactly what store_task_result wrote.
+    set_return.download_blob_returns(uploaded_json)
+
+    loaded = await blob_storage.load_task_result(sample_task_result.task_id, sample_task_result.graph_id)
+
+    assert loaded is not None, "load_task_result returned None — blob path mismatch between store and load"
+    assert loaded.status == sample_task_result.status

--- a/tests/task/test_graph.py
+++ b/tests/task/test_graph.py
@@ -156,12 +156,12 @@ def test_task_graph_ready_tasks_excludes_started():
     t1 = task.Task.default("func1")
     graph.add_task(t1)
 
+    # Populate pending results before checking readiness
+    assert len(list(graph.generate_pending_results())) == 1
+
     # Initially ready
     ready_tasks = list(graph.generate_ready_tasks())
     assert len(ready_tasks) == 1
-
-    # Put a Pending result in there
-    assert len(list(graph.generate_pending_results())) == 1
 
     # Mark as started
     graph.schedule_task(t1.task_id)
@@ -841,7 +841,12 @@ def test_task_graph_mixed_success_failure_dependencies():
     assert task_a.task_id in graph.fail_edges
     assert task_b.task_id in graph.fail_edges
     assert cleanup_a.task_id in graph.fail_edges[task_a.task_id]
-    assert cleanup_b.task_id in graph.fail_edges[task_b.task_id]  # Test scenario 1: A succeeds
+    assert cleanup_b.task_id in graph.fail_edges[task_b.task_id]
+
+    # Populate pending results so generate_ready_tasks can find Pending-status tasks
+    list(graph.generate_pending_results())
+
+    # Test scenario 1: A succeeds
     graph.results[task_a.task_id] = task.TaskResult(
         task_id=task_a.task_id, graph_id=graph.graph_id, status=task.TaskStatus.Success
     )
@@ -1704,6 +1709,9 @@ def test_failure_ready_tasks_with_complex_dependency_chains():
     graph.add_task(handler_2, parent_ids=[handler_1.task_id])  # Handler chain
     graph.add_failure_callback(main_b.task_id, handler_3)
 
+    # Populate pending results so generate_ready_tasks can find Pending-status tasks
+    list(graph.generate_pending_results())
+
     # A fails - only handler_1 should be ready (not handler_2 which depends on handler_1)
     graph.results[main_a.task_id] = task.TaskResultSlim(
         status=task.TaskStatus.Failure,
@@ -2238,13 +2246,7 @@ def test_diamond_pattern():
     task_b = task.Task.default("fn_b")
     task_c = task.Task.default("fn_c")
     task_d = task.Task.default("fn_d")
-    graph = (
-        task.TaskGraphBuilder()
-        .add(task_a)
-        .parallel(task_b, task_c)
-        .then(task_d)
-        .build()
-    )
+    graph = task.TaskGraphBuilder().add(task_a).parallel(task_b, task_c).then(task_d).build()
     assert task_b.task_id in graph.edges[task_a.task_id]
     assert task_c.task_id in graph.edges[task_a.task_id]
     assert task_d.task_id in graph.edges[task_b.task_id]
@@ -2257,12 +2259,7 @@ def test_sequential_chain_with_inline_on_failure():
     task_b = task.Task.default("fn_b")
     err_a = task.Task.default("err_a")
     err_b = task.Task.default("err_b")
-    graph = (
-        task.TaskGraphBuilder()
-        .add(task_a, on_failure=err_a)
-        .then(task_b, on_failure=err_b)
-        .build()
-    )
+    graph = task.TaskGraphBuilder().add(task_a, on_failure=err_a).then(task_b, on_failure=err_b).build()
     assert err_a.task_id in graph.fail_children
     assert err_b.task_id in graph.fail_children
     assert task_a.task_id in graph.fail_edges
@@ -2319,3 +2316,78 @@ def test_complex_parallel_fan_in_with_failure_handlers():
     assert ingest_err.task_id in graph.fail_children
     assert process_err.task_id in graph.fail_children
     assert cleanup.task_id in graph.fail_children
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # #
+# generate_ready_tasks skips tasks with missing result blobs
+# # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+
+def test_task_with_no_result_blob_is_skipped_with_warning(caplog):
+    """generate_ready_tasks must skip tasks with no result blob and emit a warning.
+
+    A task with no entry in graph.results (simulating a store_graph partial failure)
+    must not be yielded and must log a warning instead.
+    """
+    import logging
+
+    graph = task.TaskGraph()
+    t1 = task.Task.default("no_result_task")
+    graph.add_task(t1)
+    # Deliberately do NOT call generate_pending_results() — t1 has no result blob.
+
+    with caplog.at_level(logging.WARNING, logger="boilermaker.app"):
+        ready = list(graph.generate_ready_tasks())
+
+    assert ready == [], "Task with no result blob must not be yielded by generate_ready_tasks"
+    warning_messages = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any(t1.task_id in msg for msg in warning_messages), (
+        f"Expected warning to mention the task_id {t1.task_id!r}. Got: {warning_messages}"
+    )
+    assert any("no result blob" in msg for msg in warning_messages), (
+        f"Expected warning to mention missing result blob. Got: {warning_messages}"
+    )
+
+
+def test_task_with_pending_result_is_yielded():
+    """generate_ready_tasks must yield root tasks that have Pending status."""
+    graph = task.TaskGraph()
+    t1 = task.Task.default("pending_task")
+    graph.add_task(t1)
+
+    list(graph.generate_pending_results())
+
+    ready = list(graph.generate_ready_tasks())
+    assert len(ready) == 1
+    assert ready[0].task_id == t1.task_id
+
+
+def test_mixed_missing_and_pending_results(caplog):
+    """In a graph with some missing and some Pending results, only Pending tasks are yielded."""
+    import logging
+
+    graph = task.TaskGraph()
+    t_with_result = task.Task.default("has_result")
+    t_no_result = task.Task.default("no_result")
+    graph.add_task(t_with_result)
+    graph.add_task(t_no_result)
+
+    # Only populate pending result for t_with_result
+    graph.results[t_with_result.task_id] = task.TaskResultSlim(
+        task_id=t_with_result.task_id,
+        graph_id=graph.graph_id,
+        status=task.TaskStatus.Pending,
+    )
+    # t_no_result intentionally has no entry in graph.results
+
+    with caplog.at_level(logging.WARNING, logger="boilermaker.app"):
+        ready = list(graph.generate_ready_tasks())
+
+    ready_ids = {t.task_id for t in ready}
+    assert t_with_result.task_id in ready_ids, "Task with Pending result must be yielded"
+    assert t_no_result.task_id not in ready_ids, "Task with no result blob must not be yielded"
+
+    warning_messages = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any(t_no_result.task_id in msg for msg in warning_messages), (
+        f"Expected warning for task with no result blob. Got: {warning_messages}"
+    )

--- a/tests/task/test_graph_cycle_detection.py
+++ b/tests/task/test_graph_cycle_detection.py
@@ -7,6 +7,7 @@ async def sample_task(state, number1, number2: int = 4):
         state.sample_task_called += number1
     return number1 + number2
 
+
 # ~~~~ ~~~~~ ~~~~ ~~~~ #
 # Cycle Detection Tests
 # ~~~~ ~~~~~ ~~~~ ~~~~ #
@@ -205,6 +206,9 @@ def test_cycle_detection_stress_test_false_positive():
     # The stress test: this should still be valid
     assert len(graph.children) == 12  # All tasks added
 
+    # Populate pending results so generate_ready_tasks can find Pending-status tasks
+    list(graph.generate_pending_results())
+
     # Only tasks with no parents should be ready initially (just A)
     ready_tasks = list(graph.generate_ready_tasks())
     assert len(ready_tasks) == 1
@@ -374,3 +378,34 @@ def test_cycle_detection_algorithm_really_try_to_break_it():
     # Try: 8 -> 5 (would create cycle through 5 -> 8 path)
     with pytest.raises(ValueError, match="would create a cycle"):
         graph.add_task(tasks[5], parent_ids=[tasks[8].task_id])
+
+
+def test_cycle_detection_error_message_contains_all_parent_ids():
+    """Cycle detection error message must include the full parent_ids list.
+
+    Regression guard: the original message used `parent_id` (the last loop
+    variable) instead of `parent_ids` (the full argument). When multiple
+    parents are supplied the message must list all of them, not just the last.
+    """
+    graph = task.TaskGraph(graph_id="error_msg_test")
+
+    task_a = task.Task.si(sample_task)
+    task_b = task.Task.si(sample_task)
+    task_c = task.Task.si(sample_task)
+
+    # Build: A -> B -> C (valid chain)
+    graph.add_task(task_a)
+    graph.add_task(task_b, parent_ids=[task_a.task_id])
+    graph.add_task(task_c, parent_ids=[task_b.task_id])
+
+    # Attempt to close the cycle using two parents so parent_ids has >1 element.
+    # task_a already has task_b as a descendant, so making it depend on both
+    # task_b and task_c would create a cycle.
+    with pytest.raises(ValueError) as exc_info:
+        graph.add_task(task_a, parent_ids=[task_b.task_id, task_c.task_id])
+
+    error_message = str(exc_info.value)
+    assert "would create a cycle" in error_message
+    # The message must reference the full parent_ids list, not a single parent_id.
+    assert task_b.task_id in error_message
+    assert task_c.task_id in error_message

--- a/tests/task/test_result.py
+++ b/tests/task/test_result.py
@@ -34,9 +34,7 @@ def test_task_result_slim_paths():
     assert result.storage_path == Path(graph_id) / "test-task-id.json"
 
     # Without graph_id
-    result_no_graph = task.TaskResultSlim(
-        task_id=task_id, status=task.TaskStatus.Success
-    )
+    result_no_graph = task.TaskResultSlim(task_id=task_id, status=task.TaskStatus.Success)
 
     assert result_no_graph.directory_path == Path(task_id)
     assert result_no_graph.storage_path == Path(task_id) / "test-task-id.json"

--- a/tests/task/test_task.py
+++ b/tests/task/test_task.py
@@ -106,7 +106,6 @@ def test_task_properties():
 
 def test_task_message_properties():
 
-
     t = task.Task.default("test_func")
 
     # Initially no message
@@ -173,7 +172,6 @@ def test_task_serialization():
     assert t2.function_name == "test_func"
     assert t2.payload == {"key": "value"}
     assert t2.task_id == t.task_id
-
 
 
 def test_task_diagnostic_id_when_no_message():

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -161,9 +161,7 @@ async def test_create_task_with_policy(app):
     # Sanity check: default policy should be higher than what we're setting below
     assert app.task_registry["somefunc"].policy.max_tries > 2
     # Now we can create a task out of it
-    policy = retries.RetryPolicy(
-        max_tries=2, delay=30, delay_max=600, retry_mode=retries.RetryMode.Exponential
-    )
+    policy = retries.RetryPolicy(max_tries=2, delay=30, delay_max=600, retry_mode=retries.RetryMode.Exponential)
     task = app.create_task(somefunc, somekwarg="akwargval", policy=policy)
     assert task.function_name == "somefunc"
     assert task.payload == {"args": (), "kwargs": {"somekwarg": "akwargval"}}
@@ -457,6 +455,89 @@ async def test_publish_graph_failures(app, mockservicebus, mock_storage):
     mockservicebus._sender.assert_not_called()
 
 
+async def test_publish_graph_etag_cas_failure_skips_one_root_task(app, mockservicebus, mock_storage):
+    """Test that an ETag CAS failure for one root task skips publication of that task only.
+
+    Per-task exception isolation: when store_task_result raises BoilermakerStorageError
+    for one root task, that task must NOT be published to Service Bus, but all other
+    root tasks must still be published.
+    """
+    import copy
+
+    app.results_storage = mock_storage
+
+    # Build a graph with two independent root tasks (no parent-child relationship)
+    graph = TaskGraph()
+    t1 = Task.si(sample_task, 1, 2)
+    t2 = Task.si(sample_task, 3, 4)
+    graph.add_task(t1)
+    graph.add_task(t2)
+
+    # Simulate load_graph returning a graph with ETags on pending results
+    loaded_graph = copy.deepcopy(graph)
+    for result in loaded_graph.generate_pending_results():
+        result.etag = "mock-etag"
+    mock_storage.load_graph = AsyncMock(return_value=loaded_graph)
+
+    # Determine which task_id will be scheduled first by generate_ready_tasks
+    ready_task_ids = [task.task_id for task in loaded_graph.generate_ready_tasks()]
+    assert len(ready_task_ids) == 2, "Expected two root tasks"
+    failing_task_id = ready_task_ids[0]
+    succeeding_task_id = ready_task_ids[1]
+
+    # store_task_result raises for the first root task, succeeds for the second
+    async def store_task_result_side_effect(result, etag=None):
+        if result.task_id == failing_task_id:
+            raise BoilermakerStorageError("ETag conflict — concurrent write")
+
+    mock_storage.store_task_result.side_effect = store_task_result_side_effect
+
+    # Patch publish_task to track which task IDs were published
+    published_task_ids = []
+
+    original_publish_task = app.publish_task
+
+    async def tracking_publish_task(task, **kwargs):
+        published_task_ids.append(task.task_id)
+        return await original_publish_task(task, **kwargs)
+
+    app.publish_task = tracking_publish_task
+
+    await app.publish_graph(graph)
+
+    # The failing root task must NOT be published
+    assert failing_task_id not in published_task_ids
+    # The succeeding root task must be published
+    assert succeeding_task_id in published_task_ids
+    # Exactly one task published to Service Bus
+    assert len(mockservicebus._sender.method_calls) == 1
+
+
+async def test_publish_graph_fail_children_graph_id_mismatch_raises(app, mockservicebus, mock_storage):
+    """publish_graph must reject graphs where any fail_children task
+    carries a graph_id different from the graph's own graph_id.
+    """
+    app.results_storage = mock_storage
+
+    graph = TaskGraph()
+    t1 = Task.si(sample_task, 1, 2)
+    graph.add_task(t1)
+
+    # Add a failure callback and then corrupt its graph_id to simulate a mismatch.
+    # add_failure_callback sets graph_id automatically, so we must overwrite it after.
+    failure_handler = Task.si(failing_task)
+    graph.add_failure_callback(t1.task_id, failure_handler)
+    # Corrupt the graph_id on the fail_children entry to simulate a mismatch
+    graph.fail_children[failure_handler.task_id].graph_id = "wrong-graph-id"
+
+    with pytest.raises(BoilermakerAppException) as exc_info:
+        await app.publish_graph(graph)
+
+    assert "All failure callback tasks must have graph_id matching graph" in str(exc_info.value)
+    # Nothing published
+    mockservicebus._sender.assert_not_called()
+
+
 async def test_publish_graph_happy_path(app, mockservicebus, mock_storage):
     """Test that publishing a valid task graph works as expected."""
     app.results_storage = mock_storage
@@ -466,16 +547,29 @@ async def test_publish_graph_happy_path(app, mockservicebus, mock_storage):
     graph.add_task(t1)
     graph.add_task(t2, parent_ids=[t1.task_id])
 
+    # Simulate what blob storage returns after store_graph: a graph with pending results
+    # that carry ETags (required for the ETag-guarded Scheduled write).
+    import copy
+
+    loaded_graph = copy.deepcopy(graph)
+    for result in loaded_graph.generate_pending_results():
+        result.etag = "mock-etag"
+    mock_storage.load_graph = AsyncMock(return_value=loaded_graph)
+
     result = await app.publish_graph(graph)
     # We get the graph back
     assert result is graph
 
-    # One task published
+    # One task published (only t1, since t2 depends on t1)
     assert len(mockservicebus._sender.method_calls) == 1
     publish_success_call = mockservicebus._sender.method_calls[0]
     assert publish_success_call[0] == "schedule_messages"
     # Graph stored
     mock_storage.store_graph.assert_called_with(graph)
+    # Graph reloaded after storing (to obtain ETags for guarded writes)
+    mock_storage.load_graph.assert_called_once_with(graph.graph_id)
+    # Root task written to Scheduled in blob before publishing
+    mock_storage.store_task_result.assert_called_once()
 
     # We should always be able to deserialize the task
     published_task = Task.model_validate_json(str(publish_success_call[1][0]))

--- a/tests/test_retries.py
+++ b/tests/test_retries.py
@@ -36,9 +36,33 @@ def test_policy_fixed(attempts, default):
     assert default.get_delay_interval(attempts) == default.delay
 
 
-@pytest.mark.parametrize("attempts", ATTEMPTS)
-def test_policy_linear(attempts, linear):
-    assert linear.get_delay_interval(attempts) == linear.delay * attempts
+def test_policy_linear_first_retry_is_not_zero(linear):
+    """First retry (attempts_so_far=0) must return delay, not 0.
+
+    This is the regression case: the original formula `delay * attempts_so_far`
+    produced 0 on the first retry. The correct formula is `delay * (attempts_so_far + 1)`.
+    """
+    assert linear.get_delay_interval(0) == linear.delay * 1
+
+
+def test_policy_linear_second_retry(linear):
+    assert linear.get_delay_interval(1) == linear.delay * 2
+
+
+def test_policy_linear_third_retry(linear):
+    assert linear.get_delay_interval(2) == linear.delay * 3
+
+
+def test_policy_linear_caps_at_delay_max():
+    """Delay is capped at delay_max regardless of attempts_so_far."""
+    # With delay=30 and delay_max=60, attempts_so_far=10 gives 30*11=330 — cap kicks in.
+    policy = retries.RetryPolicy(
+        max_tries=20,
+        delay=30,
+        delay_max=60,
+        retry_mode=retries.RetryMode.Linear,
+    )
+    assert policy.get_delay_interval(10) == policy.delay_max
 
 
 @pytest.mark.parametrize("attempts", ATTEMPTS)

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -28,7 +28,5 @@ async def test_debug_task_retry_policy_default():
 async def test_debug_task_retry_policy_exponential():
     """Test debug_task_retry_policy raises RetryExceptionDefaultExponential when use_default is False."""
     with pytest.raises(Exception) as exc:
-        await debug_task_retry_policy(
-            DummyState, False, msg="EXPONENTIAL", max_tries=3, delay=10, delay_max=100
-        )
+        await debug_task_retry_policy(DummyState, False, msg="EXPONENTIAL", max_tries=3, delay=10, delay_max=100)
     assert "EXPONENTIAL" in str(exc.value)

--- a/uv.lock
+++ b/uv.lock
@@ -351,7 +351,7 @@ wheels = [
 
 [[package]]
 name = "boilermaker-servicebus"
-version = "1.0.0.dev4"
+version = "1.0.0.dev5"
 source = { editable = "." }
 dependencies = [
     { name = "aio-azure-clients-toolbox" },
@@ -402,30 +402,30 @@ provides-extras = ["repl"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "build", specifier = ">=1.4.2" },
+    { name = "build", specifier = ">=1.4.3" },
     { name = "mkdocs", specifier = ">=1.5.0" },
     { name = "mkdocs-material", specifier = ">=9.7.6" },
     { name = "mkdocs-mermaid2-plugin", specifier = ">=1.2.3" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0.3" },
-    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
-    { name = "ruff", specifier = ">=0.15.8" },
-    { name = "ty", specifier = ">=0.0.27" },
+    { name = "ruff", specifier = ">=0.15.10" },
+    { name = "ty", specifier = ">=0.0.29" },
 ]
 
 [[package]]
 name = "build"
-version = "1.4.2"
+version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "os_name == 'nt'" },
     { name = "packaging" },
     { name = "pyproject-hooks" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6c/1d/ab15c8ac57f4ee8778d7633bc6685f808ab414437b8644f555389cdc875e/build-1.4.2.tar.gz", hash = "sha256:35b14e1ee329c186d3f08466003521ed7685ec15ecffc07e68d706090bf161d1", size = 83433, upload-time = "2026-03-25T14:20:27.659Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/16/4b272700dea44c1d2e8ca963ebb3c684efe22b3eba8cfa31c5fdb60de707/build-1.4.3.tar.gz", hash = "sha256:5aa4231ae0e807efdf1fd0623e07366eca2ab215921345a2e38acdd5d0fa0a74", size = 89314, upload-time = "2026-04-10T21:25:40.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/57/3b7d4dd193ade4641c865bc2b93aeeb71162e81fc348b8dad020215601ed/build-1.4.2-py3-none-any.whl", hash = "sha256:7a4d8651ea877cb2a89458b1b198f2e69f536c95e89129dbf5d448045d60db88", size = 24643, upload-time = "2026-03-25T14:20:26.568Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/30/f169e1d8b2071beaf8b97088787e30662b1d8fb82f8c0941d14678c0cbf1/build-1.4.3-py3-none-any.whl", hash = "sha256:1bc22b19b383303de8f2c8554c9a32894a58d3f185fe3756b0b20d255bee9a38", size = 26171, upload-time = "2026-04-10T21:25:39.671Z" },
 ]
 
 [[package]]
@@ -1771,7 +1771,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1780,9 +1780,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -1917,27 +1917,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.8"
+version = "0.15.10"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/14/b0/73cf7550861e2b4824950b8b52eebdcc5adc792a00c514406556c5b80817/ruff-0.15.8.tar.gz", hash = "sha256:995f11f63597ee362130d1d5a327a87cb6f3f5eae3094c620bcc632329a4d26e", size = 4610921, upload-time = "2026-03-26T18:39:38.675Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/d9/aa3f7d59a10ef6b14fe3431706f854dbf03c5976be614a9796d36326810c/ruff-0.15.10.tar.gz", hash = "sha256:d1f86e67ebfdef88e00faefa1552b5e510e1d35f3be7d423dc7e84e63788c94e", size = 4631728, upload-time = "2026-04-09T14:06:09.884Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/92/c445b0cd6da6e7ae51e954939cb69f97e008dbe750cfca89b8cedc081be7/ruff-0.15.8-py3-none-linux_armv6l.whl", hash = "sha256:cbe05adeba76d58162762d6b239c9056f1a15a55bd4b346cfd21e26cd6ad7bc7", size = 10527394, upload-time = "2026-03-26T18:39:41.566Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/92/f1c662784d149ad1414cae450b082cf736430c12ca78367f20f5ed569d65/ruff-0.15.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:d3e3d0b6ba8dca1b7ef9ab80a28e840a20070c4b62e56d675c24f366ef330570", size = 10905693, upload-time = "2026-03-26T18:39:30.364Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/f2/7a631a8af6d88bcef997eb1bf87cc3da158294c57044aafd3e17030613de/ruff-0.15.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6ee3ae5c65a42f273f126686353f2e08ff29927b7b7e203b711514370d500de3", size = 10323044, upload-time = "2026-03-26T18:39:33.37Z" },
-    { url = "https://files.pythonhosted.org/packages/67/18/1bf38e20914a05e72ef3b9569b1d5c70a7ef26cd188d69e9ca8ef588d5bf/ruff-0.15.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fdce027ada77baa448077ccc6ebb2fa9c3c62fd110d8659d601cf2f475858d94", size = 10629135, upload-time = "2026-03-26T18:39:44.142Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/e9/138c150ff9af60556121623d41aba18b7b57d95ac032e177b6a53789d279/ruff-0.15.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12e617fc01a95e5821648a6df341d80456bd627bfab8a829f7cfc26a14a4b4a3", size = 10348041, upload-time = "2026-03-26T18:39:52.178Z" },
-    { url = "https://files.pythonhosted.org/packages/02/f1/5bfb9298d9c323f842c5ddeb85f1f10ef51516ac7a34ba446c9347d898df/ruff-0.15.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:432701303b26416d22ba696c39f2c6f12499b89093b61360abc34bcc9bf07762", size = 11121987, upload-time = "2026-03-26T18:39:55.195Z" },
-    { url = "https://files.pythonhosted.org/packages/10/11/6da2e538704e753c04e8d86b1fc55712fdbdcc266af1a1ece7a51fff0d10/ruff-0.15.8-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d910ae974b7a06a33a057cb87d2a10792a3b2b3b35e33d2699fdf63ec8f6b17a", size = 11951057, upload-time = "2026-03-26T18:39:19.18Z" },
-    { url = "https://files.pythonhosted.org/packages/83/f0/c9208c5fd5101bf87002fed774ff25a96eea313d305f1e5d5744698dc314/ruff-0.15.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2033f963c43949d51e6fdccd3946633c6b37c484f5f98c3035f49c27395a8ab8", size = 11464613, upload-time = "2026-03-26T18:40:06.301Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/22/d7f2fabdba4fae9f3b570e5605d5eb4500dcb7b770d3217dca4428484b17/ruff-0.15.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f29b989a55572fb885b77464cf24af05500806ab4edf9a0fd8977f9759d85b1", size = 11257557, upload-time = "2026-03-26T18:39:57.972Z" },
-    { url = "https://files.pythonhosted.org/packages/71/8c/382a9620038cf6906446b23ce8632ab8c0811b8f9d3e764f58bedd0c9a6f/ruff-0.15.8-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:ac51d486bf457cdc985a412fb1801b2dfd1bd8838372fc55de64b1510eff4bec", size = 11169440, upload-time = "2026-03-26T18:39:22.205Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/0d/0994c802a7eaaf99380085e4e40c845f8e32a562e20a38ec06174b52ef24/ruff-0.15.8-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c9861eb959edab053c10ad62c278835ee69ca527b6dcd72b47d5c1e5648964f6", size = 10605963, upload-time = "2026-03-26T18:39:46.682Z" },
-    { url = "https://files.pythonhosted.org/packages/19/aa/d624b86f5b0aad7cef6bbf9cd47a6a02dfdc4f72c92a337d724e39c9d14b/ruff-0.15.8-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8d9a5b8ea13f26ae90838afc33f91b547e61b794865374f114f349e9036835fb", size = 10357484, upload-time = "2026-03-26T18:39:49.176Z" },
-    { url = "https://files.pythonhosted.org/packages/35/c3/e0b7835d23001f7d999f3895c6b569927c4d39912286897f625736e1fd04/ruff-0.15.8-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c2a33a529fb3cbc23a7124b5c6ff121e4d6228029cba374777bd7649cc8598b8", size = 10830426, upload-time = "2026-03-26T18:40:03.702Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/51/ab20b322f637b369383adc341d761eaaa0f0203d6b9a7421cd6e783d81b9/ruff-0.15.8-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:75e5cd06b1cf3f47a3996cfc999226b19aa92e7cce682dcd62f80d7035f98f49", size = 11345125, upload-time = "2026-03-26T18:39:27.799Z" },
-    { url = "https://files.pythonhosted.org/packages/37/e6/90b2b33419f59d0f2c4c8a48a4b74b460709a557e8e0064cf33ad894f983/ruff-0.15.8-py3-none-win32.whl", hash = "sha256:bc1f0a51254ba21767bfa9a8b5013ca8149dcf38092e6a9eb704d876de94dc34", size = 10571959, upload-time = "2026-03-26T18:39:36.117Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/a2/ef467cb77099062317154c63f234b8a7baf7cb690b99af760c5b68b9ee7f/ruff-0.15.8-py3-none-win_amd64.whl", hash = "sha256:04f79eff02a72db209d47d665ba7ebcad609d8918a134f86cb13dd132159fc89", size = 11743893, upload-time = "2026-03-26T18:39:25.01Z" },
-    { url = "https://files.pythonhosted.org/packages/15/e2/77be4fff062fa78d9b2a4dea85d14785dac5f1d0c1fb58ed52331f0ebe28/ruff-0.15.8-py3-none-win_arm64.whl", hash = "sha256:cf891fa8e3bb430c0e7fac93851a5978fc99c8fa2c053b57b118972866f8e5f2", size = 11048175, upload-time = "2026-03-26T18:40:01.06Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/00/a1c2fdc9939b2c03691edbda290afcd297f1f389196172826b03d6b6a595/ruff-0.15.10-py3-none-linux_armv6l.whl", hash = "sha256:0744e31482f8f7d0d10a11fcbf897af272fefdfcb10f5af907b18c2813ff4d5f", size = 10563362, upload-time = "2026-04-09T14:06:21.189Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/15/006990029aea0bebe9d33c73c3e28c80c391ebdba408d1b08496f00d422d/ruff-0.15.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b1e7c16ea0ff5a53b7c2df52d947e685973049be1cdfe2b59a9c43601897b22e", size = 10951122, upload-time = "2026-04-09T14:06:02.236Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c0/4ac978fe874d0618c7da647862afe697b281c2806f13ce904ad652fa87e4/ruff-0.15.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:93cc06a19e5155b4441dd72808fdf84290d84ad8a39ca3b0f994363ade4cebb1", size = 10314005, upload-time = "2026-04-09T14:06:00.026Z" },
+    { url = "https://files.pythonhosted.org/packages/da/73/c209138a5c98c0d321266372fc4e33ad43d506d7e5dd817dd89b60a8548f/ruff-0.15.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83e1dd04312997c99ea6965df66a14fb4f03ba978564574ffc68b0d61fd3989e", size = 10643450, upload-time = "2026-04-09T14:05:42.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/76/0deec355d8ec10709653635b1f90856735302cb8e149acfdf6f82a5feb70/ruff-0.15.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8154d43684e4333360fedd11aaa40b1b08a4e37d8ffa9d95fee6fa5b37b6fab1", size = 10379597, upload-time = "2026-04-09T14:05:49.984Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/be/86bba8fc8798c081e28a4b3bb6d143ccad3fd5f6f024f02002b8f08a9fa3/ruff-0.15.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ab88715f3a6deb6bde6c227f3a123410bec7b855c3ae331b4c006189e895cef", size = 11146645, upload-time = "2026-04-09T14:06:12.246Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/89/140025e65911b281c57be1d385ba1d932c2366ca88ae6663685aed8d4881/ruff-0.15.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a768ff5969b4f44c349d48edf4ab4f91eddb27fd9d77799598e130fb628aa158", size = 12030289, upload-time = "2026-04-09T14:06:04.776Z" },
+    { url = "https://files.pythonhosted.org/packages/88/de/ddacca9545a5e01332567db01d44bd8cf725f2db3b3d61a80550b48308ea/ruff-0.15.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ee3ef42dab7078bda5ff6a1bcba8539e9857deb447132ad5566a038674540d0", size = 11496266, upload-time = "2026-04-09T14:05:55.485Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/bb/7ddb00a83760ff4a83c4e2fc231fd63937cc7317c10c82f583302e0f6586/ruff-0.15.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51cb8cc943e891ba99989dd92d61e29b1d231e14811db9be6440ecf25d5c1609", size = 11256418, upload-time = "2026-04-09T14:05:57.69Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8d/55de0d35aacf6cd50b6ee91ee0f291672080021896543776f4170fc5c454/ruff-0.15.10-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e59c9bdc056a320fb9ea1700a8d591718b8faf78af065484e801258d3a76bc3f", size = 11288416, upload-time = "2026-04-09T14:05:44.695Z" },
+    { url = "https://files.pythonhosted.org/packages/68/cf/9438b1a27426ec46a80e0a718093c7f958ef72f43eb3111862949ead3cc1/ruff-0.15.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:136c00ca2f47b0018b073f28cb5c1506642a830ea941a60354b0e8bc8076b151", size = 10621053, upload-time = "2026-04-09T14:05:52.782Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/50/e29be6e2c135e9cd4cb15fbade49d6a2717e009dff3766dd080fcb82e251/ruff-0.15.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8b80a2f3c9c8a950d6237f2ca12b206bccff626139be9fa005f14feb881a1ae8", size = 10378302, upload-time = "2026-04-09T14:06:14.361Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2f/e0b36a6f99c51bb89f3a30239bc7bf97e87a37ae80aa2d6542d6e5150364/ruff-0.15.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:e3e53c588164dc025b671c9df2462429d60357ea91af7e92e9d56c565a9f1b07", size = 10850074, upload-time = "2026-04-09T14:06:16.581Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/874da392558ce087a0f9b709dc6ec0d60cbc694c1c772dab8d5f31efe8cb/ruff-0.15.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b0c52744cf9f143a393e284125d2576140b68264a93c6716464e129a3e9adb48", size = 11358051, upload-time = "2026-04-09T14:06:18.948Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/46/602938f030adfa043e67112b73821024dc79f3ab4df5474c25fa4c1d2d14/ruff-0.15.10-py3-none-win32.whl", hash = "sha256:d4272e87e801e9a27a2e8df7b21011c909d9ddd82f4f3281d269b6ba19789ca5", size = 10588964, upload-time = "2026-04-09T14:06:07.14Z" },
+    { url = "https://files.pythonhosted.org/packages/25/b6/261225b875d7a13b33a6d02508c39c28450b2041bb01d0f7f1a83d569512/ruff-0.15.10-py3-none-win_amd64.whl", hash = "sha256:28cb32d53203242d403d819fd6983152489b12e4a3ae44993543d6fe62ab42ed", size = 11745044, upload-time = "2026-04-09T14:05:39.473Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ed/dea90a65b7d9e69888890fb14c90d7f51bf0c1e82ad800aeb0160e4bacfd/ruff-0.15.10-py3-none-win_arm64.whl", hash = "sha256:601d1610a9e1f1c2165a4f561eeaa2e2ea1e97f3287c5aa258d3dab8b57c6188", size = 11035607, upload-time = "2026-04-09T14:05:47.593Z" },
 ]
 
 [[package]]
@@ -2040,26 +2040,26 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.27"
+version = "0.0.29"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f4/de/e5cf1f151cf52fe1189e42d03d90909d7d1354fdc0c1847cbb63a0baa3da/ty-0.0.27.tar.gz", hash = "sha256:d7a8de3421d92420b40c94fe7e7d4816037560621903964dd035cf9bd0204a73", size = 5424130, upload-time = "2026-03-31T19:07:20.806Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d5/853561de49fae38c519e905b2d8da9c531219608f1fccc47a0fc2c896980/ty-0.0.29.tar.gz", hash = "sha256:e7936cca2f691eeda631876c92809688dbbab68687c3473f526cd83b6a9228d8", size = 5469221, upload-time = "2026-04-05T15:01:21.328Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/20/2a9ea661758bd67f2bfd54ce9daacb5a26c56c5f8b49fbd9a43b365a8a7d/ty-0.0.27-py3-none-linux_armv6l.whl", hash = "sha256:eb14456b8611c9e8287aa9b633f4d2a0d9f3082a31796969e0b50bdda8930281", size = 10571211, upload-time = "2026-03-31T19:07:23.28Z" },
-    { url = "https://files.pythonhosted.org/packages/da/b2/8887a51f705d075ddbe78ae7f0d4755ef48d0a90235f67aee289e9cee950/ty-0.0.27-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:02e662184703db7586118df611cf24a000d35dae38d950053d1dd7b6736fd2c4", size = 10427576, upload-time = "2026-03-31T19:07:15.499Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/c3/79d88163f508fb709ce19bc0b0a66c7c64b53d372d4caa56172c3d9b3ae8/ty-0.0.27-py3-none-macosx_11_0_arm64.whl", hash = "sha256:be5fc2899441f7f8f7ef40f9ffd006075a5ff6b06c44e8d2aa30e1b900c12f51", size = 9870359, upload-time = "2026-03-31T19:07:36.852Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/4d/ed1b0db0e1e46b5ed4976bbfe0d1825faf003b4e3774ef28c785ed73e4bb/ty-0.0.27-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30231e652b14742a76b64755e54bf0cb1cd4c128bcaf625222e0ca92a2094887", size = 10380488, upload-time = "2026-03-31T19:07:31.268Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/f2/20372f6d510b01570028433064880adec2f8abe68bf0c4603be61a560bef/ty-0.0.27-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5a119b1168f64261b3205a37e40b5b6c4aac8fd58e4587988f4e4b22c3c79847", size = 10390248, upload-time = "2026-03-31T19:07:28.345Z" },
-    { url = "https://files.pythonhosted.org/packages/45/4b/46b31a7311306be1a560f7f20fdc37b5bf718787f60626cd265d9b637554/ty-0.0.27-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e38f4e187b6975d2cbebf0f1eb1221f8f64f6e509bad14d7bb2a91afc97e4956", size = 10878479, upload-time = "2026-03-31T19:07:39.393Z" },
-    { url = "https://files.pythonhosted.org/packages/42/ba/5231a2a1fb1cebe053a25de8fded95e1a30a1e77d3628a9e58487297bafc/ty-0.0.27-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a07b1a8fbb23844f6d22091275430d9ac617175f34aa99159b268193de210389", size = 11461232, upload-time = "2026-03-31T19:07:02.518Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/37/558abab3e1f6670493524f61280b4dfcc3219555f13889223e733381dfab/ty-0.0.27-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d3ec4033031f240836bb0337274bac5c49dde312c7c6d7575451ed719bf8ffa3", size = 11133002, upload-time = "2026-03-31T19:07:18.371Z" },
-    { url = "https://files.pythonhosted.org/packages/32/38/188c14a57f52160407ce62c6abb556011718fd0bcbe1dca690529ce84c46/ty-0.0.27-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:924a8849afd500d260bf5b7296165a05b7424fbb6b19113f30f3b999d682873f", size = 10986624, upload-time = "2026-03-31T19:07:13.066Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/f1/667a71393f47d2cd6ba9ed07541b8df3eb63aab1f2ee658e77d91b8362fa/ty-0.0.27-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d8270026c07e7423a1b3a3fd065b46ed1478748f0662518b523b57744f3fa025", size = 10366721, upload-time = "2026-03-31T19:07:00.131Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/aa/8edafe41be898bda774249abc5be6edd733e53fb1777d59ea9331e38537d/ty-0.0.27-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e26e9735d3bdfd95d881111ad1cf570eab8188d8c3be36d6bcaad044d38984d8", size = 10412239, upload-time = "2026-03-31T19:07:05.297Z" },
-    { url = "https://files.pythonhosted.org/packages/53/ff/8bafaed4a18d38264f46bdfc427de7ea2974cf9064e4e0bdb1b6e6c724e3/ty-0.0.27-py3-none-musllinux_1_2_i686.whl", hash = "sha256:7c09cc9a699810609acc0090af8d0db68adaee6e60a7c3e05ab80cc954a83db7", size = 10573507, upload-time = "2026-03-31T19:06:57.064Z" },
-    { url = "https://files.pythonhosted.org/packages/16/2e/63a8284a2fefd08ab56ecbad0fde7dd4b2d4045a31cf24c1d1fcd9643227/ty-0.0.27-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2d3e02853bb037221a456e034b1898aaa573e6374fbb53884e33cb7513ccb85a", size = 11090233, upload-time = "2026-03-31T19:07:34.139Z" },
-    { url = "https://files.pythonhosted.org/packages/14/d3/d6fa1cafdfa2b34dbfa304fc6833af8e1669fc34e24d214fa76d2a2e5a25/ty-0.0.27-py3-none-win32.whl", hash = "sha256:34e7377f2047c14dbbb7bf5322e84114db7a5f2cb470db6bee63f8f3550cfc1e", size = 9984415, upload-time = "2026-03-31T19:07:07.98Z" },
-    { url = "https://files.pythonhosted.org/packages/85/e6/dd4e27da9632b3472d5711ca49dbd3709dbd3e8c73f3af6db9c254235ca9/ty-0.0.27-py3-none-win_amd64.whl", hash = "sha256:3f7e4145aad8b815ed69b324c93b5b773eb864dda366ca16ab8693ff88ce6f36", size = 10961535, upload-time = "2026-03-31T19:07:10.566Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/1a/824b3496d66852ed7d5d68d9787711131552b68dce8835ce9410db32e618/ty-0.0.27-py3-none-win_arm64.whl", hash = "sha256:95bf8d01eb96bb2ba3ffc39faff19da595176448e80871a7b362f4d2de58476c", size = 10376689, upload-time = "2026-03-31T19:07:25.732Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b7/911f9962115acfa24e3b2ec9d4992dd994c38e8769e1b1d7680bb4d28a51/ty-0.0.29-py3-none-linux_armv6l.whl", hash = "sha256:b8a40955f7660d3eaceb0d964affc81b790c0765e7052921a5f861ff8a471c30", size = 10568206, upload-time = "2026-04-05T15:01:19.165Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c3/fcae2167d4c77a97269f92f11d1b43b03617f81de1283d5d05b43432110c/ty-0.0.29-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6b6849adae15b00bbe2d3c5b078967dcb62eba37d38936b8eeb4c81a82d2e3b8", size = 10442530, upload-time = "2026-04-05T15:01:28.471Z" },
+    { url = "https://files.pythonhosted.org/packages/97/33/5a6bfa240cfcb9c36046ae2459fa9ea23238d20130d8656ff5ac4d6c012a/ty-0.0.29-py3-none-macosx_11_0_arm64.whl", hash = "sha256:dcdd9b17209788152f7b7ea815eda07989152325052fe690013537cc7904ce49", size = 9915735, upload-time = "2026-04-05T15:01:10.365Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/1e/318f45fae232118e81a6306c30f50de42c509c412128d5bd231eab699ffb/ty-0.0.29-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9d8ed4789bae78ffaf94462c0d25589a734cab0366b86f2bbcb1bb90e1a7a169", size = 10419748, upload-time = "2026-04-05T15:01:32.375Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/a8/5687872e2ab5a0f7dd4fd8456eac31e9381ad4dc74961f6f29965ad4dd91/ty-0.0.29-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:91ec374b8565e0ad0900011c24641ebbef2da51adbd4fb69ff3280c8a7eceb02", size = 10394738, upload-time = "2026-04-05T15:01:06.473Z" },
+    { url = "https://files.pythonhosted.org/packages/de/68/015d118097eeb95e6a44c4abce4c0a28b7b9dfb3085b7f0ee48e4f099633/ty-0.0.29-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:298a8d5faa2502d3810bbbb47a030b9455495b9921594206043c785dd61548cf", size = 10910613, upload-time = "2026-04-05T15:01:17.17Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/01/47ce3c6c53e0670eadbe80756b167bf80ed6681d1ba57cfde2e8065a13d1/ty-0.0.29-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3c8fba1a3524c6109d1e020d92301c79d41bf442fa8d335b9fa366239339cb70", size = 11475750, upload-time = "2026-04-05T15:01:30.461Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/cf/e361845b1081c9264ad5b7c963231bab03f2666865a9f2a115c4233f2137/ty-0.0.29-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4c48adf88a70d264128c39ee922ed14a947817fced1e93c08c1a89c9244edcde", size = 11190055, upload-time = "2026-04-05T15:01:12.369Z" },
+    { url = "https://files.pythonhosted.org/packages/79/12/0fb0857e9a62cb11586e9a712103877bbf717f5fb570d16634408cfdefee/ty-0.0.29-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ce0a7a0e96bc7b42518cd3a1a6a6298ef64ff40ca4614355c1aa807059b5c6f", size = 11020539, upload-time = "2026-04-05T15:01:37.022Z" },
+    { url = "https://files.pythonhosted.org/packages/20/36/5a26753802083f80cd125db6c4348ad42b3c982ec36e718e0bf4c18f75e5/ty-0.0.29-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6ac86a05b4a3731d45365ab97780acc7b8146fa62fccb3cbe94fe6546c67a97", size = 10396399, upload-time = "2026-04-05T15:01:26.167Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e6/b4e75b5752239ab3ab400f19faef4dbef81d05aab5d3419fda0c062a3765/ty-0.0.29-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:6bbbf53141af0f3150bf288d716263f1a3550054e4b3551ca866d38192ba9891", size = 10421461, upload-time = "2026-04-05T15:01:08.367Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/21/1084b5b609f9abed62070ec0b31c283a403832a6310c8bbc208bd45ee1e6/ty-0.0.29-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1c9e06b770c1d0ff5efc51e34312390db31d53fcf3088163f413030b42b74f84", size = 10599187, upload-time = "2026-04-05T15:01:23.52Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a1/ce19a2ca717bbcc1ee11378aba52ef70b6ce5b87245162a729d9fdc2360f/ty-0.0.29-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:0307fe37e3f000ef1a4ae230bbaf511508a78d24a5e51b40902a21b09d5e6037", size = 11121198, upload-time = "2026-04-05T15:01:15.22Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/6b/f1430b279af704321566ce7ec2725d3d8258c2f815ebd93e474c64cd4543/ty-0.0.29-py3-none-win32.whl", hash = "sha256:7a2a898217960a825f8bc0087e1fdbaf379606175e98f9807187221d53a4a8ed", size = 9995331, upload-time = "2026-04-05T15:01:01.32Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ef/3ef01c17785ff9a69378465c7d0faccd48a07b163554db0995e5d65a5a23/ty-0.0.29-py3-none-win_amd64.whl", hash = "sha256:fc1294200226b91615acbf34e0a9ad81caf98c081e9c6a912a31b0a7b603bc3f", size = 11023644, upload-time = "2026-04-05T15:01:04.432Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/55/87280a994d6a2d2647c65e12abbc997ed49835794366153c04c4d9304d76/ty-0.0.29-py3-none-win_arm64.whl", hash = "sha256:f9794bbd1bb3ce13f78c191d0c89ae4c63f52c12b6daa0c6fe220b90d019d12c", size = 10428165, upload-time = "2026-04-05T15:01:34.665Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
For TaskGraphs, we want to make sure that we eliminate safety guarantee violations around writing results multiple times. We had guarded launching tasks pretty well, but we were nervous about leaving unfinished TaskGraphs in an at-least-once delivery-guarantee environment, so we were indiscriminately letting workers write results back saying "I started!". 

The problem is that for tasks in a terminal state, it's possible they get redelivered (in particular in cases where message lease has been lost, but even without this).

Thus, we really need to compare-and-swap the *potentially*-written result when starting (instead of just clobbering result with whoever is starting the thing).