### PR TITLE
Fix for "Pending" on message reread

### DIFF
--- a/boilermaker/evaluators/task_graph.py
+++ b/boilermaker/evaluators/task_graph.py
@@ -218,20 +218,28 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                         status=TaskStatus.Started,
                     )
 
-                if _reread.status == TaskStatus.Scheduled:
-                    # The scheduler wrote Scheduled and released its lease before the
-                    # SB message was consumed.  No other worker holds Started yet —
-                    # this worker should claim execution by retrying the Started write
-                    # using the etag from the Scheduled blob.
-                    # Spec action: WriteStarted412 (Scheduled branch) →
+                if _reread.status in (TaskStatus.Scheduled, TaskStatus.Pending):
+                    # No other worker holds Started yet — retry the CAS with the
+                    # re-read etag.
+                    #
+                    # Scheduled: normal publish-before-store window; scheduler wrote
+                    #   Scheduled and released its lease before this worker consumed
+                    #   the SB message.
+                    # Pending:   lease acquire bumped the blob ETag (Azure advances the
+                    #   ETag on BlobLeaseClient.acquire() even without a content write)
+                    #   but the scheduler has not yet written Scheduled (or
+                    #   WriteScheduledFail left the blob Pending).  Either way no other
+                    #   worker holds Started, so this worker is the legitimate claimant.
+                    #
+                    # Spec action: WriteStarted412 (Scheduled/Pending branch) →
                     #              RetryStartedAfterScheduled
                     if _reread.etag is None:
                         logger.warning(
-                            f"412 + Scheduled re-read for task {self.task.task_id}: "
+                            f"412 + {_reread.status.value} re-read for task {self.task.task_id}: "
                             "re-read etag is None — degraded to unconditional retry write"
                         )
                     logger.warning(
-                        f"412 + Scheduled for task {self.task.task_id}; "
+                        f"412 + {_reread.status.value} for task {self.task.task_id}; "
                         "retrying Started write with re-read etag"
                     )
                     try:
@@ -304,7 +312,6 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                                     status=TaskStatus.Failure,
                                     errors=["two 412s on Started write; unexpected state after second re-read"],
                                 )
-
                 else:
                     # Truly unexpected status after 412 (not None, finished, Started, or Scheduled).
                     # Settle the message to avoid orphaning it on SB lock expiry.

--- a/boilermaker/task/graph.py
+++ b/boilermaker/task/graph.py
@@ -61,7 +61,7 @@ class TaskGraph(BaseModel):
     StorageName: typing.ClassVar[str] = "graph.json"
 
     # The graph has an ID
-    graph_id: GraphId = ident_field()
+    graph_id: GraphId = GraphId(ident_field())
     # Children is a mapping of task IDs to tasks
     children: dict[TaskId, Task] = Field(default_factory=dict)
     # Failure children is a mapping of task IDs to tasks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boilermaker-servicebus"
-version = "1.0.1a1"
+version = "1.0.1a3"
 description = "An async python Background task system using Azure Service Bus Queues"
 authors = [{ "name" = "Erik Aker", "email" = "eaker@mulliganfunding.com" }]
 license = { file = "LICENSE" }

--- a/specs/TaskGraph.tla
+++ b/specs/TaskGraph.tla
@@ -2,7 +2,7 @@
 EXTENDS TaskGraphSpecBase
 
 WorkerSet == {"w1", "w2"}
-TaskSet == {"t1", "t2", "t3"}
+TaskSet == {"t1", "t2"}
 RootTaskSet == {"t1"}
-DefaultEdges == {<<"t1", "t2">>, << "t2", "t3">>}
+DefaultEdges == {<<"t1", "t2">>}
 =============================================================================

--- a/specs/TaskGraphSpecBase.tla
+++ b/specs/TaskGraphSpecBase.tla
@@ -295,22 +295,24 @@ WriteStartedSuccess(w) ==
                        workerSnapshot, workerSnapshotEtags,
                        workerReadySet, workerCurrentReady>>
 
