### PR TITLE
Attempting to settle in all cases leaves graphs stalled

### DIFF
--- a/boilermaker/evaluators/task_graph.py
+++ b/boilermaker/evaluators/task_graph.py
@@ -262,7 +262,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                         else:
                             # RetryStartedWrite412: another worker moved the blob between
                             # the re-read and the retry.  Re-read a second time to determine
-                            # the current state.  Always settle in every branch from here.
+                            # the current state.
                             # Spec action: RetryStartedWrite412 → RereadAfterRetry412
                             logger.warning(
                                 f"Second 412 on retry Started write for task {self.task.task_id}; "
@@ -273,61 +273,125 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                                     self.task.task_id, self.task.graph_id
                                 )
                             except exc.BoilermakerStorageError:
+                                # Blob state unknown — do NOT settle.  Let the SB lock
+                                # expire and redeliver so a fresh worker can retry.
                                 logger.error(
                                     f"Second 412 + re-read also failed for task {self.task.task_id}; "
-                                    "settling and returning Failure",
+                                    "not settling — SB will redeliver",
                                     exc_info=True,
                                 )
                                 _reread2 = None
 
-                            # RereadAfterRetry: ALL branches call complete_message() before returning.
-                            try:
-                                await self.complete_message()
-                            except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
-                                logger.warning(
-                                    f"Failed to complete message after second 412 for task {self.task.task_id}; "
-                                    "SB will redeliver",
-                                    exc_info=True,
-                                )
-
                             if _reread2 is not None and _reread2.status == TaskStatus.Started:
-                                # Another worker won the second CAS — yield to that worker.
+                                # Another worker won the second CAS — settle and yield.
+                                # Spec action: RereadAfterRetry412 (Started) → Completing
+                                try:
+                                    await self.complete_message()
+                                except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
+                                    logger.warning(
+                                        f"Failed to complete message after second 412 (Started) "
+                                        f"for task {self.task.task_id}; SB will redeliver",
+                                        exc_info=True,
+                                    )
                                 return TaskResult(
                                     task_id=self.task.task_id,
                                     graph_id=self.task.graph_id,
                                     status=TaskStatus.Started,
                                 )
                             elif _reread2 is not None and _reread2.status.finished:
-                                # Task is already terminal — yield to that result.
+                                # Task is already terminal — settle and yield.
+                                # Spec action: RereadAfterRetry412 (terminal) → Completing
+                                try:
+                                    await self.complete_message()
+                                except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
+                                    logger.warning(
+                                        f"Failed to complete message after second 412 (terminal) "
+                                        f"for task {self.task.task_id}; SB will redeliver",
+                                        exc_info=True,
+                                    )
                                 return TaskResult(
                                     task_id=self.task.task_id,
                                     graph_id=self.task.graph_id,
                                     status=_reread2.status,
                                 )
+                            elif _reread2 is not None and _reread2.status == TaskStatus.Retry:
+                                # Another worker already ran this task and published a delayed
+                                # retry SB message.  Settle our duplicate and yield to the
+                                # retry mechanism — the graph will continue via that message.
+                                # Spec action: RereadAfterRetry412 (Retry) → Completing
+                                # Note: Retry is not modeled as a blob status in the TLA+ spec
+                                # (spec only produces Success/Failure from execution).
+                                logger.warning(
+                                    f"Second 412 + Retry re-read for task {self.task.task_id}; "
+                                    "another worker published a retry message — settling our duplicate"
+                                )
+                                try:
+                                    await self.complete_message()
+                                except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
+                                    logger.warning(
+                                        f"Failed to complete message after second 412 (Retry) "
+                                        f"for task {self.task.task_id}; SB will redeliver",
+                                        exc_info=True,
+                                    )
+                                return TaskResult(
+                                    task_id=self.task.task_id,
+                                    graph_id=self.task.graph_id,
+                                    status=TaskStatus.Retry,
+                                )
                             else:
-                                # Unexpected state after two 412s (None, Pending, Scheduled, etc).
+                                # Pending, Scheduled, None, or any other unclaimed state:
+                                # no other worker holds Started.  Do NOT settle — let the
+                                # SB lock expire so a fresh worker can retry from scratch.
+                                # Spec action: RereadAfterRetry412 (Pending/Scheduled) → no-settle
+                                _reread2_status = _reread2.status if _reread2 is not None else None
+                                logger.error(
+                                    f"Two 412s on Started write; second re-read returned "
+                                    f"{_reread2_status!r} "
+                                    f"for task {self.task.task_id}. "
+                                    "Not settling — SB will redeliver.",
+                                )
                                 return TaskResult(
                                     task_id=self.task.task_id,
                                     graph_id=self.task.graph_id,
                                     status=TaskStatus.Failure,
-                                    errors=["two 412s on Started write; unexpected state after second re-read"],
+                                    errors=[
+                                        f"two 412s on Started write; second re-read returned {_reread2_status!r}"
+                                    ],
                                 )