-\* Sub-action: 412 — etag mismatch; re-read blob and branch (FIXED)
+\* Sub-action: 412 — etag mismatch; re-read blob and branch
 \* We model the re-read as instantaneous (reading current blobStatus).
 \* The 412 branch covers all cases:
 \*   None      -> Completing (blob vanished — unexpected; always settle)
 \*   terminal  -> Completing (complete message)
 \*   Started   -> Completing (complete message; another worker won)
-\*   Scheduled -> RetryStartedAfterScheduled [THE FIX: retry with re-read etag]
+\*   Scheduled -> RetryStartedAfterScheduled (retry with re-read etag)
+\*   Pending   -> RetryStartedAfterScheduled (retry with re-read etag; same as Scheduled)
+\*               Lease acquire bumped the ETag without changing content.  No other
+\*               worker holds Started, so this worker is the legitimate claimant.
 \*   other     -> Completing (always settle)
 \*
 \* Since blobStatus[t] is always defined (never None) in this model, the
-\* "blob vanished" branch is unreachable. The Scheduled branch now retries
-\* instead of returning Failure without settling.
+\* "blob vanished" branch is unreachable.
 \*
 \* IMPORTANT: when transitioning to RetryStartedAfterScheduled, we capture the
-\* current blob etag (the etag from the Scheduled write) into workerCapturedEtag.
-\* The retry will use this etag for the second CAS attempt.
+\* current blob etag into workerCapturedEtag.  The retry will use this etag for
+\* the second CAS attempt.
 WriteStarted412(w) ==
     /\ workerPhase[w] = "WroteStarted"
     /\ LET t    == workerTask[w]
@@ -330,18 +332,22 @@ WriteStarted412(w) ==
                              workerMsg, workerTask, workerResult, workerCapturedEtag,
                              workerSnapshot, workerSnapshotEtags,
                              workerReadySet, workerCurrentReady>>
-          \/ \* Re-read is Scheduled: THE FIX — retry Started write with re-read etag
-             /\ rereadStatus = "Scheduled"
+          \/ \* Re-read is Scheduled or Pending: no worker owns Started yet —
+             \* retry the Started write with the re-read etag.
+             \* Pending:   lease acquire bumped the ETag (AcquireLeaseSuccess) but the
+             \*             Scheduled write has not yet happened (or WriteScheduledFail).
+             \* Scheduled: normal publish-before-store window.
+             /\ rereadStatus \in {"Scheduled", "Pending"}
              /\ workerPhase' = [workerPhase EXCEPT ![w] = "RetryStartedAfterScheduled"]
-             \* Capture the re-read etag (from the Scheduled blob) for the retry CAS
+             \* Capture the re-read etag for the retry CAS
              /\ workerCapturedEtag' = [workerCapturedEtag EXCEPT ![w] = rereadEtag]
              /\ UNCHANGED <<blobStatus, blobEtag, blobLeased, blobDeadLettered, sbMessages,
                              workerMsg, workerTask, workerResult,
                              workerSnapshot, workerSnapshotEtags,
                              workerReadySet, workerCurrentReady>>
-          \/ \* Re-read is some other non-terminal, non-Started, non-Scheduled status:
+          \/ \* Re-read is some other non-terminal, non-Started, non-Scheduled, non-Pending status:
              \* always settle (complete message, return Failure)
-             /\ rereadStatus \notin TerminalStatuses \cup {"Started", "Scheduled"}
+             /\ rereadStatus \notin TerminalStatuses \cup {"Started", "Scheduled", "Pending"}
              /\ workerPhase' = [workerPhase EXCEPT ![w] = "Completing"]
              /\ UNCHANGED <<blobStatus, blobEtag, blobLeased, blobDeadLettered, sbMessages,
                              workerMsg, workerTask, workerResult, workerCapturedEtag,
@@ -349,12 +355,13 @@ WriteStarted412(w) ==
                              workerReadySet, workerCurrentReady>>
 
 \* ===== RetryStartedWrite =====
-\* Worker retries the Started write using the etag captured from the Scheduled re-read.
-\* This is the core of the fix: the Scheduled -> Started transition is the legitimate
-\* forward move; we own the SB message, so we should try to make progress.
+\* Worker retries the Started write using the etag captured from the re-read.
+\* Entered from WriteStarted412 when the re-read status is Scheduled or Pending.
+\* In both cases no other worker holds Started, so this worker is the legitimate
+\* claimant and should try to make progress.
 \*
 \* Three outcomes:
-\*   CAS succeeds (etag still matches Scheduled write): blob -> Started, proceed to Executing.
+\*   CAS succeeds (etag still matches re-read etag): blob -> Started, proceed to Executing.
 \*   CAS 412 again (someone else mutated blob): proceed to RereadAfterRetry412.
 \*   Non-412 storage error: proceed to Executing anyway (fail-open, same as original).
 RetryStartedWriteSuccess(w) ==
@@ -525,6 +532,13 @@ StatusMismatchCheck(w) ==
 \* On success: move to PublishingTask with workerCurrentReady set.
 \* On failure: remove from readySet (skip), stay in AcquiringLease.
 \* When readySet is empty: transition to Completing.
+\*
+\* ETag bump on lease acquire: Azure Blob Storage advances the blob's ETag when
+\* BlobLeaseClient.acquire() succeeds, even though the blob content (status) does
+\* not change.  We model this as blobEtag[child] + 1.  This is the root cause of
+\* the 412+Pending race: a worker that read the blob before the lease acquire will
+\* hold a stale ETag and get a 412 on its Started write, with the re-read returning
+\* Pending (status unchanged by the lease acquire).  See WriteStarted412 below.
 
 AcquireLeaseSuccess(w) ==
     /\ workerPhase[w] = "AcquiringLease"
@@ -537,10 +551,12 @@ AcquireLeaseSuccess(w) ==
         /\ blobStatus[child] = "Pending"
         /\ ~blobLeased[child]
         /\ blobLeased' = [blobLeased EXCEPT ![child] = TRUE]
+        \* Azure bumps the ETag on lease acquire even with no content change.
+        /\ blobEtag'   = [blobEtag   EXCEPT ![child] = blobEtag[child] + 1]
         /\ workerCurrentReady' = [workerCurrentReady EXCEPT ![w] = child]
         /\ workerReadySet' = [workerReadySet EXCEPT ![w] = workerReadySet[w] \ {child}]
         /\ workerPhase' = [workerPhase EXCEPT ![w] = "PublishingTask"]
-        /\ UNCHANGED <<blobStatus, blobEtag, blobDeadLettered, sbMessages, workerMsg, workerTask,
+        /\ UNCHANGED <<blobStatus, blobDeadLettered, sbMessages, workerMsg, workerTask,
                         workerResult, workerCapturedEtag,
                         workerSnapshot, workerSnapshotEtags>>
 

--- a/tests/evaluators/test_task_graphs.py
+++ b/tests/evaluators/test_task_graphs.py
@@ -2215,13 +2215,15 @@ async def test_412_scheduled_retry_non412_error_proceeds_to_execution(evaluator_
     )
 
 
-async def test_412_unexpected_status_reread_now_settles(evaluator_context, mock_storage):
-    """When the Started write gets a 412 and the re-read returns a truly unexpected status
-    (Pending — not None, not terminal, not Started, not Scheduled), the catch-all branch
-    calls complete_message before returning Failure.
+async def test_412_pending_reread_retries_started_write_with_new_etag(evaluator_context, mock_storage):
+    """When the Started write gets a 412 and the re-read shows Pending, the retry must use
+    the etag from the re-read (not the original etag, not None).
 