-                else:
-                    # Truly unexpected status after 412 (not None, finished, Started, or Scheduled).
-                    # Settle the message to avoid orphaning it on SB lock expiry.
-                    logger.error(
-                        f"412 on Started write but re-read returned unexpected status "
-                        f"{_reread.status!r} for task {self.task.task_id}; "
-                        "settling and returning Failure to avoid stalling the graph."
+                elif _reread.status == TaskStatus.Retry:
+                    # Another worker executed the task and published a delayed retry
+                    # SB message.  Settle our duplicate — the graph will continue via
+                    # the retry message.
+                    # Spec action: WriteStarted412 (Retry) → Completing
+                    logger.warning(
+                        f"412 on Started write; re-read returned Retry for task {self.task.task_id}; "
+                        "another worker already retried — settling our duplicate"
                     )
                     try:
                         await self.complete_message()
                     except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
                         logger.warning(
-                            f"Failed to complete message after 412+unexpected status for task {self.task.task_id}; "
+                            f"Failed to complete message after 412+Retry for task {self.task.task_id}; "
                             "SB will redeliver",
                             exc_info=True,
                         )
+                    return TaskResult(
+                        task_id=self.task.task_id,
+                        graph_id=self.task.graph_id,
+                        status=TaskStatus.Retry,
+                    )
+
+                else:
+                    # Truly unexpected status after 412 (not None, finished, Started,
+                    # Scheduled, Pending, or Retry).  Do NOT settle — we don't know
+                    # whether another worker will continue the graph, so stalling here
+                    # is safer than consuming the message and orphaning the task.
+                    # Let the SB lock expire so a fresh worker can retry from scratch.
+                    logger.error(
+                        f"412 on Started write but re-read returned unexpected status "
+                        f"{_reread.status!r} for task {self.task.task_id}; "
+                        "not settling — SB will redeliver."
+                    )
                     return TaskResult(
                         task_id=self.task.task_id,
                         graph_id=self.task.graph_id,

--- a/specs/TaskGraphSpecBase.tla
+++ b/specs/TaskGraphSpecBase.tla
@@ -121,7 +121,7 @@ VARIABLES
     \*   ReleasingLease        -- releasing the blob lease
     \*   Completing                  -- settling the SB message
     \*   RetryStartedAfterScheduled  -- 412 re-read saw Scheduled; retry Started write with re-read etag
-    \*   RereadAfterRetry412         -- second 412 on retry; re-reading blob to decide settle action
+    \*   RereadAfterRetry412         -- second 412 on retry; settle if claimed/terminal, redeliver if unclaimed
     workerPhase,    \* workerPhase[w]
 
     workerMsg,      \* workerMsg[w]: the SB message the worker holds, or Nil
@@ -402,22 +402,44 @@ RetryStartedWriteNon412Error(w) ==
                     workerReadySet, workerCurrentReady>>
 
 \* ===== RereadAfterRetry =====
-\* Worker got a second 412 on the retry. Re-read the blob to determine what to do.
-\* In all cases: settle the message (complete_message). Never rely on SB redelivery.
+\* Worker got a second 412 on the retry. Re-reads the blob to determine action.
 \*
-\* Outcomes:
-\*   Started  -> Completing (another worker won the CAS; yield)
-\*   terminal -> Completing (task already done; yield)
-\*   other    -> Completing (unexpected forward-only state; still settle)
-RereadAfterRetry(w) ==
+\* Two variants, matching the code fix:
+\*   Started/terminal -> RereadAfterRetrySettle: proceed to Completing (settle msg)
+\*   Pending/Scheduled -> RereadAfterRetryNoSettle: do NOT settle; return message
+\*     to the SB queue so a fresh worker can retry (mirrors LockExpiry).
+\*
+\* Settling when the blob is unclaimed would stall the graph permanently.
+
+\* Settle variant: another worker owns the task or it is already terminal.
+RereadAfterRetrySettle(w) ==
     /\ workerPhase[w] = "RereadAfterRetry412"
-    \* In all branches: settle the message. The blob state determines what we return
-    \* conceptually but the action is always: complete message, reset worker.
+    /\ LET t == workerTask[w]
+       IN blobStatus[t] \in {"Started"} \cup TerminalStatuses
     /\ workerPhase' = [workerPhase EXCEPT ![w] = "Completing"]
     /\ UNCHANGED <<blobStatus, blobEtag, blobLeased, blobDeadLettered, sbMessages,
                     workerMsg, workerTask, workerResult, workerCapturedEtag,
                     workerSnapshot, workerSnapshotEtags,
                     workerReadySet, workerCurrentReady>>
+
+\* No-settle variant: blob is unclaimed (Pending or Scheduled).
+\* Return the SB message to the queue and reset the worker, exactly like LockExpiry.
+RereadAfterRetryNoSettle(w) ==
+    /\ workerPhase[w] = "RereadAfterRetry412"
+    /\ LET t   == workerTask[w]
+           msg == workerMsg[w]
+       IN
+       /\ blobStatus[t] \in {"Pending", "Scheduled"}
+       /\ \/ /\ msg.deliveryCount < MaxDeliveryCount
+             /\ sbMessages' = sbMessages \cup
+                   {[taskId |-> msg.taskId,
+                     deliveryCount |-> msg.deliveryCount + 1]}
+             /\ UNCHANGED blobDeadLettered
+          \/ /\ msg.deliveryCount = MaxDeliveryCount
+             /\ UNCHANGED sbMessages
+             /\ blobDeadLettered' = [blobDeadLettered EXCEPT ![msg.taskId] = TRUE]
+    /\ WorkerReset(w)
+    /\ UNCHANGED <<blobStatus, blobEtag, blobLeased>>
 
 \* Sub-action: non-412 storage error on Started write — proceed anyway (fail-open)
 WriteStartedNon412Error(w) ==
@@ -434,11 +456,10 @@ WriteStartedNon412Error(w) ==
                        workerSnapshot, workerSnapshotEtags,
                        workerReadySet, workerCurrentReady>>
 
-\* NOTE: ReturnFailureSettle / ReturnFailureNoSettle have been REMOVED.
-\* In the fixed protocol every 412 branch settles the message explicitly.
-\* The RetryStartedAfterScheduled path and RereadAfterRetry412 path both
-\* lead to Completing (which calls complete_message). There is no longer any
-\* phase in which a worker exits without settling.
+\* NOTE: Settlement is now conditional on blob state.
+\* RereadAfterRetrySettle leads to Completing (settle) when the blob is claimed/terminal.
+\* RereadAfterRetryNoSettle returns the SB message and resets the worker (no settle)
+\* when the blob is unclaimed (Pending/Scheduled) — stalling would otherwise be permanent.
 
 \* ===== ExecuteTask =====
 \* Nondeterministic task execution outcome: Success or Failure.
@@ -726,7 +747,8 @@ Next ==
         \/ RetryStartedWriteSuccess(w)
         \/ RetryStartedWrite412(w)
         \/ RetryStartedWriteNon412Error(w)
-        \/ RereadAfterRetry(w)
+        \/ RereadAfterRetrySettle(w)
+        \/ RereadAfterRetryNoSettle(w)
         \/ ExecuteTask(w)
         \/ WriteResult(w)
         \/ LoadGraph(w)
@@ -821,7 +843,8 @@ Fairness ==
         /\ WF_vars(RetryStartedWriteSuccess(w))
         /\ WF_vars(RetryStartedWrite412(w))
         /\ WF_vars(RetryStartedWriteNon412Error(w))
-        /\ WF_vars(RereadAfterRetry(w))
+        /\ WF_vars(RereadAfterRetrySettle(w))
+        /\ WF_vars(RereadAfterRetryNoSettle(w))
         /\ WF_vars(ExecuteTask(w))
         /\ WF_vars(WriteResult(w))
         /\ WF_vars(LoadGraph(w))

--- a/tests/evaluators/test_task_graphs.py
+++ b/tests/evaluators/test_task_graphs.py
@@ -2071,14 +2071,14 @@ async def test_412_scheduled_retry_second_412_sees_terminal_settles(evaluator_co
 
 
 @pytest.mark.parametrize("second_reread_value", [None, "scheduled", "pending"])
-async def test_412_scheduled_retry_second_412_sees_unexpected_settles_with_failure(
+async def test_412_scheduled_retry_second_412_sees_unclaimed_does_not_settle(
     evaluator_context, mock_storage, second_reread_value
 ):
-    """When the retry Started write gets a second 412 and the second re-read returns a
-    status that is neither Started nor terminal (None, Scheduled, Pending), the handler
-    calls complete_message and returns Failure.
+    """When the retry Started write gets a second 412 and the second re-read returns an
+    unclaimed status (None, Scheduled, Pending), the handler does NOT call complete_message
+    — it lets the SB lock expire for redelivery instead of permanently stalling the graph.
 
-    Spec action: RereadAfterRetry (other branch) → Completing.
+    Spec action: RereadAfterRetry412 (Pending/Scheduled) → RereadAfterRetryNoSettle.
     Parameterized over: None, Scheduled, Pending second re-reads.
     """
     from unittest.mock import patch
@@ -2136,11 +2136,12 @@ async def test_412_scheduled_retry_second_412_sees_unexpected_settles_with_failu
 
     assert result is not None
     assert result.status == TaskStatus.Failure, (
-        f"Expected Failure for unexpected second re-read value {second_reread_value!r}, got {result.status}"
+        f"Expected Failure for unclaimed second re-read value {second_reread_value!r}, got {result.status}"
     )
 
-    assert evaluator_context.mockservicebus._receiver.complete_message.called, (
-        "complete_message must be called once even for unexpected second re-read status"
+    assert not evaluator_context.mockservicebus._receiver.complete_message.called, (
+        "complete_message must NOT be called for unclaimed second re-read status — "
+        "let SB redeliver rather than permanently stalling the graph"
     )
 
 
@@ -2367,14 +2368,12 @@ async def test_412_pending_retry_success_falls_through_to_execution(evaluator_co
     )
 
 
-async def test_412_unexpected_status_reread_now_settles(evaluator_context, mock_storage):
-    """When the Started write gets a 412 and the re-read returns a truly unexpected status
-    (e.g. Retry — not None, not terminal, not Started, not Scheduled, not Pending), the
-    catch-all branch calls complete_message before returning Failure.
+async def test_412_retry_reread_settles_and_returns_retry(evaluator_context, mock_storage):
+    """When the Started write gets a 412 and the re-read returns Retry, the handler
+    settles the duplicate message and returns TaskResult(Retry) — another worker already
+    ran the task and published a delayed retry SB message.
 
-    Pending and Scheduled are both handled by the retry path (RetryStartedAfterScheduled).
-    Only statuses that can never legitimately appear on a blob at this point (e.g. Retry,
-    which is only written by the worker after execution) remain in the catch-all.
+    Spec action: WriteStarted412 (Retry re-read) → Completing.
     """
     from unittest.mock import patch
 
@@ -2391,7 +2390,6 @@ async def test_412_unexpected_status_reread_now_settles(evaluator_context, mock_
         status=TaskStatus.Pending,
         etag="W/\"etag-v1\"",
     )
-    # Re-read after 412 returns Retry — a truly unexpected status in the catch-all.
     retry_slim_reread = TaskResultSlim(
         task_id=ok_task.task_id,
         graph_id=GraphId(graph.graph_id),
@@ -2413,10 +2411,10 @@ async def test_412_unexpected_status_reread_now_settles(evaluator_context, mock_
     mock_eval_task.assert_not_called()
 
     assert result is not None
-    assert result.status == TaskStatus.Failure, (
-        f"Expected Failure for unexpected re-read status (Retry), got {result.status}"
+    assert result.status == TaskStatus.Retry, (
+        f"Expected Retry for Retry re-read after 412, got {result.status}"
     )
 
     assert evaluator_context.mockservicebus._receiver.complete_message.called, (
-        "complete_message must be called for unexpected re-read status (catch-all always settles)"
+        "complete_message must be called — another worker already owns the retry"
     )

--- a/tests/evaluators/test_task_graphs.py
+++ b/tests/evaluators/test_task_graphs.py
@@ -2418,3 +2418,613 @@ async def test_412_retry_reread_settles_and_returns_retry(evaluator_context, moc
     assert evaluator_context.mockservicebus._receiver.complete_message.called, (
         "complete_message must be called — another worker already owns the retry"
     )
+
+
+# ~~~~ ~~~~ ~~~~ ~~~~ ~~~~ ~~~~ ~~~~ ~~~~ ~~~~ ~~~~ ~~~~ ~~~~ ~~~~ ~~~~ ~~~~ #
+# Coverage gap tests                                                           #
+# ~~~~ ~~~~ ~~~~ ~~~~ ~~~~ ~~~~ ~~~~ ~~~~ ~~~~ ~~~~ ~~~~ ~~~~ ~~~~ ~~~~ ~~~~ #
+
+# ----- Redelivery path (lines 106-116) -----
+
+
+async def test_redelivery_continue_graph_fails_suppresses_settlement(evaluator_context, mock_storage):
+    """On SB redelivery with a terminal blob, if continue_graph raises ContinueGraphError
+    the evaluator must return the terminal result WITHOUT settling (lines 106-112).
+    Suppressing settlement allows SB to redeliver and downstream dispatch to be retried.
+    """
+    from unittest.mock import patch
+
+    from boilermaker.exc import ContinueGraphError
+    from boilermaker.task import GraphId, TaskResultSlim
+
+    ok_task = evaluator_context.ok_task
+    ok_task.graph_id = evaluator_context.graph.graph_id
+
+    mock_storage.load_task_result.return_value = TaskResultSlim(
+        task_id=ok_task.task_id,
+        graph_id=GraphId(ok_task.graph_id),
+        status=TaskStatus.Success,
+    )
+
+    evaluator_context.evaluator.task = ok_task
+    ok_task.msg = evaluator_context.make_message(ok_task)
+
+    with patch.object(evaluator_context.evaluator, "continue_graph", side_effect=ContinueGraphError("load failed")):
+        result = await evaluator_context.evaluator()
+
+    assert result.status == TaskStatus.Success
+    assert not evaluator_context.mockservicebus._receiver.complete_message.called, (
+        "must not settle when continue_graph fails on redelivery"
+    )
+
+
+async def test_redelivery_complete_message_fails_still_returns_terminal(evaluator_context, mock_storage):
+    """On SB redelivery with a terminal blob, if complete_message raises the evaluator
+    must still return the terminal result (lines 115-116).
+    """
+    from unittest.mock import patch
+
+    from boilermaker.exc import BoilermakerTaskLeaseLost
+    from boilermaker.task import GraphId, TaskResultSlim
+
+    ok_task = evaluator_context.ok_task
+    ok_task.graph_id = evaluator_context.graph.graph_id
+
+    mock_storage.load_task_result.return_value = TaskResultSlim(
+        task_id=ok_task.task_id,
+        graph_id=GraphId(ok_task.graph_id),
+        status=TaskStatus.Success,
+    )
+
+    evaluator_context.mockservicebus._receiver.complete_message.side_effect = BoilermakerTaskLeaseLost("lost")
+
+    evaluator_context.evaluator.task = ok_task
+    ok_task.msg = evaluator_context.make_message(ok_task)
+
+    with patch.object(evaluator_context.evaluator, "continue_graph", return_value=None):
+        result = await evaluator_context.evaluator()
+
+    assert result.status == TaskStatus.Success
+
+
+# ----- Non-412 error on Started write (line 138) -----
+
+
+async def test_non_412_started_write_error_falls_through_to_execution(evaluator_context, mock_storage):
+    """A non-412 storage error on the Started write must be logged and execution must
+    proceed (fail-open, line 138).
+    """
+    from unittest.mock import patch
+
+    from boilermaker.exc import BoilermakerStorageError
+    from boilermaker.task import GraphId, TaskResultSlim
+
+    ok_task = evaluator_context.ok_task
+    ok_task.graph_id = evaluator_context.graph.graph_id
+
+    mock_storage.load_task_result.return_value = TaskResultSlim(
+        task_id=ok_task.task_id,
+        graph_id=GraphId(ok_task.graph_id),
+        status=TaskStatus.Pending,
+        etag='W/"e1"',
+    )
+    # First store (Started) raises a 500-style error; second store (result) succeeds.
+    mock_storage.store_task_result.side_effect = [
+        BoilermakerStorageError("500 Internal Server Error", status_code=500),
+        None,
+    ]
+
+    evaluator_context.evaluator.task = ok_task
+    ok_task.msg = evaluator_context.make_message(ok_task)
+
+    with patch("boilermaker.evaluators.task_graph.eval_task") as mock_eval_task:
+        mock_eval_task.return_value = TaskResult(
+            task_id=ok_task.task_id,
+            graph_id=ok_task.graph_id,
+            status=TaskStatus.Success,
+            result="OK",
+        )
+        result = await evaluator_context.evaluator()
+
+    mock_eval_task.assert_called_once()
+    assert result.status == TaskStatus.Success
+
+
+# ----- 412 + re-read also fails (lines 152-158) -----
+
+
+async def test_412_started_write_reread_also_fails_returns_failure(evaluator_context, mock_storage):
+    """When the Started write gets a 412 and the re-read also raises a storage error,
+    the evaluator must return Failure without settling (lines 152-158).
+    """
+    from unittest.mock import patch
+
+    from boilermaker.exc import BoilermakerStorageError
+    from boilermaker.task import GraphId, TaskResultSlim
+
+    ok_task = evaluator_context.ok_task
+    ok_task.graph_id = evaluator_context.graph.graph_id
+
+    pending_slim = TaskResultSlim(
+        task_id=ok_task.task_id,
+        graph_id=GraphId(ok_task.graph_id),
+        status=TaskStatus.Pending,
+        etag='W/"e1"',
+    )
+    # First call: idempotency read → Pending. Second call: re-read after 412 → raises.
+    mock_storage.load_task_result.side_effect = [
+        pending_slim,
+        BoilermakerStorageError("503 Service Unavailable", status_code=503),
+    ]
+    mock_storage.store_task_result.side_effect = BoilermakerStorageError("412 Precondition Failed", status_code=412)
+
+    evaluator_context.evaluator.task = ok_task
+    ok_task.msg = evaluator_context.make_message(ok_task)
+
+    with patch("boilermaker.evaluators.task_graph.eval_task") as mock_eval_task:
+        result = await evaluator_context.evaluator()
+
+    mock_eval_task.assert_not_called()
+    assert result.status == TaskStatus.Failure
+    assert not evaluator_context.mockservicebus._receiver.complete_message.called
+
+
+# ----- 412 complete_message failures (lines 189-190, 209-210) -----
+
+
+async def test_412_terminal_reread_complete_message_failure_still_returns_terminal(evaluator_context, mock_storage):
+    """After a 412 + terminal re-read, if complete_message raises the evaluator must
+    still return the terminal status (lines 189-190).
+    """
+    from unittest.mock import patch
+
+    from boilermaker.exc import BoilermakerStorageError, BoilermakerTaskLeaseLost
+    from boilermaker.task import GraphId, TaskResultSlim
+
+    ok_task = evaluator_context.ok_task
+    ok_task.graph_id = evaluator_context.graph.graph_id
+
+    mock_storage.load_task_result.side_effect = [
+        TaskResultSlim(
+            task_id=ok_task.task_id, graph_id=GraphId(ok_task.graph_id), status=TaskStatus.Pending, etag='W/"e1"'
+        ),
+        TaskResultSlim(task_id=ok_task.task_id, graph_id=GraphId(ok_task.graph_id), status=TaskStatus.Success),
+    ]
+    mock_storage.store_task_result.side_effect = BoilermakerStorageError("412", status_code=412)
+    evaluator_context.mockservicebus._receiver.complete_message.side_effect = BoilermakerTaskLeaseLost("lost")
+
+    evaluator_context.evaluator.task = ok_task
+    ok_task.msg = evaluator_context.make_message(ok_task)
+
+    with patch("boilermaker.evaluators.task_graph.eval_task") as mock_eval_task:
+        result = await evaluator_context.evaluator()
+
+    mock_eval_task.assert_not_called()
+    assert result.status == TaskStatus.Success
+
+
+async def test_412_started_reread_complete_message_failure_still_returns_started(evaluator_context, mock_storage):
+    """After a 412 + Started re-read, if complete_message raises the evaluator must
+    still return Started (lines 209-210).
+    """
+    from unittest.mock import patch
+
+    from boilermaker.exc import BoilermakerStorageError, BoilermakerTaskLeaseLost
+    from boilermaker.task import GraphId, TaskResultSlim
+
+    ok_task = evaluator_context.ok_task
+    ok_task.graph_id = evaluator_context.graph.graph_id
+
+    mock_storage.load_task_result.side_effect = [
+        TaskResultSlim(
+            task_id=ok_task.task_id, graph_id=GraphId(ok_task.graph_id), status=TaskStatus.Pending, etag='W/"e1"'
+        ),
+        TaskResultSlim(task_id=ok_task.task_id, graph_id=GraphId(ok_task.graph_id), status=TaskStatus.Started),
+    ]
+    mock_storage.store_task_result.side_effect = BoilermakerStorageError("412", status_code=412)
+    evaluator_context.mockservicebus._receiver.complete_message.side_effect = BoilermakerTaskLeaseLost("lost")
+
+    evaluator_context.evaluator.task = ok_task
+    ok_task.msg = evaluator_context.make_message(ok_task)
+
+    with patch("boilermaker.evaluators.task_graph.eval_task") as mock_eval_task:
+        result = await evaluator_context.evaluator()
+
+    mock_eval_task.assert_not_called()
+    assert result.status == TaskStatus.Started
+
+
+# ----- 412 + Pending/Scheduled re-read with None etag warning (line 237) -----
+
+
+async def test_412_reread_with_none_etag_logs_warning_and_retries(evaluator_context, mock_storage):
+    """When the re-read after a 412 returns Scheduled with a None etag, the evaluator
+    logs a warning and retries the Started write with etag=None (line 237).
+    """
+    from unittest.mock import patch
+
+    from boilermaker.exc import BoilermakerStorageError
+    from boilermaker.task import GraphId, TaskResultSlim
+
+    ok_task = evaluator_context.ok_task
+    ok_task.graph_id = evaluator_context.graph.graph_id
+
+    mock_storage.load_task_result.side_effect = [
+        TaskResultSlim(
+            task_id=ok_task.task_id, graph_id=GraphId(ok_task.graph_id), status=TaskStatus.Pending, etag='W/"e1"'
+        ),
+        # Re-read has etag=None — triggers the warning log at line 237.
+        TaskResultSlim(
+            task_id=ok_task.task_id, graph_id=GraphId(ok_task.graph_id), status=TaskStatus.Scheduled, etag=None
+        ),
+    ]
+    # First store: 412; retry store: succeeds; result store: succeeds.
+    mock_storage.store_task_result.side_effect = [
+        BoilermakerStorageError("412", status_code=412),
+        None,
+        None,
+    ]
+    evaluator_context.graph.add_result(
+        TaskResult(
+            task_id=ok_task.task_id,
+            graph_id=ok_task.graph_id,
+            status=TaskStatus.Success,
+            result="OK",
+        )
+    )
+    mock_storage.load_graph.return_value = evaluator_context.graph
+
+    evaluator_context.evaluator.task = ok_task
+    ok_task.msg = evaluator_context.make_message(ok_task)
+
+    with patch("boilermaker.evaluators.task_graph.eval_task") as mock_eval_task:
+        mock_eval_task.return_value = TaskResult(
+            task_id=ok_task.task_id,
+            graph_id=ok_task.graph_id,
+            status=TaskStatus.Success,
+            result="OK",
+        )
+        result = await evaluator_context.evaluator()
+        assert result.status == TaskStatus.Success
+
+    mock_eval_task.assert_called_once()
+    # Verify that the retry write used None as the etag (unconditional).
+    retry_call = mock_storage.store_task_result.call_args_list[1]
+    assert retry_call.kwargs.get("etag") is None or retry_call.args[1] is None
+
+
+# ----- Second 412 paths (lines 275-283, 290-291, 306-307, 324-336) -----
+
+
+async def test_second_412_reread_also_fails_returns_failure_no_settle(evaluator_context, mock_storage):
+    """When the second 412 + second re-read also raises a storage error, _reread2 is set
+    to None and the evaluator returns Failure without settling (lines 275-283).
+    """
+    from unittest.mock import patch
+
+    from boilermaker.exc import BoilermakerStorageError
+    from boilermaker.task import GraphId, TaskResultSlim
+
+    ok_task = evaluator_context.ok_task
+    ok_task.graph_id = evaluator_context.graph.graph_id
+
+    mock_storage.load_task_result.side_effect = [
+        TaskResultSlim(
+            task_id=ok_task.task_id, graph_id=GraphId(ok_task.graph_id), status=TaskStatus.Pending, etag='W/"e1"'
+        ),
+        TaskResultSlim(
+            task_id=ok_task.task_id, graph_id=GraphId(ok_task.graph_id), status=TaskStatus.Scheduled, etag='W/"e2"'
+        ),
+        BoilermakerStorageError("503", status_code=503),  # re-read2 fails
+    ]
+    mock_storage.store_task_result.side_effect = [
+        BoilermakerStorageError("412", status_code=412),
+        BoilermakerStorageError("412", status_code=412),
+    ]
+
+    evaluator_context.evaluator.task = ok_task
+    ok_task.msg = evaluator_context.make_message(ok_task)
+
+    with patch("boilermaker.evaluators.task_graph.eval_task") as mock_eval_task:
+        result = await evaluator_context.evaluator()
+
+    mock_eval_task.assert_not_called()
+    assert result.status == TaskStatus.Failure
+    assert not evaluator_context.mockservicebus._receiver.complete_message.called
+
+
+async def test_second_412_started_reread2_complete_message_failure(evaluator_context, mock_storage):
+    """After second 412 + Started re-read2, if complete_message raises the evaluator
+    still returns Started (lines 290-291).
+    """
+    from unittest.mock import patch
+
+    from boilermaker.exc import BoilermakerStorageError, BoilermakerTaskLeaseLost
+    from boilermaker.task import GraphId, TaskResultSlim
+
+    ok_task = evaluator_context.ok_task
+    ok_task.graph_id = evaluator_context.graph.graph_id
+
+    mock_storage.load_task_result.side_effect = [
+        TaskResultSlim(
+            task_id=ok_task.task_id, graph_id=GraphId(ok_task.graph_id), status=TaskStatus.Pending, etag='W/"e1"'
+        ),
+        TaskResultSlim(
+            task_id=ok_task.task_id, graph_id=GraphId(ok_task.graph_id), status=TaskStatus.Scheduled, etag='W/"e2"'
+        ),
+        TaskResultSlim(task_id=ok_task.task_id, graph_id=GraphId(ok_task.graph_id), status=TaskStatus.Started),
+    ]
+    mock_storage.store_task_result.side_effect = [
+        BoilermakerStorageError("412", status_code=412),
+        BoilermakerStorageError("412", status_code=412),
+    ]
+    evaluator_context.mockservicebus._receiver.complete_message.side_effect = BoilermakerTaskLeaseLost("lost")
+
+    evaluator_context.evaluator.task = ok_task
+    ok_task.msg = evaluator_context.make_message(ok_task)
+
+    with patch("boilermaker.evaluators.task_graph.eval_task") as mock_eval_task:
+        result = await evaluator_context.evaluator()
+
+    mock_eval_task.assert_not_called()
+    assert result.status == TaskStatus.Started
+
+
+async def test_second_412_terminal_reread2_complete_message_failure(evaluator_context, mock_storage):
+    """After second 412 + terminal re-read2, if complete_message raises the evaluator
+    still returns the terminal status (lines 306-307).
+    """
+    from unittest.mock import patch
+
+    from boilermaker.exc import BoilermakerStorageError, BoilermakerTaskLeaseLost
+    from boilermaker.task import GraphId, TaskResultSlim
+
+    ok_task = evaluator_context.ok_task
+    ok_task.graph_id = evaluator_context.graph.graph_id
+
+    mock_storage.load_task_result.side_effect = [
+        TaskResultSlim(
+            task_id=ok_task.task_id, graph_id=GraphId(ok_task.graph_id), status=TaskStatus.Pending, etag='W/"e1"'
+        ),
+        TaskResultSlim(
+            task_id=ok_task.task_id, graph_id=GraphId(ok_task.graph_id), status=TaskStatus.Scheduled, etag='W/"e2"'
+        ),
+        TaskResultSlim(task_id=ok_task.task_id, graph_id=GraphId(ok_task.graph_id), status=TaskStatus.Success),
+    ]
+    mock_storage.store_task_result.side_effect = [
+        BoilermakerStorageError("412", status_code=412),
+        BoilermakerStorageError("412", status_code=412),
+    ]
+    evaluator_context.mockservicebus._receiver.complete_message.side_effect = BoilermakerTaskLeaseLost("lost")
+
+    evaluator_context.evaluator.task = ok_task
+    ok_task.msg = evaluator_context.make_message(ok_task)
+
+    with patch("boilermaker.evaluators.task_graph.eval_task") as mock_eval_task:
+        result = await evaluator_context.evaluator()
+
+    mock_eval_task.assert_not_called()
+    assert result.status == TaskStatus.Success
+
+
+async def test_second_412_retry_reread2_complete_message_failure(evaluator_context, mock_storage):
+    """After second 412 + Retry re-read2, if complete_message raises the evaluator still
+    returns Retry (lines 330-331).
+    """
+    from unittest.mock import patch
+
+    from boilermaker.exc import BoilermakerStorageError, BoilermakerTaskLeaseLost
+    from boilermaker.task import GraphId, TaskResultSlim
+
+    ok_task = evaluator_context.ok_task
+    ok_task.graph_id = evaluator_context.graph.graph_id
+
+    mock_storage.load_task_result.side_effect = [
+        TaskResultSlim(
+            task_id=ok_task.task_id, graph_id=GraphId(ok_task.graph_id), status=TaskStatus.Pending, etag='W/"e1"'
+        ),
+        TaskResultSlim(
+            task_id=ok_task.task_id, graph_id=GraphId(ok_task.graph_id), status=TaskStatus.Scheduled, etag='W/"e2"'
+        ),
+        TaskResultSlim(task_id=ok_task.task_id, graph_id=GraphId(ok_task.graph_id), status=TaskStatus.Retry),
+    ]
+    mock_storage.store_task_result.side_effect = [
+        BoilermakerStorageError("412", status_code=412),
+        BoilermakerStorageError("412", status_code=412),
+    ]
+    evaluator_context.mockservicebus._receiver.complete_message.side_effect = BoilermakerTaskLeaseLost("lost")
+
+    evaluator_context.evaluator.task = ok_task
+    ok_task.msg = evaluator_context.make_message(ok_task)
+
+    with patch("boilermaker.evaluators.task_graph.eval_task") as mock_eval_task:
+        result = await evaluator_context.evaluator()
+
+    mock_eval_task.assert_not_called()
+    assert result.status == TaskStatus.Retry
+
+
+async def test_second_412_retry_reread2_settles_and_returns_retry(evaluator_context, mock_storage):
+    """After second 412 + Retry re-read2, the evaluator settles and returns Retry
+    (lines 324-336).
+    """
+    from unittest.mock import patch
+
+    from boilermaker.exc import BoilermakerStorageError
+    from boilermaker.task import GraphId, TaskResultSlim
+
+    ok_task = evaluator_context.ok_task
+    ok_task.graph_id = evaluator_context.graph.graph_id
+
+    mock_storage.load_task_result.side_effect = [
+        TaskResultSlim(
+            task_id=ok_task.task_id, graph_id=GraphId(ok_task.graph_id), status=TaskStatus.Pending, etag='W/"e1"'
+        ),
+        TaskResultSlim(
+            task_id=ok_task.task_id, graph_id=GraphId(ok_task.graph_id), status=TaskStatus.Scheduled, etag='W/"e2"'
+        ),
+        TaskResultSlim(task_id=ok_task.task_id, graph_id=GraphId(ok_task.graph_id), status=TaskStatus.Retry),
+    ]
+    mock_storage.store_task_result.side_effect = [
+        BoilermakerStorageError("412", status_code=412),
+        BoilermakerStorageError("412", status_code=412),
+    ]
+
+    evaluator_context.evaluator.task = ok_task
+    ok_task.msg = evaluator_context.make_message(ok_task)
+
+    with patch("boilermaker.evaluators.task_graph.eval_task") as mock_eval_task:
+        result = await evaluator_context.evaluator()
+
+    mock_eval_task.assert_not_called()
+    assert result.status == TaskStatus.Retry
+    assert evaluator_context.mockservicebus._receiver.complete_message.called
+
+
+# ----- First 412 Retry, complete_message fails (lines 372-373) -----
+
+
+async def test_412_retry_reread_complete_message_failure_still_returns_retry(evaluator_context, mock_storage):
+    """After first 412 + Retry re-read, if complete_message raises the evaluator still
+    returns Retry (lines 372-373).
+    """
+    from unittest.mock import patch
+
+    from boilermaker.exc import BoilermakerStorageError, BoilermakerTaskLeaseLost
+    from boilermaker.task import GraphId, TaskResultSlim
+
+    ok_task = evaluator_context.ok_task
+    ok_task.graph_id = evaluator_context.graph.graph_id
+
+    mock_storage.load_task_result.side_effect = [
+        TaskResultSlim(
+            task_id=ok_task.task_id, graph_id=GraphId(ok_task.graph_id), status=TaskStatus.Pending, etag='W/"e1"'
+        ),
+        TaskResultSlim(task_id=ok_task.task_id, graph_id=GraphId(ok_task.graph_id), status=TaskStatus.Retry),
+    ]
+    mock_storage.store_task_result.side_effect = BoilermakerStorageError("412", status_code=412)
+    evaluator_context.mockservicebus._receiver.complete_message.side_effect = BoilermakerTaskLeaseLost("lost")
+
+    evaluator_context.evaluator.task = ok_task
+    ok_task.msg = evaluator_context.make_message(ok_task)
+
+    with patch("boilermaker.evaluators.task_graph.eval_task") as mock_eval_task:
+        result = await evaluator_context.evaluator()
+
+    mock_eval_task.assert_not_called()
+    assert result.status == TaskStatus.Retry
+
+
+# ----- continue_graph: graph blob not found (lines 614-619) -----
+
+
+async def test_continue_graph_graph_not_found_returns_none(evaluator_context, mock_storage):
+    """When load_graph returns None (graph blob missing), continue_graph logs critical and
+    returns None — the main flow settles normally (lines 614-619).
+    """
+    from unittest.mock import patch
+
+    ok_task = evaluator_context.ok_task
+    ok_task.graph_id = evaluator_context.graph.graph_id
+
+    # Override load_graph to return None (graph missing).
+    mock_storage.load_graph.return_value = None
+
+    evaluator_context.evaluator.task = ok_task
+    ok_task.msg = evaluator_context.make_message(ok_task)
+
+    with patch("boilermaker.evaluators.task_graph.eval_task") as mock_eval_task:
+        mock_eval_task.return_value = TaskResult(
+            task_id=ok_task.task_id,
+            graph_id=ok_task.graph_id,
+            status=TaskStatus.Success,
+            result="OK",
+        )
+        result = await evaluator_context.evaluator()
+
+    assert result.status == TaskStatus.Success
+    # Message still settled (continue_graph returned None, not raised).
+    assert evaluator_context.mockservicebus._receiver.complete_message.called
+
+
+# ----- continue_graph: try_acquire_lease unexpected error (lines 651-658) -----
+
+
+async def test_continue_graph_lease_unexpected_error_skips_task(evaluator_context, mock_storage):
+    """When try_acquire_lease raises an unexpected BoilermakerStorageError, the task is
+    skipped and processing continues (lines 651-658).
+    """
+    from unittest.mock import patch
+
+    from boilermaker.exc import BoilermakerStorageError
+
+    ok_task = evaluator_context.ok_task
+    ok_task.graph_id = evaluator_context.graph.graph_id
+
+    # Graph needs a ready task so the lease acquisition code is reached.
+    graph = evaluator_context.graph
+    graph.add_result(
+        TaskResult(
+            task_id=ok_task.task_id,
+            graph_id=graph.graph_id,
+            status=TaskStatus.Success,
+            result="OK",
+        )
+    )
+    mock_storage.load_graph.return_value = graph
+
+    # Unexpected error on lease acquisition.
+    mock_storage.try_acquire_lease.side_effect = BoilermakerStorageError("unexpected", status_code=500)
+
+    evaluator_context.evaluator.task = ok_task
+    ok_task.msg = evaluator_context.make_message(ok_task)
+
+    with patch("boilermaker.evaluators.task_graph.eval_task") as mock_eval_task:
+        mock_eval_task.return_value = TaskResult(
+            task_id=ok_task.task_id,
+            graph_id=ok_task.graph_id,
+            status=TaskStatus.Success,
+            result="OK",
+        )
+        result = await evaluator_context.evaluator()
+
+    # Evaluator completes normally; the ready task was skipped but no exception raised.
+    assert result.status == TaskStatus.Success
+
+
+async def test_continue_graph_lease_returns_none_skips_task(evaluator_context, mock_storage):
+    """When try_acquire_lease returns None (lease already held or etag mismatch),
+    the task is skipped silently (lines 660-664).
+    """
+    from unittest.mock import patch
+
+    ok_task = evaluator_context.ok_task
+    ok_task.graph_id = evaluator_context.graph.graph_id
+
+    graph = evaluator_context.graph
+    graph.add_result(
+        TaskResult(
+            task_id=ok_task.task_id,
+            graph_id=graph.graph_id,
+            status=TaskStatus.Success,
+            result="OK",
+        )
+    )
+    mock_storage.load_graph.return_value = graph
+
+    # Returning None means lease not acquired — task is skipped.
+    mock_storage.try_acquire_lease.return_value = None
+
+    evaluator_context.evaluator.task = ok_task
+    ok_task.msg = evaluator_context.make_message(ok_task)
+
+    with patch("boilermaker.evaluators.task_graph.eval_task") as mock_eval_task:
+        mock_eval_task.return_value = TaskResult(
+            task_id=ok_task.task_id,
+            graph_id=ok_task.graph_id,
+            status=TaskStatus.Success,
+            result="OK",
+        )
+        result = await evaluator_context.evaluator()
+
+    assert result.status == TaskStatus.Success

--- a/tests/task/test_graph.py
+++ b/tests/task/test_graph.py
@@ -2391,3 +2391,151 @@ def test_mixed_missing_and_pending_results(caplog):
     assert any(t_no_result.task_id in msg for msg in warning_messages), (
         f"Expected warning for task with no result blob. Got: {warning_messages}"
     )
+
+
+# ~~~~ ~~~~ ~~~~ ~~~~ ~~~~ ~~~~ ~~~~ ~~~~ #
+# Coverage gap tests                       #
+# ~~~~ ~~~~ ~~~~ ~~~~ ~~~~ ~~~~ ~~~~ ~~~~ #
+
+def test_schedule_task_raises_when_not_pending():
+    """schedule_task must raise ValueError when the task is already past Pending."""
+    g = task.TaskGraph()
+    t1 = task.Task.default("func1")
+    g.add_task(t1)
+    list(g.generate_pending_results())
+
+    # Manually set to Scheduled so the task is no longer Pending.
+    g.results[t1.task_id].status = task.TaskStatus.Scheduled
+
+    with pytest.raises(ValueError, match="not pending"):
+        g.schedule_task(t1.task_id)
+
+
+def test_is_complete_empty_graph_returns_false():
+    """is_complete must return False when the graph has no children (line 415)."""
+    g = task.TaskGraph()
+    assert g.is_complete() is False
+
+
+def test_is_complete_with_skipped_unreachable_task():
+    """is_complete returns True when a task has no result (status is None) but all its
+    antecedents finished with at least one failure (task will never run — line 427 continue)."""
+    g = task.TaskGraph()
+    t1 = task.Task.default("root")
+    t2 = task.Task.default("child")
+    g.add_task(t1)
+    g.add_task(t2, parent_ids=[t1.task_id])
+
+    # Only populate the result for t1; t2 has no entry in results (status is None).
+    g.results[t1.task_id] = task.TaskResultSlim(
+        task_id=t1.task_id,
+        graph_id=g.graph_id,
+        status=task.TaskStatus.Failure,
+    )
+    # t2 intentionally absent from g.results so get_status returns None.
+
+    assert g.is_complete() is True
+
+
+def test_generate_scheduled_regular_child():
+    """generate_scheduled_tasks must yield regular children that are already Scheduled
+    when all antecedents have succeeded (lines 360-361)."""
+    g = task.TaskGraph()
+    t1 = task.Task.default("root")
+    t2 = task.Task.default("child")
+    g.add_task(t1)
+    g.add_task(t2, parent_ids=[t1.task_id])
+    list(g.generate_pending_results())
+
+    # t1 succeeded, t2 is Scheduled (e.g. SB publish happened but blob write is pending).
+    g.add_result(task.TaskResult(task_id=t1.task_id, graph_id=g.graph_id, status=task.TaskStatus.Success))
+    g.results[t2.task_id].status = task.TaskStatus.Scheduled
+
+    scheduled = list(g.generate_scheduled_tasks())
+    assert t2 in scheduled
+
+
+def test_generate_already_scheduled_failure_callback():
+    """generate_scheduled_tasks must yield failure callbacks that are
+    already in Scheduled status (lines 371-372)."""
+    g = task.TaskGraph()
+    t1 = task.Task.default("root")
+    cb = task.Task.default("on_fail")
+    g.add_task(t1)
+    g.add_failure_callback(t1.task_id, cb)
+    list(g.generate_pending_results())
+
+    # t1 failed, failure callback is Scheduled.
+    g.add_result(task.TaskResult(task_id=t1.task_id, graph_id=g.graph_id, status=task.TaskStatus.Failure))
+    g.results[cb.task_id].status = task.TaskStatus.Scheduled
+
+    scheduled = list(g.generate_scheduled_tasks())
+    assert cb in scheduled
+
+
+def test_get_reachable_failure_tasks_nested_success_chain():
+    """_get_reachable_failure_tasks follows success edges of failure callback tasks
+    (lines 499-504) when the intermediate task succeeded."""
+    g = task.TaskGraph()
+    t1 = task.Task.default("root")
+    cb1 = task.Task.default("on_fail")
+    cb2 = task.Task.default("after_on_fail")  # success child of cb1
+    g.add_task(t1)
+    g.add_failure_callback(t1.task_id, cb1)
+    # cb2 is a regular child of cb1 (runs when cb1 succeeds).
+    g.add_task(cb2, parent_ids=[cb1.task_id])
+    list(g.generate_pending_results())
+
+    # t1 failed — cb1 is reachable.  cb1 succeeded — cb2 is reachable via success edge.
+    g.add_result(task.TaskResult(task_id=t1.task_id, graph_id=g.graph_id, status=task.TaskStatus.Failure))
+    g.add_result(task.TaskResult(task_id=cb1.task_id, graph_id=g.graph_id, status=task.TaskStatus.Success))
+
+    reachable = g._get_reachable_failure_tasks()
+    assert cb1.task_id in reachable
+    assert cb2.task_id in reachable
+
+
+def test_get_reachable_failure_tasks_nested_failure_chain():
+    """_get_reachable_failure_tasks follows fail_edges of failure callback tasks
+    (lines 491-494): a failure callback that itself has a failure callback."""
+    g = task.TaskGraph()
+    t1 = task.Task.default("root")
+    cb1 = task.Task.default("on_fail_1")
+    cb2 = task.Task.default("on_fail_2")  # failure callback of cb1
+    g.add_task(t1)
+    g.add_failure_callback(t1.task_id, cb1)
+    g.add_failure_callback(cb1.task_id, cb2)
+    list(g.generate_pending_results())
+
+    # t1 failed → cb1 reachable.  cb1 also in fail_edges → cb2 reachable via fail edge.
+    g.add_result(task.TaskResult(task_id=t1.task_id, graph_id=g.graph_id, status=task.TaskStatus.Failure))
+
+    reachable = g._get_reachable_failure_tasks()
+    assert cb1.task_id in reachable
+    assert cb2.task_id in reachable
+
+
+def test_cycle_detection_via_fail_edges():
+    """_has_cycle_dfs must detect a cycle introduced through fail_edges (line 122)."""
+    g = task.TaskGraph()
+    t1 = task.Task.default("root")
+    t2 = task.Task.default("cb")
+    g.add_task(t1)
+    g.add_failure_callback(t1.task_id, t2)
+    list(g.generate_pending_results())
+
+    # Manually introduce a cycle in fail_edges: t2's failure callback points back to t1.
+    g.fail_edges[t2.task_id] = {t1.task_id}
+
+    assert g._detect_cycles() is True
+
+
+def test_task_chain_len():
+    """TaskChain.__len__ returns the number of tasks in the chain (line 558)."""
+    from boilermaker.task.graph import TaskChain
+
+    t1 = task.Task.default("a")
+    t2 = task.Task.default("b")
+    t3 = task.Task.default("c")
+    chain = TaskChain(t1, t2, t3)
+    assert len(chain) == 3


### PR DESCRIPTION
We should not always settle the ServiceBus message.

Originally, we were a little too paranoid that our graph was going to send duplicate messages and then we'd spiral outward, so we were aggressively settling everything, but after rethinking this, settling in all cases makes it more likely that we'll leave in our graph in a stalled state. 

This PR also adds more tests (which is the bulk of the lines added in the diff.)