-    This is a regression guard for the catch-all fix: the old code returned Failure without
-    settling, which would leave an orphaned SB message. The fix always settles.
+    This models the production race: the scheduler's BlobLeaseClient.acquire() bumped the
+    blob ETag without changing the status, so the re-read returns Pending with a new etag.
+    The handler must treat this identically to the Scheduled case and retry the CAS.
+
+    Spec action: WriteStarted412 (Pending branch) → RetryStartedAfterScheduled.
     """
     from unittest.mock import patch
 
@@ -2238,14 +2240,165 @@ async def test_412_unexpected_status_reread_now_settles(evaluator_context, mock_
         status=TaskStatus.Pending,
         etag="W/\"etag-v1\"",
     )
-    # Re-read after 412 returns Pending again — an unexpected state the old catch-all handled.
+    # Re-read after 412 returns Pending with a NEW etag — lease acquire bumped it.
     pending_slim_reread = TaskResultSlim(
         task_id=ok_task.task_id,
         graph_id=GraphId(graph.graph_id),
         status=TaskStatus.Pending,
-        etag="W/\"etag-v3\"",
+        etag="W/\"etag-v2\"",
     )
     mock_storage.load_task_result.side_effect = [pending_slim, pending_slim_reread]
+
+    # First store raises 412; retry succeeds; result write also succeeds.
+    mock_storage.store_task_result.side_effect = [
+        BoilermakerStorageError("412 Precondition Failed", status_code=412),
+        None,
+        None,
+    ]
+
+    graph.add_result(
+        TaskResult(
+            task_id=ok_task.task_id,
+            graph_id=graph.graph_id,
+            status=TaskStatus.Success,
+            result="OK",
+        )
+    )
+    mock_storage.load_graph.return_value = graph
+
+    evaluator_context.evaluator.task = ok_task
+    ok_task.msg = evaluator_context.make_message(ok_task)
+
+    with patch("boilermaker.evaluators.task_graph.eval_task") as mock_eval_task:
+        mock_eval_task.return_value = TaskResult(
+            task_id=ok_task.task_id,
+            graph_id=graph.graph_id,
+            status=TaskStatus.Success,
+            result="OK",
+        )
+        await evaluator_context.evaluator()
+
+    assert mock_storage.store_task_result.call_count >= 2, (
+        "store_task_result must be called at least twice (Started write + retry)"
+    )
+    retry_call = mock_storage.store_task_result.call_args_list[1]
+    actual_etag = retry_call.kwargs.get("etag") or (
+        retry_call.args[1] if len(retry_call.args) > 1 else None
+    )
+    assert actual_etag == "W/\"etag-v2\"", (
+        f"Retry Started write must use the re-read Pending blob etag 'W/\"etag-v2\"', got {actual_etag!r}"
+    )
+
+
+async def test_412_pending_retry_success_falls_through_to_execution(evaluator_context, mock_storage):
+    """When the retry Started write succeeds after a Pending re-read, the task executes
+    normally: eval_task is called, the result is stored, and complete_message is called.
+
+    This is the expected recovery path when the scheduler's lease acquire bumped the ETag
+    but the worker can still claim the task by retrying with the new etag.
+
+    Spec action: RetryStartedWriteSuccess → Executing (same path as WriteStartedSuccess).
+    """
+    from unittest.mock import patch
+
+    from boilermaker.exc import BoilermakerStorageError
+    from boilermaker.task import GraphId, TaskResultSlim
+
+    graph = evaluator_context.graph
+    ok_task = evaluator_context.ok_task
+    ok_task.graph_id = graph.graph_id
+
+    pending_slim = TaskResultSlim(
+        task_id=ok_task.task_id,
+        graph_id=GraphId(graph.graph_id),
+        status=TaskStatus.Pending,
+        etag="W/\"etag-v1\"",
+    )
+    pending_slim_reread = TaskResultSlim(
+        task_id=ok_task.task_id,
+        graph_id=GraphId(graph.graph_id),
+        status=TaskStatus.Pending,
+        etag="W/\"etag-v2\"",
+    )
+    mock_storage.load_task_result.side_effect = [pending_slim, pending_slim_reread]
+
+    # First store raises 412; retry succeeds; result write also succeeds.
+    mock_storage.store_task_result.side_effect = [
+        BoilermakerStorageError("412 Precondition Failed", status_code=412),
+        None,
+        None,
+    ]
+
+    graph.add_result(
+        TaskResult(
+            task_id=ok_task.task_id,
+            graph_id=graph.graph_id,
+            status=TaskStatus.Success,
+            result="OK",
+        )
+    )
+    mock_storage.load_graph.return_value = graph
+
+    evaluator_context.evaluator.task = ok_task
+    ok_task.msg = evaluator_context.make_message(ok_task)
+
+    with patch("boilermaker.evaluators.task_graph.eval_task") as mock_eval_task:
+        mock_eval_task.return_value = TaskResult(
+            task_id=ok_task.task_id,
+            graph_id=graph.graph_id,
+            status=TaskStatus.Success,
+            result="OK",
+        )
+        result = await evaluator_context.evaluator()
+
+    mock_eval_task.assert_called_once()
+
+    assert mock_storage.store_task_result.call_count >= 2, (
+        "store_task_result must be called at least twice (Started retry + result write)"
+    )
+
+    assert result is not None
+    assert result.status == TaskStatus.Success, (
+        f"Expected Success after Pending retry success + execution, got {result.status}"
+    )
+
+    assert evaluator_context.mockservicebus._receiver.complete_message.called, (
+        "complete_message must be called via the normal execution path after retry success"
+    )
+
+
+async def test_412_unexpected_status_reread_now_settles(evaluator_context, mock_storage):
+    """When the Started write gets a 412 and the re-read returns a truly unexpected status
+    (e.g. Retry — not None, not terminal, not Started, not Scheduled, not Pending), the
+    catch-all branch calls complete_message before returning Failure.
+
+    Pending and Scheduled are both handled by the retry path (RetryStartedAfterScheduled).
+    Only statuses that can never legitimately appear on a blob at this point (e.g. Retry,
+    which is only written by the worker after execution) remain in the catch-all.
+    """
+    from unittest.mock import patch
+
+    from boilermaker.exc import BoilermakerStorageError
+    from boilermaker.task import GraphId, TaskResultSlim
+
+    graph = evaluator_context.graph
+    ok_task = evaluator_context.ok_task
+    ok_task.graph_id = graph.graph_id
+
+    pending_slim = TaskResultSlim(
+        task_id=ok_task.task_id,
+        graph_id=GraphId(graph.graph_id),
+        status=TaskStatus.Pending,
+        etag="W/\"etag-v1\"",
+    )
+    # Re-read after 412 returns Retry — a truly unexpected status in the catch-all.
+    retry_slim_reread = TaskResultSlim(
+        task_id=ok_task.task_id,
+        graph_id=GraphId(graph.graph_id),
+        status=TaskStatus.Retry,
+        etag="W/\"etag-v2\"",
+    )
+    mock_storage.load_task_result.side_effect = [pending_slim, retry_slim_reread]
 
     mock_storage.store_task_result.side_effect = BoilermakerStorageError(
         "412 Precondition Failed", status_code=412
@@ -2261,9 +2414,9 @@ async def test_412_unexpected_status_reread_now_settles(evaluator_context, mock_
 
     assert result is not None
     assert result.status == TaskStatus.Failure, (
-        f"Expected Failure for unexpected re-read status (Pending), got {result.status}"
+        f"Expected Failure for unexpected re-read status (Retry), got {result.status}"
     )
 
     assert evaluator_context.mockservicebus._receiver.complete_message.called, (
-        "complete_message must be called for unexpected re-read status (catch-all fix)"
+        "complete_message must be called for unexpected re-read status (catch-all always settles)"
     )

--- a/uv.lock
+++ b/uv.lock
@@ -350,7 +350,7 @@ wheels = [
 
 [[package]]
 name = "boilermaker-servicebus"
-version = "1.0.1a1"
+version = "1.0.1a3"
 source = { editable = "." }
 dependencies = [
     { name = "aio-azure-clients-toolbox" },


### PR DESCRIPTION
We have seen a few cases of stalled graphs where the message-handler is trying to take-ownership of a message and it fails due to the `Pending` status on reread. Because `Pending` is only written when the graph is published, this should be a state we can proceed from.

Error message looks like this:

```"412 on Started write but re-read returned unexpected status <TaskStatus.Pending: 'pending'> for task 019d9b91-60ed-7b81-a51c-3bb2c335c463; settling and returning Failure to avoid stalling the graph."```