### PR TITLE
Add Graph Renderer into a local temp HTML file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,9 +23,12 @@ todo*.md
 tmp/
 .bmo/
 .claude/
+docs/tdd/
+docs/ux/
 specs/states/
 specs/*out
 specs/*TTrace*
 specs/*trace*
 specs/*toolbox/
 states/
+.envrc

--- a/boilermaker/cli/__init__.py
+++ b/boilermaker/cli/__init__.py
@@ -77,6 +77,11 @@ def _add_inspect_subparser(subparsers: argparse._SubParsersAction) -> None:  # n
         action="store_true",
         help="Output JSON instead of Rich-formatted output",
     )
+    inspect_parser.add_argument(
+        "--visual",
+        action="store_true",
+        help="Generate an HTML DAG visualization and open in browser (requires --graph)",
+    )
 
 
 def _add_recover_subparser(subparsers: argparse._SubParsersAction) -> None:  # noqa: SLF001
@@ -158,6 +163,13 @@ def _validate_inspect_args(args: argparse.Namespace, parser: argparse.ArgumentPa
         parser.error("inspect: one of --graph or --task is required")
     if args.task is not None and args.graph is None:
         parser.error("inspect: --task requires --graph")
+    if hasattr(args, "visual") and args.visual:
+        if args.graph is None:
+            parser.error("inspect: --visual requires --graph")
+        if args.json:
+            parser.error("inspect: --visual and --json are mutually exclusive")
+        if args.task is not None:
+            parser.error("inspect: --visual and --task are mutually exclusive")
 
 
 def main() -> None:
@@ -192,6 +204,7 @@ def main() -> None:
                     console=console,
                     output_json=args.json,
                     task_id=args.task,
+                    visual=getattr(args, "visual", False),
                 )
             if args.command == "recover":
                 return await run_recover(

--- a/boilermaker/cli/_mermaid.py
+++ b/boilermaker/cli/_mermaid.py
@@ -10,7 +10,7 @@ from boilermaker.task.result import TaskResult
 from boilermaker.task.task_id import TaskId
 
 # ---------------------------------------------------------------------------
-# Color mapping (from UX spec docs/ux/dag-visualization.md)
+# Color mapping
 # ---------------------------------------------------------------------------
 
 _STATUS_COLORS: dict[str, tuple[str, str, str]] = {
@@ -46,6 +46,11 @@ _STATUS_TO_CLASS: dict[TaskStatus, str] = {
 def _sanitize_id(task_id: TaskId) -> str:
     """Replace hyphens with underscores for valid Mermaid node IDs."""
     return str(task_id).replace("-", "_")
+
+
+def _escape_label(text: str) -> str:
+    """Escape text for use inside a Mermaid quoted label."""
+    return text.replace("\\", "\\\\").replace('"', "#quot;").replace("\n", " ")
 
 
 def _short_task_id(task_id: TaskId) -> str:
@@ -97,7 +102,7 @@ def generate_mermaid(graph: TaskGraph, stalled_task_ids: set[TaskId]) -> str:
         is_stalled = task_id in stalled_task_ids
         cls = _node_class(status, is_stalled, has_blob)
 
-        label_parts = [task.function_name]
+        label_parts = [_escape_label(task.function_name)]
         if not has_blob:
             label_parts.append("NO BLOB")
         label_parts.append(f"...{_short_task_id(task_id)}")
@@ -116,9 +121,9 @@ def generate_mermaid(graph: TaskGraph, stalled_task_ids: set[TaskId]) -> str:
         cls = _node_class(status, is_stalled, has_blob)
 
         if task_id == graph.all_failed_callback_id:
-            label_parts = ["on_all_failed", task.function_name]
+            label_parts = ["on_all_failed", _escape_label(task.function_name)]
         else:
-            label_parts = [task.function_name]
+            label_parts = [_escape_label(task.function_name)]
 
         if not has_blob:
             label_parts.append("NO BLOB")

--- a/boilermaker/cli/_mermaid.py
+++ b/boilermaker/cli/_mermaid.py
@@ -6,9 +6,8 @@ import json
 from typing import Any
 
 from boilermaker.task import TaskGraph, TaskStatus
-from boilermaker.task.result import TaskResult, TaskResultSlim
+from boilermaker.task.result import TaskResult
 from boilermaker.task.task_id import TaskId
-
 
 # ---------------------------------------------------------------------------
 # Color mapping (from UX spec docs/ux/dag-visualization.md)
@@ -169,13 +168,10 @@ def generate_mermaid(graph: TaskGraph, stalled_task_ids: set[TaskId]) -> str:
         lines.append(f"    classDef {cls_name} fill:{fill},stroke:{stroke},color:{color}")
 
     # Stalled composite classes: preserve status fill color, add dashed stroke overlay
-    _STALLED_OVERLAY = "stroke-dasharray:5,stroke-width:3px,stroke:#333"
+    _stalled_overlay = "stroke-dasharray:5,stroke-width:3px,stroke:#333"
     for cls_name, (fill, stroke, color) in _STATUS_COLORS.items():
         composite = f"stalled{cls_name[0].upper()}{cls_name[1:]}"
-        lines.append(
-            f"    classDef {composite} fill:{fill},stroke:{stroke},color:{color},"
-            f"{_STALLED_OVERLAY}"
-        )
+        lines.append(f"    classDef {composite} fill:{fill},stroke:{stroke},color:{color},{_stalled_overlay}")
 
     return "\n".join(lines)
 

--- a/boilermaker/cli/_mermaid.py
+++ b/boilermaker/cli/_mermaid.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Any, cast
 
 from boilermaker.task import TaskGraph, TaskStatus
 from boilermaker.task.result import TaskResult
@@ -133,19 +133,17 @@ def generate_mermaid(graph: TaskGraph, stalled_task_ids: set[TaskId]) -> str:
     fail_edge_indices: list[int] = []
 
     # Success-path edges (solid arrows)
-    for parent_id in sorted(graph.edges, key=str):
-        child_ids = graph.edges[parent_id]
+    for parent_id in cast(list[TaskId], sorted(graph.edges, key=str)):
         parent_san = _sanitize_id(parent_id)
-        for child_id in sorted(child_ids, key=str):
+        for child_id in cast(list[TaskId], sorted(graph.edges[parent_id], key=str)):
             child_san = _sanitize_id(child_id)
             lines.append(f"    {parent_san} --> {child_san}")
             edge_index += 1
 
     # Failure-path edges (dashed arrows)
-    for parent_id in sorted(graph.fail_edges, key=str):
-        child_ids = graph.fail_edges[parent_id]
+    for parent_id in cast(list[TaskId], sorted(graph.fail_edges, key=str)):
         parent_san = _sanitize_id(parent_id)
-        for child_id in sorted(child_ids, key=str):
+        for child_id in cast(list[TaskId], sorted(graph.fail_edges[parent_id], key=str)):
             child_san = _sanitize_id(child_id)
             lines.append(f"    {parent_san} -.-> {child_san}")
             fail_edge_indices.append(edge_index)

--- a/boilermaker/cli/_mermaid.py
+++ b/boilermaker/cli/_mermaid.py
@@ -1,0 +1,241 @@
+"""Pure-function Mermaid flowchart generator for TaskGraph DAG visualization."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from boilermaker.task import TaskGraph, TaskStatus
+from boilermaker.task.result import TaskResult, TaskResultSlim
+from boilermaker.task.task_id import TaskId
+
+
+# ---------------------------------------------------------------------------
+# Color mapping (from UX spec docs/ux/dag-visualization.md)
+# ---------------------------------------------------------------------------
+
+_STATUS_COLORS: dict[str, tuple[str, str, str]] = {
+    # status_key: (fill, stroke, text_color)
+    "success": ("#28a745", "#1e7e34", "#fff"),
+    "failure": ("#dc3545", "#bd2130", "#fff"),
+    "retriesExhausted": ("#dc3545", "#bd2130", "#fff"),
+    "deadlettered": ("#851923", "#5a1018", "#fff"),
+    "pending": ("#6c757d", "#545b62", "#fff"),
+    "scheduled": ("#ffc107", "#d39e00", "#000"),
+    "started": ("#fd7e14", "#d36b0f", "#fff"),
+    "retry": ("#e0a800", "#c69500", "#000"),
+    "noBlob": ("#343a40", "#1d2124", "#fff"),
+}
+
+_STATUS_TO_CLASS: dict[TaskStatus, str] = {
+    TaskStatus.Success: "success",
+    TaskStatus.Failure: "failure",
+    TaskStatus.RetriesExhausted: "retriesExhausted",
+    TaskStatus.Deadlettered: "deadlettered",
+    TaskStatus.Pending: "pending",
+    TaskStatus.Scheduled: "scheduled",
+    TaskStatus.Started: "started",
+    TaskStatus.Retry: "retry",
+}
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _sanitize_id(task_id: TaskId) -> str:
+    """Replace hyphens with underscores for valid Mermaid node IDs."""
+    return str(task_id).replace("-", "_")
+
+
+def _short_task_id(task_id: TaskId) -> str:
+    """Return the last 12 characters of a task ID for compact display."""
+    full = str(task_id)
+    return full[-12:] if len(full) > 12 else full
+
+
+def _node_class(status: TaskStatus | None, is_stalled: bool, has_blob: bool) -> str:
+    """Map task state to the Mermaid classDef name.
+
+    Stalled nodes receive a composite class (e.g. ``stalledScheduled``) that
+    preserves the status fill color while adding a thick dashed stroke overlay.
+    """
+    if not has_blob:
+        return "noBlob"
+    base_cls = _STATUS_TO_CLASS.get(status, "pending") if status is not None else "noBlob"
+    if is_stalled:
+        return f"stalled{base_cls[0].upper()}{base_cls[1:]}"
+    return base_cls
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def generate_mermaid(graph: TaskGraph, stalled_task_ids: set[TaskId]) -> str:
+    """Generate a Mermaid flowchart string from a TaskGraph.
+
+    Returns a complete ``flowchart LR`` string including node definitions,
+    edge definitions, classDef declarations, and linkStyle declarations.
+
+    Pure function: no I/O, no side effects.
+    """
+    lines: list[str] = ["flowchart LR"]
+
+    # -- Node definitions --------------------------------------------------
+
+    all_task_ids: list[TaskId] = []
+
+    # Children (rectangle shape)
+    for task_id, task in graph.children.items():
+        all_task_ids.append(task_id)
+        sanitized = _sanitize_id(task_id)
+        result = graph.results.get(task_id)
+        has_blob = result is not None
+        status = result.status if result else None
+        is_stalled = task_id in stalled_task_ids
+        cls = _node_class(status, is_stalled, has_blob)
+
+        label_parts = [task.function_name]
+        if not has_blob:
+            label_parts.append("NO BLOB")
+        label_parts.append(f"...{_short_task_id(task_id)}")
+        label = "\\n".join(label_parts)
+
+        lines.append(f'    {sanitized}["{label}"]:::{cls}')
+
+    # Fail children (hexagon shape)
+    for task_id, task in graph.fail_children.items():
+        all_task_ids.append(task_id)
+        sanitized = _sanitize_id(task_id)
+        result = graph.results.get(task_id)
+        has_blob = result is not None
+        status = result.status if result else None
+        is_stalled = task_id in stalled_task_ids
+        cls = _node_class(status, is_stalled, has_blob)
+
+        if task_id == graph.all_failed_callback_id:
+            label_parts = ["on_all_failed", task.function_name]
+        else:
+            label_parts = [task.function_name]
+
+        if not has_blob:
+            label_parts.append("NO BLOB")
+        label_parts.append(f"...{_short_task_id(task_id)}")
+        label = "\\n".join(label_parts)
+
+        lines.append(f'    {sanitized}{{{{"{label}"}}}}:::{cls}')
+
+    # -- Edge definitions (track indices for linkStyle) --------------------
+
+    edge_index = 0
+    fail_edge_indices: list[int] = []
+
+    # Success-path edges (solid arrows)
+    for parent_id in sorted(graph.edges, key=str):
+        child_ids = graph.edges[parent_id]
+        parent_san = _sanitize_id(parent_id)
+        for child_id in sorted(child_ids, key=str):
+            child_san = _sanitize_id(child_id)
+            lines.append(f"    {parent_san} --> {child_san}")
+            edge_index += 1
+
+    # Failure-path edges (dashed arrows)
+    for parent_id in sorted(graph.fail_edges, key=str):
+        child_ids = graph.fail_edges[parent_id]
+        parent_san = _sanitize_id(parent_id)
+        for child_id in sorted(child_ids, key=str):
+            child_san = _sanitize_id(child_id)
+            lines.append(f"    {parent_san} -.-> {child_san}")
+            fail_edge_indices.append(edge_index)
+            edge_index += 1
+
+    # -- linkStyle for failure edges (dashed, red) -------------------------
+
+    for idx in fail_edge_indices:
+        lines.append(f"    linkStyle {idx} stroke:#dc3545,stroke-width:2px")
+
+    # -- Click callbacks (Mermaid native click directive) --------------------
+
+    for task_id in all_task_ids:
+        sanitized = _sanitize_id(task_id)
+        lines.append(f"    click {sanitized} showDetail")
+
+    # -- classDef declarations ---------------------------------------------
+
+    for cls_name, (fill, stroke, color) in _STATUS_COLORS.items():
+        lines.append(f"    classDef {cls_name} fill:{fill},stroke:{stroke},color:{color}")
+
+    # Stalled composite classes: preserve status fill color, add dashed stroke overlay
+    _STALLED_OVERLAY = "stroke-dasharray:5,stroke-width:3px,stroke:#333"
+    for cls_name, (fill, stroke, color) in _STATUS_COLORS.items():
+        composite = f"stalled{cls_name[0].upper()}{cls_name[1:]}"
+        lines.append(
+            f"    classDef {composite} fill:{fill},stroke:{stroke},color:{color},"
+            f"{_STALLED_OVERLAY}"
+        )
+
+    return "\n".join(lines)
+
+
+def build_task_data_json(graph: TaskGraph, stalled_task_ids: set[TaskId]) -> str:
+    """Build a JSON string of task metadata for the HTML detail panel.
+
+    Each task entry includes: task_id, function_name, status, type
+    (child/fail_child/all_failed_callback), is_stalled. When the graph
+    contains full ``TaskResult`` instances (loaded via ``load_graph(full=True)``),
+    entries also include ``result``, ``errors``, and ``formatted_exception``
+    where present and non-empty.
+
+    Fields that are ``None`` or empty are omitted from the JSON entry.
+    """
+    entries: dict[str, dict[str, Any]] = {}
+
+    def _build_entry(
+        task_id: TaskId,
+        function_name: str,
+        task_type: str,
+    ) -> dict[str, Any]:
+        result = graph.results.get(task_id)
+        status = str(result.status) if result is not None else None
+        is_stalled = task_id in stalled_task_ids
+
+        entry: dict[str, Any] = {
+            "task_id": str(task_id),
+            "function_name": function_name,
+            "status": status,
+            "type": task_type,
+            "is_stalled": is_stalled,
+        }
+
+        # Include rich fields when we have a full TaskResult
+        if isinstance(result, TaskResult):
+            if result.result is not None:
+                if isinstance(result.result, str):
+                    entry["result"] = result.result
+                else:
+                    entry["result"] = json.dumps(result.result, indent=2, default=str)
+
+            if result.errors is not None and len(result.errors) > 0:
+                entry["errors"] = result.errors
+
+            if result.formatted_exception is not None and result.formatted_exception != "":
+                entry["formatted_exception"] = result.formatted_exception
+
+        return entry
+
+    # Children
+    for task_id, task in graph.children.items():
+        entries[_sanitize_id(task_id)] = _build_entry(task_id, task.function_name, "child")
+
+    # Fail children
+    for task_id, task in graph.fail_children.items():
+        if task_id == graph.all_failed_callback_id:
+            task_type = "all_failed_callback"
+        else:
+            task_type = "fail_child"
+        entries[_sanitize_id(task_id)] = _build_entry(task_id, task.function_name, task_type)
+
+    return json.dumps(entries, indent=2)

--- a/boilermaker/cli/_visual.py
+++ b/boilermaker/cli/_visual.py
@@ -282,6 +282,8 @@ def open_visual(
 
     console.print("Opening DAG visualization in browser...")
     console.print(f"HTML file: {path}")
-    webbrowser.open(f"file://{path}")
+    from pathlib import Path
+
+    webbrowser.open(Path(path).resolve().as_uri())
 
     return path

--- a/boilermaker/cli/_visual.py
+++ b/boilermaker/cli/_visual.py
@@ -244,7 +244,7 @@ def render_visual_html(
     }});
   </script>
 </body>
-</html>"""
+</html>"""  # noqa: E501
 
 
 def open_visual(

--- a/boilermaker/cli/_visual.py
+++ b/boilermaker/cli/_visual.py
@@ -8,6 +8,7 @@ import webbrowser
 
 from rich.console import Console
 
+from boilermaker.cli._mermaid import build_task_data_json, generate_mermaid
 from boilermaker.task import TaskGraph, TaskStatus
 from boilermaker.task.task_id import TaskId
 
@@ -112,6 +113,12 @@ def render_visual_html(
     # This is the standard mitigation for inline JSON in script elements.
     safe_task_data_json = task_data_json.replace("</", r"<\/")
 
+    status_line = (
+        f"Status: {html.escape(str(summary['overall']))} "
+        f"| Tasks: {summary['complete_tasks']}/{summary['total_tasks']} "
+        f"| Failures: {summary['failure_count']} | Stalled: {summary['stalled_count']}"
+    )
+
     return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -157,7 +164,9 @@ def render_visual_html(
 <body>
   <header>
     <h1>Graph: {graph_id}</h1>
-    <div class="summary">Status: {html.escape(str(summary["overall"]))} | Tasks: {summary["complete_tasks"]}/{summary["total_tasks"]} | Failures: {summary["failure_count"]} | Stalled: {summary["stalled_count"]}</div>
+    <div class="summary">
+      Status: {status_line}
+    </div>
   </header>
   {legend_html}
   <div class="mermaid">
@@ -257,8 +266,6 @@ def open_visual(
     Returns:
         The absolute path to the generated HTML file.
     """
-    from boilermaker.cli._mermaid import build_task_data_json, generate_mermaid
-
     mermaid_text = generate_mermaid(graph, stalled_task_ids)
     task_data_json = build_task_data_json(graph, stalled_task_ids)
     html_content = render_visual_html(mermaid_text, task_data_json, graph)

--- a/boilermaker/cli/_visual.py
+++ b/boilermaker/cli/_visual.py
@@ -1,0 +1,280 @@
+"""HTML assembly, temp file creation, and browser opening for DAG visualization."""
+
+from __future__ import annotations
+
+import html
+import tempfile
+import webbrowser
+
+from rich.console import Console
+
+from boilermaker.task import TaskGraph, TaskStatus
+from boilermaker.task.task_id import TaskId
+
+MERMAID_CDN_URL = "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"
+
+# Color mapping matching the UX spec and _output.py semantics.
+STATUS_COLORS: dict[str, tuple[str, str]] = {
+    # status_name -> (fill, label)
+    "Success": ("#28a745", "Success"),
+    "Failure": ("#dc3545", "Failure"),
+    "RetriesExhausted": ("#dc3545", "Retries Exhausted"),
+    "Deadlettered": ("#851923", "Deadlettered"),
+    "Pending": ("#6c757d", "Pending"),
+    "Scheduled": ("#ffc107", "Scheduled"),
+    "Started": ("#fd7e14", "Started"),
+    "Retry": ("#e0a800", "Retry"),
+    "No Blob": ("#343a40", "No Blob"),
+    "Stalled": ("stroke overlay", "Stalled (dashed border)"),
+}
+
+
+def _compute_summary(graph: TaskGraph) -> dict[str, str | int]:
+    """Compute summary statistics from a TaskGraph for the HTML header."""
+    stalled = graph.detect_stalled_tasks()
+    stalled_count = len(stalled)
+    is_complete = graph.is_complete()
+    has_failures = graph.has_failures()
+
+    total_tasks = len(graph.children) + len(graph.fail_children)
+    complete_tasks = sum(
+        1
+        for task_id in list(graph.children) + list(graph.fail_children)
+        if (r := graph.results.get(task_id)) and r.status == TaskStatus.Success
+    )
+    failure_count = sum(
+        1
+        for r in graph.results.values()
+        if r.status in (TaskStatus.Failure, TaskStatus.RetriesExhausted, TaskStatus.Deadlettered)
+    )
+
+    if is_complete and not has_failures:
+        overall = "Complete"
+    elif has_failures:
+        overall = "Has Failures"
+    else:
+        overall = "In Progress"
+
+    return {
+        "overall": overall,
+        "complete_tasks": complete_tasks,
+        "total_tasks": total_tasks,
+        "failure_count": failure_count,
+        "stalled_count": stalled_count,
+    }
+
+
+def _build_legend_html() -> str:
+    """Build the color legend HTML with swatches for each status."""
+    items: list[str] = []
+    for name, (color, label) in STATUS_COLORS.items():
+        if name == "Stalled":
+            # Stalled uses a stroke overlay, not a fill color
+            swatch_style = (
+                "display:inline-block;width:18px;height:18px;border:3px dashed #ffc107;"
+                "background:#6c757d;border-radius:3px;vertical-align:middle;margin-right:6px;"
+            )
+        else:
+            swatch_style = (
+                f"display:inline-block;width:18px;height:18px;background:{color};"
+                "border-radius:3px;vertical-align:middle;margin-right:6px;"
+            )
+        items.append(
+            f'<span style="margin-right:16px;">'
+            f'<span style="{swatch_style}"></span>{html.escape(label)}</span>'
+        )
+    return '<div class="legend">' + "\n".join(items) + "</div>"
+
+
+def render_visual_html(
+    mermaid_text: str,
+    task_data_json: str,
+    graph: TaskGraph,
+) -> str:
+    """Assemble a self-contained HTML string with the Mermaid diagram.
+
+    The HTML includes a header with summary stats, a color legend, the Mermaid
+    flowchart, a click-to-reveal detail panel, and inline JS for interaction.
+
+    Args:
+        mermaid_text: A complete Mermaid flowchart string (e.g. ``flowchart LR ...``).
+        task_data_json: JSON string mapping sanitized task IDs to task metadata.
+        graph: The TaskGraph used to compute summary statistics.
+
+    Returns:
+        A complete HTML document string.
+    """
+    graph_id = html.escape(str(graph.graph_id))
+    summary = _compute_summary(graph)
+    legend_html = _build_legend_html()
+
+    # Escape "</script>" sequences to prevent breaking out of the <script> tag.
+    # This is the standard mitigation for inline JSON in script elements.
+    safe_task_data_json = task_data_json.replace("</", r"<\/")
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Boilermaker DAG: {graph_id}</title>
+  <script src="{MERMAID_CDN_URL}"></script>
+  <style>
+    body {{
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      margin: 0; padding: 20px; background: #f8f9fa;
+    }}
+    header {{ margin-bottom: 16px; }}
+    h1 {{ margin: 0 0 8px 0; font-size: 1.4rem; }}
+    .summary {{ color: #495057; font-size: 0.95rem; }}
+    .legend {{
+      margin: 12px 0; padding: 10px 14px; background: #fff;
+      border: 1px solid #dee2e6; border-radius: 6px; font-size: 0.85rem;
+    }}
+    .mermaid {{ background: #fff; padding: 16px; border-radius: 6px; border: 1px solid #dee2e6; }}
+    #detail-panel {{
+      display: none; position: fixed; top: 0; right: 0; width: 400px; height: 100%;
+      background: #fff; border-left: 2px solid #dee2e6; padding: 20px;
+      overflow-y: auto; box-shadow: -4px 0 12px rgba(0,0,0,0.1); z-index: 1000;
+    }}
+    #detail-panel.visible {{ display: block; }}
+    #detail-panel h2 {{ margin-top: 0; font-size: 1.1rem; }}
+    #detail-panel .field {{ margin-bottom: 12px; }}
+    #detail-panel .field-label {{ font-weight: 600; color: #495057; font-size: 0.85rem; }}
+    #detail-panel .field-value {{ margin-top: 2px; }}
+    #detail-panel pre {{
+      background: #f1f3f5; padding: 12px; border-radius: 4px;
+      overflow-x: auto; font-size: 0.82rem; white-space: pre-wrap;
+      word-wrap: break-word; font-family: 'SF Mono', Monaco, Consolas, monospace;
+    }}
+    #detail-panel ul {{ margin: 4px 0; padding-left: 20px; }}
+    #detail-panel li {{ margin-bottom: 4px; }}
+    #detail-close {{
+      position: absolute; top: 12px; right: 12px; cursor: pointer;
+      background: none; border: none; font-size: 1.2rem; color: #495057;
+    }}
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Graph: {graph_id}</h1>
+    <div class="summary">Status: {html.escape(str(summary["overall"]))} | Tasks: {summary["complete_tasks"]}/{summary["total_tasks"]} | Failures: {summary["failure_count"]} | Stalled: {summary["stalled_count"]}</div>
+  </header>
+  {legend_html}
+  <div class="mermaid">
+{html.escape(mermaid_text)}
+  </div>
+  <div id="detail-panel">
+    <button id="detail-close" aria-label="Close">&times;</button>
+    <div id="detail-content"></div>
+  </div>
+  <script>
+    const taskData = {safe_task_data_json};
+
+    mermaid.initialize({{ startOnLoad: false, securityLevel: 'loose' }});
+
+    function showDetail(nodeId) {{
+      var task = taskData[nodeId];
+      if (!task) return;
+      var h = '<h2>' + escapeHtml(task.function_name) + '</h2>';
+      h += field('Task ID', escapeHtml(task.task_id));
+      h += field('Function', escapeHtml(task.function_name));
+      h += field('Status', escapeHtml(task.status || 'unknown'));
+      h += field('Type', escapeHtml(task.type));
+      if (task.is_stalled) {{
+        h += field('Stalled', '<strong style="color:#dc3545;">Yes</strong>');
+      }}
+      if (task.result !== undefined && task.result !== null) {{
+        h += field('Result', '<pre>' + escapeHtml(String(task.result)) + '</pre>');
+      }}
+      if (task.errors && task.errors.length > 0) {{
+        var items = task.errors.map(function(e) {{ return '<li>' + escapeHtml(e) + '</li>'; }}).join('');
+        h += field('Errors', '<ul>' + items + '</ul>');
+      }}
+      if (task.formatted_exception) {{
+        h += field('Exception', '<pre>' + escapeHtml(task.formatted_exception) + '</pre>');
+      }}
+      document.getElementById('detail-content').innerHTML = h;
+      document.getElementById('detail-panel').classList.add('visible');
+    }}
+
+    function field(label, value) {{
+      return '<div class="field"><div class="field-label">' + label + '</div><div class="field-value">' + value + '</div></div>';
+    }}
+
+    function escapeHtml(text) {{
+      var d = document.createElement('div');
+      d.appendChild(document.createTextNode(text));
+      return d.innerHTML;
+    }}
+
+    function closePanel() {{
+      document.getElementById('detail-panel').classList.remove('visible');
+    }}
+
+    document.getElementById('detail-close').addEventListener('click', closePanel);
+
+    document.addEventListener('keydown', function(e) {{
+      if (e.key === 'Escape') closePanel();
+    }});
+
+    document.addEventListener('click', function(e) {{
+      var panel = document.getElementById('detail-panel');
+      if (panel.classList.contains('visible') && !panel.contains(e.target)) {{
+        var node = e.target.closest('.node');
+        if (!node) closePanel();
+      }}
+    }});
+
+    // Render Mermaid explicitly; click callbacks are handled via Mermaid's
+    // native "click nodeId showDetail" directives in the flowchart definition.
+    // securityLevel: 'loose' is required for these callbacks to fire.
+    mermaid.run().then(function() {{
+      // Style all nodes as clickable after rendering completes.
+      var nodes = document.querySelectorAll('.node');
+      nodes.forEach(function(node) {{ node.style.cursor = 'pointer'; }});
+    }});
+  </script>
+</body>
+</html>"""
+
+
+def open_visual(
+    graph: TaskGraph,
+    stalled_task_ids: set[TaskId],
+    console: Console,
+) -> str:
+    """Generate a visual DAG HTML file and open it in the default browser.
+
+    Orchestrates the full visual rendering pipeline: generates Mermaid text
+    and task data JSON via ``_mermaid.py``, assembles the HTML, writes it
+    to a temp file, and opens the browser.
+
+    Args:
+        graph: The TaskGraph to visualize.
+        stalled_task_ids: Pre-computed set of stalled task IDs.
+        console: Rich Console for printing status messages.
+
+    Returns:
+        The absolute path to the generated HTML file.
+    """
+    from boilermaker.cli._mermaid import build_task_data_json, generate_mermaid
+
+    mermaid_text = generate_mermaid(graph, stalled_task_ids)
+    task_data_json = build_task_data_json(graph, stalled_task_ids)
+    html_content = render_visual_html(mermaid_text, task_data_json, graph)
+
+    with tempfile.NamedTemporaryFile(
+        suffix=".html",
+        prefix="boilermaker-dag-",
+        delete=False,
+        mode="w",
+        encoding="utf-8",
+    ) as f:
+        f.write(html_content)
+        path = f.name
+
+    console.print("Opening DAG visualization in browser...")
+    console.print(f"HTML file: {path}")
+    webbrowser.open(f"file://{path}")
+
+    return path

--- a/boilermaker/cli/inspect.py
+++ b/boilermaker/cli/inspect.py
@@ -11,6 +11,7 @@ from boilermaker.cli._output import (
     render_task_detail,
     render_task_table,
 )
+from boilermaker.cli._visual import open_visual
 from boilermaker.storage.blob_storage import BlobClientStorage
 from boilermaker.task.task_id import GraphId
 
@@ -21,12 +22,14 @@ async def run_inspect(
     console: Console | None = None,
     output_json: bool = False,
     task_id: str | None = None,
+    visual: bool = False,
 ) -> int:
     """Load a graph from blob storage and print its status output.
 
     When output_json is True, prints a JSON string directly to stdout and skips
     all Rich rendering. When task_id is provided and output_json is False, renders
-    a focused single-task detail panel instead of the full graph table.
+    a focused single-task detail panel instead of the full graph table. When
+    visual is True, generates an HTML DAG visualization and opens it in the browser.
 
     Args:
         storage: Blob storage client.
@@ -36,12 +39,30 @@ async def run_inspect(
         output_json: When True, print JSON to stdout instead of Rich output.
         task_id: When provided, show detail for this single task instead of the
             full graph table. Ignored when output_json is True.
+        visual: When True, generate an HTML DAG visualization and open in browser.
+            Calls load_graph with full=True to get full TaskResult data.
 
     Returns:
         EXIT_HEALTHY (0) when no stalled tasks are found.
         EXIT_STALLED (1) when stalled tasks are detected.
         EXIT_ERROR (2) when the graph or task is not found.
     """
+    if visual:
+        graph = await storage.load_graph(GraphId(graph_id), full=True)
+        if graph is None:
+            print(f"ERROR: Graph {graph_id} not found in storage.", file=sys.stderr)
+            return EXIT_ERROR
+
+        stalled = graph.detect_stalled_tasks()
+        exit_code = EXIT_STALLED if stalled else EXIT_HEALTHY
+        stalled_task_ids = {tid for tid, _, _ in stalled}
+
+        if console is None:
+            console = Console()
+
+        open_visual(graph, stalled_task_ids, console=console)
+        return exit_code
+
     graph = await storage.load_graph(GraphId(graph_id))
     if graph is None:
         print(f"ERROR: Graph {graph_id} not found in storage.", file=sys.stderr)

--- a/boilermaker/storage/base.py
+++ b/boilermaker/storage/base.py
@@ -10,12 +10,18 @@ class StorageInterface(ABC):
     """Interface for storage operations related to TaskGraph and TaskResult objects."""
 
     @abstractmethod
-    async def load_graph(self, graph_id: GraphId) -> TaskGraph | None:
+    async def load_graph(self, graph_id: GraphId, full: bool = False) -> TaskGraph | None:
         """
         Loads a TaskGraph from storage.
 
         Args:
             graph_id: The GraphId of the TaskGraph to load.
+            full: When True, task result blobs are deserialized as TaskResult
+                (with result, errors, formatted_exception fields) instead of
+                TaskResultSlim. The full blob data is already downloaded in
+                both cases; this flag only controls which Pydantic model is
+                used for parsing. Defaults to False for memory-efficient
+                status-only loading.
 
         Returns:
             The loaded TaskGraph instance, or None if not found.

--- a/boilermaker/storage/blob_storage.py
+++ b/boilermaker/storage/blob_storage.py
@@ -4,7 +4,7 @@ from functools import partial
 
 from aio_azure_clients_toolbox import AzureBlobStorageClient
 from aio_azure_clients_toolbox.clients.azure_blobs import AzureBlobError
-from anyio import create_task_group
+from anyio import CapacityLimiter, create_task_group
 from azure.core import MatchConditions
 from azure.core.exceptions import (
     HttpResponseError,
@@ -44,11 +44,15 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
             credentials=credentials,
         )
 
-    async def load_graph(self, graph_id: GraphId) -> TaskGraph | None:
+    async def load_graph(self, graph_id: GraphId, full: bool = False) -> TaskGraph | None:
         """Loads a TaskGraph from Azure Blob Storage.
 
         Args:
             graph_id: The GraphId to filter TaskResult instances by.
+            full: When True, task result blobs are deserialized as TaskResult
+                (with result, errors, formatted_exception fields) instead of
+                TaskResultSlim. Defaults to False for memory-efficient
+                status-only loading.
         Returns:
             The loaded TaskGraph instance, or None if not found.
         Raises:
@@ -81,23 +85,23 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
                     status_code=None,
                 ) from e
 
-            # Load all TaskResultSlim instances associated with this graph
-            # We don't want to load *all* return values into memory. Just the statuses.
-            try:
-                async for blob in self.list_blobs(prefix=graph_dir):
-                    # DO NOT REDOWNLOAD GRAPH
-                    if blob.name == graph_path:
-                        continue
+            # Load all task result instances associated with this graph.
+            # Downloads run concurrently (up to 10 at a time) for speed.
+            model = TaskResult if full else TaskResultSlim
+            limiter = CapacityLimiter(10)
+
+            async def _download_result(blob_name: str) -> None:
+                async with limiter:
                     try:
-                        async with self.get_blob_download_stream(blob.name) as stream:
+                        async with self.get_blob_download_stream(blob_name) as stream:
                             blob_etag = stream.properties.etag
                             contents = await stream.readall()
-                        tr = TaskResultSlim.model_validate_json(contents)
+                        tr = model.model_validate_json(contents)
                         tr.etag = blob_etag
                     except AzureBlobError as exc:
                         raise BoilermakerStorageError(
-                            f"Failed to load task result blob {blob.name} in graph {graph_id}",
-                            name=blob.name,
+                            f"Failed to load task result blob {blob_name} in graph {graph_id}",
+                            name=blob_name,
                             graph_id=graph_id,
                             status_code=exc.status_code,
                             reason=exc.reason,
@@ -105,7 +109,7 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
                     except ValidationError as e:
                         raise BoilermakerStorageError(
                             f"Failed to deserialize task result in graph {graph_id}: {e}",
-                            name=blob.name,
+                            name=blob_name,
                             graph_id=graph_id,
                             status_code=None,
                             reason="DeserializationError",
@@ -117,6 +121,15 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
                         logger.warning(
                             f"TaskResult {tr.task_id} in graph {graph_dir} with wrong graph_id {tr.graph_id}!"
                         )
+
+            # Collect blob names first (sequential), then download concurrently.
+            # This keeps list_blobs errors outside the task group so they are
+            # caught by the existing AzureBlobError/HttpResponseError handlers.
+            try:
+                blob_names: list[str] = []
+                async for blob in self.list_blobs(prefix=graph_dir):
+                    if blob.name != graph_path:
+                        blob_names.append(blob.name)
             except AzureBlobError as exc:
                 raise BoilermakerStorageError(
                     f"Failed to list blobs for graph {graph_id}",
@@ -131,6 +144,17 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
                     status_code=exc.status_code,
                     reason=str(exc),
                 ) from exc
+
+            # Download result blobs concurrently (up to 10 at a time).
+            try:
+                async with create_task_group() as tg:
+                    for blob_name in blob_names:
+                        tg.start_soon(_download_result, blob_name)
+            except* BoilermakerStorageError as exc_group:
+                # Unwrap the ExceptionGroup — raise the first storage error
+                # directly to preserve the existing API contract.
+                raise exc_group.exceptions[0] from exc_group.exceptions[0].__cause__
+
             return graph
 
     async def try_acquire_lease(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boilermaker-servicebus"
-version = "1.1.0a6"
+version = "1.1.0"
 description = "An async python Background task system using Azure Service Bus Queues"
 authors = [{ "name" = "Erik Aker", "email" = "eaker@mulliganfunding.com" }]
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,3 +99,4 @@ ignore = ["N818", "N805"] # exception naming
 [tool.ruff.lint.isort]
 force-single-line = false
 order-by-type = false
+

--- a/tests/storage/test_blob_storage.py
+++ b/tests/storage/test_blob_storage.py
@@ -540,3 +540,164 @@ async def test_store_and_load_task_result_round_trip(mock_azureblob, blob_storag
 
     assert loaded is not None, "load_task_result returned None — blob path mismatch between store and load"
     assert loaded.status == sample_task_result.status
+
+
+# Tests for load_graph full=True parameter
+
+
+async def test_load_graph_full_true_returns_task_result_instances(
+    mock_azureblob,
+    blob_storage,
+    sample_task_graph,
+    sample_task,
+):
+    """load_graph(full=True) must deserialize task result blobs as TaskResult
+    (not TaskResultSlim), so that rich fields are available to callers.
+    """
+    sample_task_graph.add_task(sample_task)
+    full_result = TaskResult(
+        task_id=sample_task.task_id,
+        graph_id=sample_task.graph_id,
+        status=TaskStatus.Success,
+        result={"key": "value"},
+        errors=None,
+        formatted_exception=None,
+    )
+
+    graph_json = sample_task_graph.model_dump_json()
+    task_result_json = full_result.model_dump_json()
+    _, _, set_return = mock_azureblob
+    set_return.download_blob_returns(None, side_effect=[graph_json, task_result_json])
+    set_return.list_blobs_returns(
+        [
+            BlobProperties(
+                name=f"task-results/{sample_task_graph.graph_id}/test-task.json",
+                last_modified="2023-01-01T00:00:00Z",
+            ),
+        ]
+    )
+
+    result = await blob_storage.load_graph(sample_task_graph.graph_id, full=True)
+
+    assert result is not None
+    assert sample_task.task_id in result.results
+    task_result = result.results[sample_task.task_id]
+    assert isinstance(task_result, TaskResult)
+    assert task_result.result == {"key": "value"}
+
+
+async def test_load_graph_full_true_includes_rich_fields(
+    mock_azureblob,
+    blob_storage,
+    sample_task,
+):
+    """load_graph(full=True) must round-trip all rich TaskResult fields:
+    result, errors, and formatted_exception for both successful and failed tasks.
+    """
+    # Build a graph with two tasks: one successful, one failed.
+    success_task = sample_task
+    failed_task = Task.default("failing_function", args=[], kwargs={})
+
+    graph = TaskGraph()
+    graph.add_task(success_task)
+    graph.add_task(failed_task)
+
+    success_result = TaskResult(
+        task_id=success_task.task_id,
+        graph_id=success_task.graph_id,
+        status=TaskStatus.Success,
+        result={"key": "value"},
+        errors=None,
+        formatted_exception=None,
+    )
+    failed_result = TaskResult(
+        task_id=failed_task.task_id,
+        graph_id=failed_task.graph_id,
+        status=TaskStatus.Failure,
+        result=None,
+        errors=["something went wrong"],
+        formatted_exception="Traceback (most recent call last):\n  File ...\nValueError: bad",
+    )
+
+    graph_json = graph.model_dump_json()
+    _, _, set_return = mock_azureblob
+    set_return.download_blob_returns(
+        None,
+        side_effect=[graph_json, success_result.model_dump_json(), failed_result.model_dump_json()],
+    )
+    set_return.list_blobs_returns(
+        [
+            BlobProperties(
+                name=f"task-results/{graph.graph_id}/{success_task.task_id}.json",
+                last_modified="2023-01-01T00:00:00Z",
+            ),
+            BlobProperties(
+                name=f"task-results/{graph.graph_id}/{failed_task.task_id}.json",
+                last_modified="2023-01-01T00:00:00Z",
+            ),
+        ]
+    )
+
+    loaded = await blob_storage.load_graph(graph.graph_id, full=True)
+    assert loaded is not None
+
+    # Verify successful task round-trips correctly
+    sr = loaded.results[success_task.task_id]
+    assert isinstance(sr, TaskResult)
+    assert sr.result == {"key": "value"}
+    assert sr.errors is None
+    assert sr.formatted_exception is None
+
+    # Verify failed task round-trips correctly
+    fr = loaded.results[failed_task.task_id]
+    assert isinstance(fr, TaskResult)
+    assert fr.result is None
+    assert fr.errors == ["something went wrong"]
+    assert fr.formatted_exception == "Traceback (most recent call last):\n  File ...\nValueError: bad"
+
+
+async def test_load_graph_default_still_returns_task_result_slim(
+    mock_azureblob,
+    blob_storage,
+    sample_task_graph,
+    sample_task,
+):
+    """load_graph() without the full parameter (default False) must continue to
+    return TaskResultSlim instances, confirming backward compatibility.
+    The rich fields (result, errors, formatted_exception) must NOT be populated.
+    """
+    sample_task_graph.add_task(sample_task)
+    # Provide a full TaskResult JSON blob -- the default path should still
+    # parse it as TaskResultSlim, discarding the extra fields.
+    full_result = TaskResult(
+        task_id=sample_task.task_id,
+        graph_id=sample_task.graph_id,
+        status=TaskStatus.Success,
+        result={"key": "value"},
+        errors=["some error"],
+        formatted_exception="Traceback ...",
+    )
+
+    graph_json = sample_task_graph.model_dump_json()
+    task_result_json = full_result.model_dump_json()
+    _, _, set_return = mock_azureblob
+    set_return.download_blob_returns(None, side_effect=[graph_json, task_result_json])
+    set_return.list_blobs_returns(
+        [
+            BlobProperties(
+                name=f"task-results/{sample_task_graph.graph_id}/test-task.json",
+                last_modified="2023-01-01T00:00:00Z",
+            ),
+        ]
+    )
+
+    result = await blob_storage.load_graph(sample_task_graph.graph_id)
+
+    assert result is not None
+    assert sample_task.task_id in result.results
+    task_result = result.results[sample_task.task_id]
+    # Must be TaskResultSlim, not TaskResult
+    assert type(task_result) is TaskResultSlim
+    assert not hasattr(task_result, "result") or task_result.__class__ is TaskResultSlim
+    # TaskResultSlim does not have result/errors/formatted_exception fields
+    assert not isinstance(task_result, TaskResult)

--- a/tests/test_cli_mermaid.py
+++ b/tests/test_cli_mermaid.py
@@ -10,6 +10,10 @@ from boilermaker.cli._mermaid import (
     build_task_data_json,
     generate_mermaid,
 )
+from boilermaker.task import Task, TaskGraph, TaskStatus
+from boilermaker.task.result import TaskResult, TaskResultSlim
+from boilermaker.task.task_id import TaskId
+
 
 # Helper to look up an entry in the dict-keyed task data JSON by function name.
 def _find_entry_by_func(parsed: dict, func_name: str) -> dict:
@@ -18,10 +22,6 @@ def _find_entry_by_func(parsed: dict, func_name: str) -> dict:
         if entry["function_name"] == func_name:
             return entry
     raise KeyError(f"No entry with function_name={func_name!r}")
-from boilermaker.task import Task, TaskGraph, TaskStatus
-from boilermaker.task.result import TaskResult, TaskResultSlim
-from boilermaker.task.task_id import TaskId
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -95,7 +95,7 @@ class TestShortTaskId:
 
 
 class TestNodeClass:
-    def test_no_blob_returns_noBlob(self):
+    def test_no_blob_returns_no_blob(self):
         assert _node_class(None, False, False) == "noBlob"
 
     def test_stalled_returns_composite_class(self):
@@ -107,7 +107,7 @@ class TestNodeClass:
     def test_failure_returns_failure(self):
         assert _node_class(TaskStatus.Failure, False, True) == "failure"
 
-    def test_retries_exhausted_returns_retriesExhausted(self):
+    def test_retries_exhausted_returns_retries_exhausted(self):
         assert _node_class(TaskStatus.RetriesExhausted, False, True) == "retriesExhausted"
 
     def test_deadlettered_returns_deadlettered(self):
@@ -125,7 +125,7 @@ class TestNodeClass:
     def test_retry_returns_retry(self):
         assert _node_class(TaskStatus.Retry, False, True) == "retry"
 
-    def test_has_blob_none_status_returns_noBlob(self):
+    def test_has_blob_none_status_returns_no_blob(self):
         # blob exists but status is None (edge case)
         assert _node_class(None, False, True) == "noBlob"
 
@@ -267,7 +267,7 @@ class TestDiamond:
         assert f"{a_san} --> {b_san}" in mermaid or f"{a_san} --> {c_san}" in mermaid
         assert f"{b_san} --> {d_san}" in mermaid or f"{c_san} --> {d_san}" in mermaid
         # 4 edges total
-        edge_lines = [l for l in mermaid.splitlines() if " --> " in l]
+        edge_lines = [ln for ln in mermaid.splitlines() if " --> " in ln]
         assert len(edge_lines) == 4
 
 
@@ -325,10 +325,10 @@ class TestSharedFailureCallback:
 
         handler_san = _sanitize_id(handler.task_id)
         # Two dashed edges to the same handler
-        dashed_to_handler = [l for l in mermaid.splitlines() if f"-.-> {handler_san}" in l]
+        dashed_to_handler = [ln for ln in mermaid.splitlines() if f"-.-> {handler_san}" in ln]
         assert len(dashed_to_handler) == 2
         # Only one node definition for the handler
-        node_defs = [l for l in mermaid.splitlines() if l.strip().startswith(handler_san + "{{")]
+        node_defs = [ln for ln in mermaid.splitlines() if ln.strip().startswith(handler_san + "{{")]
         assert len(node_defs) == 1
 
 
@@ -359,7 +359,7 @@ class TestAllFailedCallbackPresent:
         # Function name in label
         assert "notify_admins" in mermaid
         # No incoming edges to the callback
-        edges_to_cb = [l for l in mermaid.splitlines() if f"--> {cb_san}" in l or f"-.-> {cb_san}" in l]
+        edges_to_cb = [ln for ln in mermaid.splitlines() if f"--> {cb_san}" in ln or f"-.-> {cb_san}" in ln]
         assert len(edges_to_cb) == 0
 
 

--- a/tests/test_cli_mermaid.py
+++ b/tests/test_cli_mermaid.py
@@ -1,0 +1,865 @@
+"""Tests for boilermaker.cli._mermaid — Mermaid flowchart generator."""
+
+import json
+
+import pytest
+from boilermaker.cli._mermaid import (
+    _node_class,
+    _sanitize_id,
+    _short_task_id,
+    build_task_data_json,
+    generate_mermaid,
+)
+
+# Helper to look up an entry in the dict-keyed task data JSON by function name.
+def _find_entry_by_func(parsed: dict, func_name: str) -> dict:
+    """Find a task data entry by function_name in the dict-keyed JSON output."""
+    for entry in parsed.values():
+        if entry["function_name"] == func_name:
+            return entry
+    raise KeyError(f"No entry with function_name={func_name!r}")
+from boilermaker.task import Task, TaskGraph, TaskStatus
+from boilermaker.task.result import TaskResult, TaskResultSlim
+from boilermaker.task.task_id import TaskId
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _set_result(graph: TaskGraph, task: Task, status: TaskStatus) -> None:
+    """Set a slim result on a graph for the given task and status."""
+    result = TaskResultSlim(
+        task_id=task.task_id,
+        graph_id=graph.graph_id,
+        status=status,
+    )
+    graph.results[task.task_id] = result
+
+
+def _set_full_result(
+    graph: TaskGraph,
+    task: Task,
+    status: TaskStatus,
+    *,
+    result_value: object = None,
+    errors: list[str] | None = None,
+    formatted_exception: str | None = None,
+) -> None:
+    """Set a full TaskResult on a graph for the given task."""
+    result = TaskResult(
+        task_id=task.task_id,
+        graph_id=graph.graph_id,
+        status=status,
+        result=result_value,
+        errors=errors,
+        formatted_exception=formatted_exception,
+    )
+    graph.results[task.task_id] = result
+
+
+# ---------------------------------------------------------------------------
+# TestSanitizeId
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeId:
+    def test_replaces_hyphens_with_underscores(self):
+        tid = TaskId("abc-def-123")
+        assert _sanitize_id(tid) == "abc_def_123"
+
+    def test_no_hyphens_unchanged(self):
+        tid = TaskId("abcdef123")
+        assert _sanitize_id(tid) == "abcdef123"
+
+
+# ---------------------------------------------------------------------------
+# TestShortTaskId
+# ---------------------------------------------------------------------------
+
+
+class TestShortTaskId:
+    def test_returns_last_12_chars(self):
+        tid = TaskId("0192f5e0-abcd-7def-8901-234567890abc")
+        assert _short_task_id(tid) == "234567890abc"
+
+    def test_short_id_returned_as_is(self):
+        tid = TaskId("short")
+        assert _short_task_id(tid) == "short"
+
+
+# ---------------------------------------------------------------------------
+# TestNodeClass
+# ---------------------------------------------------------------------------
+
+
+class TestNodeClass:
+    def test_no_blob_returns_noBlob(self):
+        assert _node_class(None, False, False) == "noBlob"
+
+    def test_stalled_returns_composite_class(self):
+        assert _node_class(TaskStatus.Scheduled, True, True) == "stalledScheduled"
+
+    def test_success_returns_success(self):
+        assert _node_class(TaskStatus.Success, False, True) == "success"
+
+    def test_failure_returns_failure(self):
+        assert _node_class(TaskStatus.Failure, False, True) == "failure"
+
+    def test_retries_exhausted_returns_retriesExhausted(self):
+        assert _node_class(TaskStatus.RetriesExhausted, False, True) == "retriesExhausted"
+
+    def test_deadlettered_returns_deadlettered(self):
+        assert _node_class(TaskStatus.Deadlettered, False, True) == "deadlettered"
+
+    def test_pending_returns_pending(self):
+        assert _node_class(TaskStatus.Pending, False, True) == "pending"
+
+    def test_scheduled_returns_scheduled(self):
+        assert _node_class(TaskStatus.Scheduled, False, True) == "scheduled"
+
+    def test_started_returns_started(self):
+        assert _node_class(TaskStatus.Started, False, True) == "started"
+
+    def test_retry_returns_retry(self):
+        assert _node_class(TaskStatus.Retry, False, True) == "retry"
+
+    def test_has_blob_none_status_returns_noBlob(self):
+        # blob exists but status is None (edge case)
+        assert _node_class(None, False, True) == "noBlob"
+
+
+# ---------------------------------------------------------------------------
+# TestStatusToClassMappingAllValues
+# ---------------------------------------------------------------------------
+
+
+class TestStatusToClassMappingAllValues:
+    """Ensure every TaskStatus value has a corresponding classDef in the generated output."""
+
+    @pytest.mark.parametrize("status", list(TaskStatus))
+    def test_every_status_maps_to_a_class(self, status: TaskStatus):
+        cls = _node_class(status, False, True)
+        assert cls != "noBlob", f"TaskStatus.{status.name} should map to a real class, not noBlob"
+
+
+# ---------------------------------------------------------------------------
+# TestSequentialChain
+# ---------------------------------------------------------------------------
+
+
+class TestSequentialChain:
+    """A -> B -> C: correct node IDs, solid edges, class assignments."""
+
+    def test_sequential_chain(self):
+        graph = TaskGraph()
+        a = Task.default("fetch_data")
+        b = Task.default("process")
+        c = Task.default("save")
+        graph.add_task(a)
+        graph.add_task(b, parent_ids=[a.task_id])
+        graph.add_task(c, parent_ids=[b.task_id])
+        _set_result(graph, a, TaskStatus.Success)
+        _set_result(graph, b, TaskStatus.Success)
+        _set_result(graph, c, TaskStatus.Pending)
+
+        mermaid = generate_mermaid(graph, set())
+
+        assert "flowchart LR" in mermaid
+        # Nodes present
+        assert _sanitize_id(a.task_id) in mermaid
+        assert _sanitize_id(b.task_id) in mermaid
+        assert _sanitize_id(c.task_id) in mermaid
+        # Solid edges
+        assert f"{_sanitize_id(a.task_id)} --> {_sanitize_id(b.task_id)}" in mermaid
+        assert f"{_sanitize_id(b.task_id)} --> {_sanitize_id(c.task_id)}" in mermaid
+        # Class assignments
+        assert ":::success" in mermaid
+        assert ":::pending" in mermaid
+
+
+# ---------------------------------------------------------------------------
+# TestFanOut
+# ---------------------------------------------------------------------------
+
+
+class TestFanOut:
+    """A -> B, A -> C: single parent with multiple children."""
+
+    def test_fan_out(self):
+        graph = TaskGraph()
+        a = Task.default("start")
+        b = Task.default("branch_one")
+        c = Task.default("branch_two")
+        graph.add_task(a)
+        graph.add_task(b, parent_ids=[a.task_id])
+        graph.add_task(c, parent_ids=[a.task_id])
+        _set_result(graph, a, TaskStatus.Success)
+        _set_result(graph, b, TaskStatus.Pending)
+        _set_result(graph, c, TaskStatus.Pending)
+
+        mermaid = generate_mermaid(graph, set())
+
+        a_san = _sanitize_id(a.task_id)
+        b_san = _sanitize_id(b.task_id)
+        c_san = _sanitize_id(c.task_id)
+        assert f"{a_san} --> {b_san}" in mermaid or f"{a_san} --> {c_san}" in mermaid
+        # Both edges must exist
+        edges_from_a = [line for line in mermaid.splitlines() if f"{a_san} -->" in line]
+        assert len(edges_from_a) == 2
+
+
+# ---------------------------------------------------------------------------
+# TestFanIn
+# ---------------------------------------------------------------------------
+
+
+class TestFanIn:
+    """A, B -> C: multiple parents converging."""
+
+    def test_fan_in(self):
+        graph = TaskGraph()
+        a = Task.default("step_a")
+        b = Task.default("step_b")
+        c = Task.default("merge")
+        graph.add_task(a)
+        graph.add_task(b)
+        graph.add_task(c, parent_ids=[a.task_id, b.task_id])
+        _set_result(graph, a, TaskStatus.Success)
+        _set_result(graph, b, TaskStatus.Success)
+        _set_result(graph, c, TaskStatus.Pending)
+
+        mermaid = generate_mermaid(graph, set())
+
+        c_san = _sanitize_id(c.task_id)
+        edges_to_c = [line for line in mermaid.splitlines() if f"--> {c_san}" in line]
+        assert len(edges_to_c) == 2
+
+
+# ---------------------------------------------------------------------------
+# TestDiamond
+# ---------------------------------------------------------------------------
+
+
+class TestDiamond:
+    """A -> B, A -> C, B -> D, C -> D."""
+
+    def test_diamond(self):
+        graph = TaskGraph()
+        a = Task.default("start")
+        b = Task.default("left")
+        c = Task.default("right")
+        d = Task.default("join")
+        graph.add_task(a)
+        graph.add_task(b, parent_ids=[a.task_id])
+        graph.add_task(c, parent_ids=[a.task_id])
+        graph.add_task(d, parent_ids=[b.task_id, c.task_id])
+        for t in [a, b, c, d]:
+            _set_result(graph, t, TaskStatus.Pending)
+
+        mermaid = generate_mermaid(graph, set())
+
+        a_san = _sanitize_id(a.task_id)
+        b_san = _sanitize_id(b.task_id)
+        c_san = _sanitize_id(c.task_id)
+        d_san = _sanitize_id(d.task_id)
+        assert f"{a_san} --> {b_san}" in mermaid or f"{a_san} --> {c_san}" in mermaid
+        assert f"{b_san} --> {d_san}" in mermaid or f"{c_san} --> {d_san}" in mermaid
+        # 4 edges total
+        edge_lines = [l for l in mermaid.splitlines() if " --> " in l]
+        assert len(edge_lines) == 4
+
+
+# ---------------------------------------------------------------------------
+# TestFailureCallback
+# ---------------------------------------------------------------------------
+
+
+class TestFailureCallback:
+    """A --fail--> E: dashed edge, hexagon shape."""
+
+    def test_failure_callback_dashed_edge_and_hexagon(self):
+        graph = TaskGraph()
+        a = Task.default("do_work")
+        e = Task.default("handle_error")
+        graph.add_task(a)
+        graph.add_failure_callback(a.task_id, e)
+        _set_result(graph, a, TaskStatus.Failure)
+        _set_result(graph, e, TaskStatus.Pending)
+
+        mermaid = generate_mermaid(graph, set())
+
+        a_san = _sanitize_id(a.task_id)
+        e_san = _sanitize_id(e.task_id)
+        # Dashed edge
+        assert f"{a_san} -.-> {e_san}" in mermaid
+        # Hexagon shape (double curly braces)
+        assert f'{e_san}{{{{' in mermaid
+        # linkStyle declaration exists for the failure edge
+        assert "linkStyle" in mermaid
+
+
+# ---------------------------------------------------------------------------
+# TestSharedFailureCallback
+# ---------------------------------------------------------------------------
+
+
+class TestSharedFailureCallback:
+    """Multiple parents -> one failure handler."""
+
+    def test_shared_failure_callback(self):
+        graph = TaskGraph()
+        a = Task.default("step_a")
+        b = Task.default("step_b")
+        handler = Task.default("shared_handler")
+        graph.add_task(a)
+        graph.add_task(b)
+        graph.add_failure_callback(a.task_id, handler)
+        graph.add_failure_callback(b.task_id, handler)
+        _set_result(graph, a, TaskStatus.Failure)
+        _set_result(graph, b, TaskStatus.Failure)
+        _set_result(graph, handler, TaskStatus.Pending)
+
+        mermaid = generate_mermaid(graph, set())
+
+        handler_san = _sanitize_id(handler.task_id)
+        # Two dashed edges to the same handler
+        dashed_to_handler = [l for l in mermaid.splitlines() if f"-.-> {handler_san}" in l]
+        assert len(dashed_to_handler) == 2
+        # Only one node definition for the handler
+        node_defs = [l for l in mermaid.splitlines() if l.strip().startswith(handler_san + "{{")]
+        assert len(node_defs) == 1
+
+
+# ---------------------------------------------------------------------------
+# TestAllFailedCallbackPresent
+# ---------------------------------------------------------------------------
+
+
+class TestAllFailedCallbackPresent:
+    """all_failed_callback: hexagon, 'on_all_failed' prefix, no incoming edges."""
+
+    def test_all_failed_callback_rendering(self):
+        graph = TaskGraph()
+        a = Task.default("do_work")
+        cb = Task.default("notify_admins")
+        graph.add_task(a)
+        graph.add_all_failed_callback(cb)
+        _set_result(graph, a, TaskStatus.Failure)
+        _set_result(graph, cb, TaskStatus.Pending)
+
+        mermaid = generate_mermaid(graph, set())
+
+        cb_san = _sanitize_id(cb.task_id)
+        # Hexagon shape
+        assert f'{cb_san}{{{{' in mermaid
+        # "on_all_failed" prefix in label
+        assert "on_all_failed" in mermaid
+        # Function name in label
+        assert "notify_admins" in mermaid
+        # No incoming edges to the callback
+        edges_to_cb = [l for l in mermaid.splitlines() if f"--> {cb_san}" in l or f"-.-> {cb_san}" in l]
+        assert len(edges_to_cb) == 0
+
+
+# ---------------------------------------------------------------------------
+# TestAllFailedCallbackAbsent
+# ---------------------------------------------------------------------------
+
+
+class TestAllFailedCallbackAbsent:
+    """No all_failed_callback registered."""
+
+    def test_no_all_failed_node(self):
+        graph = TaskGraph()
+        a = Task.default("do_work")
+        graph.add_task(a)
+        _set_result(graph, a, TaskStatus.Success)
+
+        mermaid = generate_mermaid(graph, set())
+
+        assert "on_all_failed" not in mermaid
+
+
+# ---------------------------------------------------------------------------
+# TestNoBlobNode
+# ---------------------------------------------------------------------------
+
+
+class TestNoBlobNode:
+    """Node with no result blob gets noBlob class and 'NO BLOB' in label."""
+
+    def test_no_blob_node(self):
+        graph = TaskGraph()
+        a = Task.default("missing_result")
+        graph.add_task(a)
+        # No result set — simulates missing blob
+
+        mermaid = generate_mermaid(graph, set())
+
+        assert ":::noBlob" in mermaid
+        assert "NO BLOB" in mermaid
+
+
+# ---------------------------------------------------------------------------
+# TestStalledTask
+# ---------------------------------------------------------------------------
+
+
+class TestStalledTask:
+    """Stalled task gets composite stalled class preserving status color."""
+
+    def test_stalled_class_preserves_status(self):
+        graph = TaskGraph()
+        a = Task.default("stuck_task")
+        graph.add_task(a)
+        _set_result(graph, a, TaskStatus.Scheduled)
+
+        stalled = {a.task_id}
+        mermaid = generate_mermaid(graph, stalled)
+
+        assert ":::stalledScheduled" in mermaid
+
+    def test_stalled_success_class(self):
+        graph = TaskGraph()
+        a = Task.default("stuck_success")
+        graph.add_task(a)
+        _set_result(graph, a, TaskStatus.Success)
+
+        mermaid = generate_mermaid(graph, {a.task_id})
+
+        assert ":::stalledSuccess" in mermaid
+
+    def test_stalled_failure_class(self):
+        graph = TaskGraph()
+        a = Task.default("stuck_failure")
+        graph.add_task(a)
+        _set_result(graph, a, TaskStatus.Failure)
+
+        mermaid = generate_mermaid(graph, {a.task_id})
+
+        assert ":::stalledFailure" in mermaid
+
+
+# ---------------------------------------------------------------------------
+# TestTaskIdSanitization
+# ---------------------------------------------------------------------------
+
+
+class TestTaskIdSanitization:
+    """Hyphens replaced in Mermaid IDs, original preserved in label."""
+
+    def test_sanitization_in_output(self):
+        graph = TaskGraph()
+        a = Task.default("my_func")
+        graph.add_task(a)
+        _set_result(graph, a, TaskStatus.Success)
+
+        mermaid = generate_mermaid(graph, set())
+
+        sanitized = _sanitize_id(a.task_id)
+        # Sanitized ID used as Mermaid node ID (no hyphens)
+        assert "-" not in sanitized
+        assert sanitized in mermaid
+        # Last 12 chars of original ID are in the label
+        assert _short_task_id(a.task_id) in mermaid
+
+
+# ---------------------------------------------------------------------------
+# TestEmptyGraph
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyGraph:
+    """Empty graph produces minimal valid Mermaid."""
+
+    def test_empty_graph(self):
+        graph = TaskGraph()
+        mermaid = generate_mermaid(graph, set())
+        assert "flowchart LR" in mermaid
+        # No edges
+        assert "-->" not in mermaid
+        assert "-.->" not in mermaid
+
+
+# ---------------------------------------------------------------------------
+# TestClassDefDeclarations
+# ---------------------------------------------------------------------------
+
+
+class TestClassDefDeclarations:
+    """All expected classDef declarations are present."""
+
+    def test_all_status_class_defs_present(self):
+        graph = TaskGraph()
+        a = Task.default("x")
+        graph.add_task(a)
+        _set_result(graph, a, TaskStatus.Pending)
+
+        mermaid = generate_mermaid(graph, set())
+
+        for cls_name in [
+            "success", "failure", "retriesExhausted", "deadlettered",
+            "pending", "scheduled", "started", "retry", "noBlob",
+        ]:
+            assert f"classDef {cls_name}" in mermaid
+
+    def test_stalled_composite_class_defs_present(self):
+        graph = TaskGraph()
+        a = Task.default("x")
+        graph.add_task(a)
+        _set_result(graph, a, TaskStatus.Pending)
+
+        mermaid = generate_mermaid(graph, set())
+
+        for cls_name in [
+            "stalledSuccess", "stalledFailure", "stalledRetriesExhausted",
+            "stalledDeadlettered", "stalledPending", "stalledScheduled",
+            "stalledStarted", "stalledRetry", "stalledNoBlob",
+        ]:
+            assert f"classDef {cls_name}" in mermaid
+
+    def test_stalled_class_defs_have_dashed_stroke(self):
+        graph = TaskGraph()
+        a = Task.default("x")
+        graph.add_task(a)
+        _set_result(graph, a, TaskStatus.Pending)
+
+        mermaid = generate_mermaid(graph, set())
+
+        # Every stalledXxx classDef should have stroke-dasharray
+        for line in mermaid.splitlines():
+            if "classDef stalled" in line:
+                assert "stroke-dasharray:5" in line
+                assert "stroke-width:3px" in line
+
+
+# ---------------------------------------------------------------------------
+# TestLinkStyleIndexTracking
+# ---------------------------------------------------------------------------
+
+
+class TestLinkStyleIndexTracking:
+    """linkStyle targets the correct edge indices."""
+
+    def test_link_style_indices(self):
+        graph = TaskGraph()
+        a = Task.default("step_a")
+        b = Task.default("step_b")
+        handler = Task.default("err_handler")
+        graph.add_task(a)
+        graph.add_task(b, parent_ids=[a.task_id])
+        graph.add_failure_callback(a.task_id, handler)
+        _set_result(graph, a, TaskStatus.Failure)
+        _set_result(graph, b, TaskStatus.Pending)
+        _set_result(graph, handler, TaskStatus.Pending)
+
+        mermaid = generate_mermaid(graph, set())
+
+        # One success edge (index 0: a -> b), one fail edge (index 1: a -.-> handler)
+        # linkStyle should target index 1
+        assert "linkStyle 1" in mermaid
+        assert "linkStyle 0" not in mermaid or "linkStyle 0 stroke" not in mermaid
+
+
+# ---------------------------------------------------------------------------
+# TestBuildTaskDataJson
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTaskDataJson:
+    """build_task_data_json returns valid JSON dict keyed by sanitized node ID."""
+
+    def test_valid_json_dict_output(self):
+        graph = TaskGraph()
+        a = Task.default("fetch")
+        graph.add_task(a)
+        _set_result(graph, a, TaskStatus.Success)
+
+        result = build_task_data_json(graph, set())
+        parsed = json.loads(result)
+
+        assert isinstance(parsed, dict)
+        assert len(parsed) == 1
+
+    def test_keyed_by_sanitized_id(self):
+        graph = TaskGraph()
+        a = Task.default("fetch")
+        graph.add_task(a)
+        _set_result(graph, a, TaskStatus.Success)
+
+        parsed = json.loads(build_task_data_json(graph, set()))
+        expected_key = _sanitize_id(a.task_id)
+        assert expected_key in parsed
+
+    def test_expected_keys_present(self):
+        graph = TaskGraph()
+        a = Task.default("fetch")
+        graph.add_task(a)
+        _set_result(graph, a, TaskStatus.Success)
+
+        parsed = json.loads(build_task_data_json(graph, set()))
+        entry = parsed[_sanitize_id(a.task_id)]
+
+        assert "task_id" in entry
+        assert "function_name" in entry
+        assert "status" in entry
+        assert "type" in entry
+        assert "is_stalled" in entry
+
+    def test_child_type(self):
+        graph = TaskGraph()
+        a = Task.default("do_work")
+        graph.add_task(a)
+        _set_result(graph, a, TaskStatus.Success)
+
+        parsed = json.loads(build_task_data_json(graph, set()))
+        assert parsed[_sanitize_id(a.task_id)]["type"] == "child"
+
+    def test_fail_child_type(self):
+        graph = TaskGraph()
+        parent = Task.default("work")
+        handler = Task.default("handle")
+        graph.add_task(parent)
+        graph.add_failure_callback(parent.task_id, handler)
+        _set_result(graph, parent, TaskStatus.Failure)
+        _set_result(graph, handler, TaskStatus.Pending)
+
+        parsed = json.loads(build_task_data_json(graph, set()))
+        fail_entry = _find_entry_by_func(parsed, "handle")
+        assert fail_entry["type"] == "fail_child"
+
+    def test_all_failed_callback_type(self):
+        graph = TaskGraph()
+        a = Task.default("work")
+        cb = Task.default("on_fail_all")
+        graph.add_task(a)
+        graph.add_all_failed_callback(cb)
+        _set_result(graph, a, TaskStatus.Failure)
+        _set_result(graph, cb, TaskStatus.Pending)
+
+        parsed = json.loads(build_task_data_json(graph, set()))
+        cb_entry = _find_entry_by_func(parsed, "on_fail_all")
+        assert cb_entry["type"] == "all_failed_callback"
+
+    def test_stalled_flag(self):
+        graph = TaskGraph()
+        a = Task.default("stuck")
+        graph.add_task(a)
+        _set_result(graph, a, TaskStatus.Scheduled)
+
+        parsed = json.loads(build_task_data_json(graph, {a.task_id}))
+        assert parsed[_sanitize_id(a.task_id)]["is_stalled"] is True
+
+    def test_not_stalled_flag(self):
+        graph = TaskGraph()
+        a = Task.default("ok")
+        graph.add_task(a)
+        _set_result(graph, a, TaskStatus.Success)
+
+        parsed = json.loads(build_task_data_json(graph, set()))
+        assert parsed[_sanitize_id(a.task_id)]["is_stalled"] is False
+
+
+# ---------------------------------------------------------------------------
+# TestBuildTaskDataJsonFullResult
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTaskDataJsonFullResult:
+    """build_task_data_json with full TaskResult includes rich fields."""
+
+    def test_full_result_includes_result_field(self):
+        graph = TaskGraph()
+        a = Task.default("compute")
+        graph.add_task(a)
+        _set_full_result(graph, a, TaskStatus.Success, result_value={"answer": 42})
+
+        parsed = json.loads(build_task_data_json(graph, set()))
+        entry = parsed[_sanitize_id(a.task_id)]
+        assert "result" in entry
+        # Non-string result should be JSON-serialized
+        inner = json.loads(entry["result"])
+        assert inner == {"answer": 42}
+
+    def test_full_result_string_value_not_double_encoded(self):
+        graph = TaskGraph()
+        a = Task.default("greet")
+        graph.add_task(a)
+        _set_full_result(graph, a, TaskStatus.Success, result_value="hello world")
+
+        parsed = json.loads(build_task_data_json(graph, set()))
+        assert parsed[_sanitize_id(a.task_id)]["result"] == "hello world"
+
+    def test_full_result_includes_errors(self):
+        graph = TaskGraph()
+        a = Task.default("fail_task")
+        graph.add_task(a)
+        _set_full_result(
+            graph, a, TaskStatus.Failure,
+            errors=["connection timeout", "retry failed"],
+        )
+
+        parsed = json.loads(build_task_data_json(graph, set()))
+        entry = parsed[_sanitize_id(a.task_id)]
+        assert "errors" in entry
+        assert entry["errors"] == ["connection timeout", "retry failed"]
+
+    def test_full_result_includes_formatted_exception(self):
+        graph = TaskGraph()
+        a = Task.default("crash_task")
+        graph.add_task(a)
+        _set_full_result(
+            graph, a, TaskStatus.Failure,
+            formatted_exception="Traceback (most recent call last):\n  ValueError: boom",
+        )
+
+        parsed = json.loads(build_task_data_json(graph, set()))
+        entry = parsed[_sanitize_id(a.task_id)]
+        assert "formatted_exception" in entry
+        assert "ValueError: boom" in entry["formatted_exception"]
+
+
+# ---------------------------------------------------------------------------
+# TestBuildTaskDataJsonOmitsNoneFields
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTaskDataJsonOmitsNoneFields:
+    """Fields that are None or empty are omitted from the JSON entry."""
+
+    def test_successful_task_omits_errors_and_exception(self):
+        graph = TaskGraph()
+        a = Task.default("ok_task")
+        graph.add_task(a)
+        _set_full_result(
+            graph, a, TaskStatus.Success,
+            result_value="done",
+            errors=None,
+            formatted_exception=None,
+        )
+
+        parsed = json.loads(build_task_data_json(graph, set()))
+        entry = parsed[_sanitize_id(a.task_id)]
+        assert "errors" not in entry
+        assert "formatted_exception" not in entry
+        assert entry["result"] == "done"
+
+    def test_empty_errors_list_omitted(self):
+        graph = TaskGraph()
+        a = Task.default("ok_task")
+        graph.add_task(a)
+        _set_full_result(graph, a, TaskStatus.Success, errors=[])
+
+        parsed = json.loads(build_task_data_json(graph, set()))
+        entry = parsed[_sanitize_id(a.task_id)]
+        assert "errors" not in entry
+
+    def test_empty_string_exception_omitted(self):
+        graph = TaskGraph()
+        a = Task.default("ok_task")
+        graph.add_task(a)
+        _set_full_result(graph, a, TaskStatus.Success, formatted_exception="")
+
+        parsed = json.loads(build_task_data_json(graph, set()))
+        entry = parsed[_sanitize_id(a.task_id)]
+        assert "formatted_exception" not in entry
+
+    def test_none_result_omitted(self):
+        graph = TaskGraph()
+        a = Task.default("void_task")
+        graph.add_task(a)
+        _set_full_result(graph, a, TaskStatus.Success, result_value=None)
+
+        parsed = json.loads(build_task_data_json(graph, set()))
+        entry = parsed[_sanitize_id(a.task_id)]
+        assert "result" not in entry
+
+
+# ---------------------------------------------------------------------------
+# TestBuildTaskDataJsonSlimResult
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTaskDataJsonSlimResult:
+    """TaskResultSlim instances do not include rich fields."""
+
+    def test_slim_result_omits_rich_fields(self):
+        graph = TaskGraph()
+        a = Task.default("slim_task")
+        graph.add_task(a)
+        _set_result(graph, a, TaskStatus.Success)
+
+        parsed = json.loads(build_task_data_json(graph, set()))
+        entry = parsed[_sanitize_id(a.task_id)]
+        assert "result" not in entry
+        assert "errors" not in entry
+        assert "formatted_exception" not in entry
+
+
+# ---------------------------------------------------------------------------
+# TestBuildTaskDataJsonNonStringResult
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTaskDataJsonNonStringResult:
+    """Non-string result values are JSON-serialized with json.dumps(default=str)."""
+
+    def test_dict_result_serialized(self):
+        graph = TaskGraph()
+        a = Task.default("compute")
+        graph.add_task(a)
+        _set_full_result(graph, a, TaskStatus.Success, result_value={"count": 5, "items": [1, 2, 3]})
+
+        parsed = json.loads(build_task_data_json(graph, set()))
+        inner = json.loads(parsed[_sanitize_id(a.task_id)]["result"])
+        assert inner["count"] == 5
+        assert inner["items"] == [1, 2, 3]
+
+    def test_list_result_serialized(self):
+        graph = TaskGraph()
+        a = Task.default("list_task")
+        graph.add_task(a)
+        _set_full_result(graph, a, TaskStatus.Success, result_value=[1, 2, 3])
+
+        parsed = json.loads(build_task_data_json(graph, set()))
+        inner = json.loads(parsed[_sanitize_id(a.task_id)]["result"])
+        assert inner == [1, 2, 3]
+
+    def test_numeric_result_serialized(self):
+        graph = TaskGraph()
+        a = Task.default("num_task")
+        graph.add_task(a)
+        _set_full_result(graph, a, TaskStatus.Success, result_value=42)
+
+        parsed = json.loads(build_task_data_json(graph, set()))
+        # json.dumps(42) => "42" — a string containing the number
+        inner = json.loads(parsed[_sanitize_id(a.task_id)]["result"])
+        assert inner == 42
+
+
+# ---------------------------------------------------------------------------
+# TestBuildTaskDataJsonFailedTask
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTaskDataJsonFailedTask:
+    """Failed task: formatted_exception as raw string, errors as list."""
+
+    def test_failed_task_has_exception_and_errors(self):
+        graph = TaskGraph()
+        a = Task.default("boom_task")
+        graph.add_task(a)
+        _set_full_result(
+            graph, a, TaskStatus.Failure,
+            errors=["step 1 failed", "step 2 failed"],
+            formatted_exception="Traceback:\n  RuntimeError: kaboom",
+        )
+
+        parsed = json.loads(build_task_data_json(graph, set()))
+        entry = parsed[_sanitize_id(a.task_id)]
+        assert isinstance(entry["errors"], list)
+        assert len(entry["errors"]) == 2
+        assert isinstance(entry["formatted_exception"], str)
+        assert "RuntimeError: kaboom" in entry["formatted_exception"]

--- a/tests/test_cli_visual.py
+++ b/tests/test_cli_visual.py
@@ -1,0 +1,729 @@
+"""Tests for boilermaker.cli._visual — HTML template, browser integration, and CLI wiring."""
+
+import json
+from io import StringIO
+from unittest import mock
+
+import pytest
+from rich.console import Console
+
+from boilermaker.cli import build_parser, _validate_inspect_args
+from boilermaker.cli._globals import EXIT_ERROR, EXIT_HEALTHY, EXIT_STALLED
+from boilermaker.cli._visual import (
+    MERMAID_CDN_URL,
+    render_visual_html,
+    open_visual,
+)
+from boilermaker.cli.inspect import run_inspect
+from boilermaker.task import Task, TaskGraph, TaskResultSlim, TaskStatus
+from boilermaker.task.task_id import TaskId
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_graph_with_tasks() -> tuple[TaskGraph, Task, Task, Task]:
+    """Build a graph with three children: A -> B -> C."""
+    graph = TaskGraph()
+    task_a = Task.default("fetch_data")
+    task_b = Task.default("process_report")
+    task_c = Task.default("send_notification")
+    graph.add_task(task_a)
+    graph.add_task(task_b, parent_ids=[task_a.task_id])
+    graph.add_task(task_c, parent_ids=[task_b.task_id])
+    return graph, task_a, task_b, task_c
+
+
+def _set_result(graph: TaskGraph, task: Task, status: TaskStatus) -> None:
+    """Set a result on a graph for the given task and status."""
+    result = TaskResultSlim(
+        task_id=task.task_id,
+        graph_id=graph.graph_id,
+        status=status,
+    )
+    graph.results[task.task_id] = result
+
+
+def _no_color_console() -> Console:
+    """Return a Rich Console that writes to a StringIO buffer with no color."""
+    return Console(file=StringIO(), no_color=True, width=120)
+
+
+def _sample_mermaid_text() -> str:
+    """Return a minimal Mermaid flowchart string for testing."""
+    return 'flowchart LR\n    id_aaa["fetch_data\\n...aaa"]:::success\n    id_bbb["process\\n...bbb"]:::pending'
+
+
+def _sample_task_data_json(
+    include_result: bool = False,
+    include_errors: bool = False,
+    include_exception: bool = False,
+) -> str:
+    """Return a JSON string of task data for testing.
+
+    By default returns minimal fields. Optional flags add rich TaskResult fields.
+    """
+    entry_a: dict = {
+        "task_id": "aaaa-bbbb-cccc-dddd",
+        "function_name": "fetch_data",
+        "status": "success",
+        "type": "child",
+        "is_stalled": False,
+    }
+    entry_b: dict = {
+        "task_id": "eeee-ffff-gggg-hhhh",
+        "function_name": "process_report",
+        "status": "failure",
+        "type": "child",
+        "is_stalled": False,
+    }
+
+    if include_result:
+        entry_a["result"] = '{"key": "value"}'
+    if include_errors:
+        entry_b["errors"] = ["Connection timeout", "Retry limit exceeded"]
+    if include_exception:
+        entry_b["formatted_exception"] = "Traceback (most recent call last):\n  File ...\nValueError: bad input"
+
+    data = {
+        "id_aaaa_bbbb_cccc_dddd": entry_a,
+        "id_eeee_ffff_gggg_hhhh": entry_b,
+    }
+    return json.dumps(data)
+
+
+# ---------------------------------------------------------------------------
+# TestRenderVisualHtmlStructure
+# ---------------------------------------------------------------------------
+
+
+class TestRenderVisualHtmlStructure:
+    def test_html_contains_html_tag(self):
+        graph, *_ = _make_graph_with_tasks()
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        assert "<html" in result
+
+    def test_html_contains_script_tag(self):
+        graph, *_ = _make_graph_with_tasks()
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        assert "<script" in result
+
+    def test_html_contains_mermaid_div(self):
+        graph, *_ = _make_graph_with_tasks()
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        assert '<div class="mermaid">' in result
+
+    def test_html_contains_legend_div(self):
+        graph, *_ = _make_graph_with_tasks()
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        assert '<div class="legend">' in result
+
+    def test_html_contains_mermaid_cdn_url(self):
+        graph, *_ = _make_graph_with_tasks()
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        assert MERMAID_CDN_URL in result
+
+    def test_html_contains_mermaid_initialize(self):
+        graph, *_ = _make_graph_with_tasks()
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        assert "mermaid.initialize" in result
+        assert "startOnLoad: false" in result
+        assert "securityLevel: 'loose'" in result
+
+
+# ---------------------------------------------------------------------------
+# TestRenderVisualHtmlSecurity
+# ---------------------------------------------------------------------------
+
+
+class TestRenderVisualHtmlSecurity:
+    def test_script_close_tag_in_task_data_is_escaped(self):
+        """A task result containing </script> must not break out of the script tag."""
+        graph, *_ = _make_graph_with_tasks()
+        # Build task data JSON with a </script> payload in a result field
+        malicious_data = {
+            "id_aaaa_bbbb_cccc_dddd": {
+                "task_id": "aaaa-bbbb-cccc-dddd",
+                "function_name": "fetch_data",
+                "status": "success",
+                "type": "child",
+                "is_stalled": False,
+                "result": 'payload</script><script>alert("xss")</script>',
+            },
+        }
+        task_json = json.dumps(malicious_data)
+        result = render_visual_html(_sample_mermaid_text(), task_json, graph)
+        # The literal </script> must not appear in the output — it should be escaped
+        assert "</script><script>" not in result
+        # The escaped form <\/ should be present instead
+        assert r"<\/" in result
+
+    def test_mermaid_run_then_used_instead_of_set_timeout(self):
+        """Click handlers should be attached via mermaid.run().then(), not setTimeout."""
+        graph, *_ = _make_graph_with_tasks()
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        assert "mermaid.run().then(" in result
+        assert "setTimeout" not in result
+
+
+# ---------------------------------------------------------------------------
+# TestRenderVisualHtmlMermaidContent
+# ---------------------------------------------------------------------------
+
+
+class TestRenderVisualHtmlMermaidContent:
+    def test_mermaid_text_embedded_in_div(self):
+        graph, *_ = _make_graph_with_tasks()
+        mermaid_text = _sample_mermaid_text()
+        result = render_visual_html(mermaid_text, _sample_task_data_json(), graph)
+        # The mermaid text should appear inside the mermaid div
+        assert "flowchart LR" in result
+        assert "fetch_data" in result
+
+    def test_mermaid_text_is_html_escaped(self):
+        """Mermaid text containing HTML-special chars is escaped."""
+        graph, *_ = _make_graph_with_tasks()
+        mermaid_text = 'flowchart LR\n    id_a["data<br>test"]'
+        result = render_visual_html(mermaid_text, _sample_task_data_json(), graph)
+        # The < should be escaped in the HTML output
+        assert "&lt;br&gt;" in result
+
+
+# ---------------------------------------------------------------------------
+# TestRenderVisualHtmlTaskData
+# ---------------------------------------------------------------------------
+
+
+class TestRenderVisualHtmlTaskData:
+    def test_task_data_json_embedded_in_script(self):
+        graph, *_ = _make_graph_with_tasks()
+        task_json = _sample_task_data_json()
+        result = render_visual_html(_sample_mermaid_text(), task_json, graph)
+        assert "const taskData =" in result
+        assert "fetch_data" in result
+        assert "process_report" in result
+
+    def test_task_data_is_parseable_json_in_html(self):
+        graph, *_ = _make_graph_with_tasks()
+        task_json = _sample_task_data_json()
+        result = render_visual_html(_sample_mermaid_text(), task_json, graph)
+        # Extract the JSON blob assigned to taskData
+        start = result.index("const taskData = ") + len("const taskData = ")
+        end = result.index(";\n", start)
+        embedded_json = result[start:end]
+        parsed = json.loads(embedded_json)
+        assert isinstance(parsed, dict)
+
+
+# ---------------------------------------------------------------------------
+# TestRenderVisualHtmlTitle
+# ---------------------------------------------------------------------------
+
+
+class TestRenderVisualHtmlTitle:
+    def test_title_contains_graph_id(self):
+        graph, *_ = _make_graph_with_tasks()
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        assert f"<title>Boilermaker DAG: {graph.graph_id}</title>" in result
+
+    def test_header_contains_graph_id(self):
+        graph, *_ = _make_graph_with_tasks()
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        assert f"Graph: {graph.graph_id}" in result
+
+
+# ---------------------------------------------------------------------------
+# TestRenderVisualHtmlLegend
+# ---------------------------------------------------------------------------
+
+
+class TestRenderVisualHtmlLegend:
+    def test_legend_contains_success(self):
+        graph, *_ = _make_graph_with_tasks()
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        assert "Success" in result
+
+    def test_legend_contains_failure(self):
+        graph, *_ = _make_graph_with_tasks()
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        assert "Failure" in result
+
+    def test_legend_contains_pending(self):
+        graph, *_ = _make_graph_with_tasks()
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        assert "Pending" in result
+
+    def test_legend_contains_scheduled(self):
+        graph, *_ = _make_graph_with_tasks()
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        assert "Scheduled" in result
+
+    def test_legend_contains_started(self):
+        graph, *_ = _make_graph_with_tasks()
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        assert "Started" in result
+
+    def test_legend_contains_retry(self):
+        graph, *_ = _make_graph_with_tasks()
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        assert "Retry" in result
+
+    def test_legend_contains_retries_exhausted(self):
+        graph, *_ = _make_graph_with_tasks()
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        assert "Retries Exhausted" in result
+
+    def test_legend_contains_deadlettered(self):
+        graph, *_ = _make_graph_with_tasks()
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        assert "Deadlettered" in result
+
+    def test_legend_contains_no_blob(self):
+        graph, *_ = _make_graph_with_tasks()
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        assert "No Blob" in result
+
+    def test_legend_contains_stalled(self):
+        graph, *_ = _make_graph_with_tasks()
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        assert "Stalled" in result
+
+
+# ---------------------------------------------------------------------------
+# TestRenderVisualHtmlDetailPanel
+# ---------------------------------------------------------------------------
+
+
+class TestRenderVisualHtmlDetailPanel:
+    def test_detail_panel_div_exists(self):
+        graph, *_ = _make_graph_with_tasks()
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        assert 'id="detail-panel"' in result
+
+    def test_detail_panel_has_pre_element_for_exception(self):
+        """The JS showDetail function renders formatted_exception inside a <pre> block."""
+        graph, *_ = _make_graph_with_tasks()
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        # The JS template creates <pre> when formatted_exception is present
+        assert "formatted_exception" in result
+        assert "<pre>" in result
+
+    def test_detail_panel_js_renders_errors_as_list(self):
+        """The JS showDetail function renders errors as <ul><li> elements."""
+        graph, *_ = _make_graph_with_tasks()
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        assert "<ul>" in result
+        assert "<li>" in result
+
+    def test_detail_panel_js_renders_result_field(self):
+        """The JS showDetail function renders the result field as text."""
+        graph, *_ = _make_graph_with_tasks()
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        # The JS checks for task.result and displays it
+        assert "task.result" in result
+
+    def test_detail_panel_js_omits_absent_fields(self):
+        """The JS only renders sections when fields are present in the JSON entry."""
+        graph, *_ = _make_graph_with_tasks()
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        # The JS uses conditional checks (if task.result, if task.errors, etc.)
+        # to skip absent fields -- no "Not available" placeholders
+        assert "Not available" not in result
+        # The JS conditionally checks before rendering
+        assert "if (task.result !== undefined && task.result !== null)" in result
+        assert "if (task.errors && task.errors.length > 0)" in result
+        assert "if (task.formatted_exception)" in result
+
+    def test_escape_key_closes_panel(self):
+        """The JS includes an Escape key handler to close the detail panel."""
+        graph, *_ = _make_graph_with_tasks()
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        assert "Escape" in result
+
+    def test_click_outside_closes_panel(self):
+        """The JS includes a click-outside handler to close the detail panel."""
+        graph, *_ = _make_graph_with_tasks()
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        assert "closePanel" in result
+
+
+# ---------------------------------------------------------------------------
+# TestRenderVisualHtmlDetailPanelRichFields
+# ---------------------------------------------------------------------------
+
+
+class TestRenderVisualHtmlDetailPanelRichFields:
+    """Verify that task data JSON with rich fields is correctly embedded."""
+
+    def test_result_field_embedded_in_task_data(self):
+        graph, *_ = _make_graph_with_tasks()
+        task_json = _sample_task_data_json(include_result=True)
+        result = render_visual_html(_sample_mermaid_text(), task_json, graph)
+        # The JSON is embedded verbatim as a JS constant; check the value is present
+        assert "key" in result
+        assert "value" in result
+
+    def test_errors_field_embedded_in_task_data(self):
+        graph, *_ = _make_graph_with_tasks()
+        task_json = _sample_task_data_json(include_errors=True)
+        result = render_visual_html(_sample_mermaid_text(), task_json, graph)
+        assert "Connection timeout" in result
+        assert "Retry limit exceeded" in result
+
+    def test_formatted_exception_field_embedded_in_task_data(self):
+        graph, *_ = _make_graph_with_tasks()
+        task_json = _sample_task_data_json(include_exception=True)
+        result = render_visual_html(_sample_mermaid_text(), task_json, graph)
+        assert "Traceback (most recent call last)" in result
+
+    def test_absent_fields_not_in_task_data(self):
+        """When rich fields are not included, they do not appear in the JSON."""
+        graph, *_ = _make_graph_with_tasks()
+        task_json = _sample_task_data_json()  # no rich fields
+        parsed = json.loads(task_json)
+        for entry in parsed.values():
+            assert "result" not in entry
+            assert "errors" not in entry
+            assert "formatted_exception" not in entry
+
+
+# ---------------------------------------------------------------------------
+# TestRenderVisualHtmlSummary
+# ---------------------------------------------------------------------------
+
+
+class TestRenderVisualHtmlSummary:
+    def test_summary_shows_task_completion_fraction(self):
+        graph, task_a, task_b, task_c = _make_graph_with_tasks()
+        _set_result(graph, task_a, TaskStatus.Success)
+        _set_result(graph, task_b, TaskStatus.Success)
+        _set_result(graph, task_c, TaskStatus.Pending)
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        assert "Tasks: 2/3" in result
+
+    def test_summary_shows_failure_count(self):
+        graph, task_a, task_b, task_c = _make_graph_with_tasks()
+        _set_result(graph, task_a, TaskStatus.Success)
+        _set_result(graph, task_b, TaskStatus.Failure)
+        _set_result(graph, task_c, TaskStatus.Pending)
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        assert "Failures: 1" in result
+
+    def test_summary_shows_stalled_count(self):
+        graph, task_a, task_b, task_c = _make_graph_with_tasks()
+        _set_result(graph, task_a, TaskStatus.Success)
+        _set_result(graph, task_b, TaskStatus.Success)
+        _set_result(graph, task_c, TaskStatus.Scheduled)
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        assert "Stalled: 1" in result
+
+    def test_summary_shows_complete_status(self):
+        graph, task_a, task_b, task_c = _make_graph_with_tasks()
+        _set_result(graph, task_a, TaskStatus.Success)
+        _set_result(graph, task_b, TaskStatus.Success)
+        _set_result(graph, task_c, TaskStatus.Success)
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        assert "Status: Complete" in result
+
+    def test_summary_shows_has_failures_status(self):
+        graph, task_a, task_b, task_c = _make_graph_with_tasks()
+        _set_result(graph, task_a, TaskStatus.Failure)
+        _set_result(graph, task_b, TaskStatus.Pending)
+        _set_result(graph, task_c, TaskStatus.Pending)
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        assert "Status: Has Failures" in result
+
+    def test_summary_shows_in_progress_status(self):
+        graph, task_a, task_b, task_c = _make_graph_with_tasks()
+        _set_result(graph, task_a, TaskStatus.Success)
+        _set_result(graph, task_b, TaskStatus.Started)
+        _set_result(graph, task_c, TaskStatus.Pending)
+        result = render_visual_html(_sample_mermaid_text(), _sample_task_data_json(), graph)
+        assert "Status: In Progress" in result
+
+
+# ---------------------------------------------------------------------------
+# TestOpenVisual
+# ---------------------------------------------------------------------------
+
+
+class TestOpenVisual:
+    @mock.patch("webbrowser.open")
+    @mock.patch("boilermaker.cli._mermaid.generate_mermaid", return_value="flowchart LR\n    A-->B")
+    @mock.patch("boilermaker.cli._mermaid.build_task_data_json", return_value="{}")
+    def test_writes_temp_file_and_calls_browser(
+        self, mock_build_json, mock_gen_mermaid, mock_browser_open
+    ):
+        graph, task_a, task_b, task_c = _make_graph_with_tasks()
+        _set_result(graph, task_a, TaskStatus.Success)
+        _set_result(graph, task_b, TaskStatus.Success)
+        _set_result(graph, task_c, TaskStatus.Success)
+        console = _no_color_console()
+
+        path = open_visual(graph, set(), console)
+
+        assert path.endswith(".html")
+        assert "boilermaker-dag-" in path
+        mock_browser_open.assert_called_once()
+        call_url = mock_browser_open.call_args[0][0]
+        assert call_url.startswith("file://")
+        assert path in call_url
+
+    @mock.patch("webbrowser.open")
+    @mock.patch("boilermaker.cli._mermaid.generate_mermaid", return_value="flowchart LR\n    A-->B")
+    @mock.patch("boilermaker.cli._mermaid.build_task_data_json", return_value="{}")
+    def test_prints_file_path_to_console(
+        self, mock_build_json, mock_gen_mermaid, mock_browser_open
+    ):
+        graph, task_a, task_b, task_c = _make_graph_with_tasks()
+        _set_result(graph, task_a, TaskStatus.Success)
+        _set_result(graph, task_b, TaskStatus.Success)
+        _set_result(graph, task_c, TaskStatus.Success)
+        buf = StringIO()
+        console = Console(file=buf, no_color=True, width=120)
+
+        path = open_visual(graph, set(), console)
+
+        output = buf.getvalue()
+        assert "Opening DAG visualization in browser..." in output
+        assert path in output
+        assert "HTML file:" in output
+
+    @mock.patch("webbrowser.open")
+    @mock.patch("boilermaker.cli._mermaid.generate_mermaid", return_value="flowchart LR\n    A-->B")
+    @mock.patch("boilermaker.cli._mermaid.build_task_data_json", return_value="{}")
+    def test_temp_file_contains_valid_html(
+        self, mock_build_json, mock_gen_mermaid, mock_browser_open
+    ):
+        graph, task_a, task_b, task_c = _make_graph_with_tasks()
+        _set_result(graph, task_a, TaskStatus.Success)
+        _set_result(graph, task_b, TaskStatus.Success)
+        _set_result(graph, task_c, TaskStatus.Success)
+        console = _no_color_console()
+
+        path = open_visual(graph, set(), console)
+
+        with open(path, "r", encoding="utf-8") as f:
+            content = f.read()
+        assert "<html" in content
+        assert "mermaid" in content
+
+    @mock.patch("webbrowser.open")
+    @mock.patch("boilermaker.cli._mermaid.generate_mermaid", return_value="flowchart LR\n    A-->B")
+    @mock.patch("boilermaker.cli._mermaid.build_task_data_json", return_value="{}")
+    def test_returns_file_path_string(
+        self, mock_build_json, mock_gen_mermaid, mock_browser_open
+    ):
+        graph, task_a, task_b, task_c = _make_graph_with_tasks()
+        _set_result(graph, task_a, TaskStatus.Success)
+        _set_result(graph, task_b, TaskStatus.Success)
+        _set_result(graph, task_c, TaskStatus.Success)
+        console = _no_color_console()
+
+        path = open_visual(graph, set(), console)
+
+        assert isinstance(path, str)
+        assert len(path) > 0
+
+
+# ---------------------------------------------------------------------------
+# Helpers for CLI wiring tests
+# ---------------------------------------------------------------------------
+
+_STORAGE_URL = "https://example.blob.core.windows.net"
+_CONTAINER = "my-container"
+_GRAPH_ID = "019d8c0c-bd9b-7c23-be84-4d0799d7ecd4"
+_TASK_ID = "019d8c0c-be84-4c5388b8de6c"
+
+_GLOBAL_OPTS = [
+    "--storage-url", _STORAGE_URL,
+    "--container", _CONTAINER,
+]
+
+
+def _mock_storage(graph: TaskGraph | None = None) -> mock.AsyncMock:
+    """Return a mock storage whose load_graph returns the given graph."""
+    storage = mock.AsyncMock()
+    storage.load_graph = mock.AsyncMock(return_value=graph)
+    return storage
+
+
+# ---------------------------------------------------------------------------
+# TestVisualParserFlag
+# ---------------------------------------------------------------------------
+
+
+class TestVisualParserFlag:
+    def test_visual_flag_parses_correctly(self):
+        parser = build_parser()
+        args = parser.parse_args([*_GLOBAL_OPTS, "inspect", "--graph", _GRAPH_ID, "--visual"])
+        assert args.visual is True
+
+    def test_visual_defaults_false(self):
+        parser = build_parser()
+        args = parser.parse_args([*_GLOBAL_OPTS, "inspect", "--graph", _GRAPH_ID])
+        assert args.visual is False
+
+
+# ---------------------------------------------------------------------------
+# TestVisualValidation
+# ---------------------------------------------------------------------------
+
+
+class TestVisualValidation:
+    def test_visual_without_graph_is_error(self):
+        """--visual without --graph should fail post-parse validation."""
+        parser = build_parser()
+        args = parser.parse_args([*_GLOBAL_OPTS, "inspect", "--visual"])
+        with pytest.raises(SystemExit) as exc_info:
+            _validate_inspect_args(args, parser)
+        assert exc_info.value.code == 2
+
+    def test_visual_with_json_is_error(self):
+        """--visual and --json are mutually exclusive."""
+        parser = build_parser()
+        args = parser.parse_args([*_GLOBAL_OPTS, "inspect", "--graph", _GRAPH_ID, "--visual", "--json"])
+        with pytest.raises(SystemExit) as exc_info:
+            _validate_inspect_args(args, parser)
+        assert exc_info.value.code == 2
+
+    def test_visual_with_task_is_error(self):
+        """--visual and --task are mutually exclusive."""
+        parser = build_parser()
+        args = parser.parse_args([
+            *_GLOBAL_OPTS, "inspect", "--graph", _GRAPH_ID, "--visual", "--task", _TASK_ID,
+        ])
+        with pytest.raises(SystemExit) as exc_info:
+            _validate_inspect_args(args, parser)
+        assert exc_info.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# TestVisualCallsOpenVisual
+# ---------------------------------------------------------------------------
+
+
+class TestVisualCallsOpenVisual:
+    @pytest.mark.asyncio
+    @mock.patch("boilermaker.cli.inspect.open_visual")
+    async def test_visual_flag_calls_open_visual(self, mock_open_visual):
+        graph, task_a, task_b, task_c = _make_graph_with_tasks()
+        _set_result(graph, task_a, TaskStatus.Success)
+        _set_result(graph, task_b, TaskStatus.Success)
+        _set_result(graph, task_c, TaskStatus.Success)
+        storage = _mock_storage(graph)
+        console = _no_color_console()
+
+        await run_inspect(storage, str(graph.graph_id), console=console, visual=True)
+
+        mock_open_visual.assert_called_once()
+        call_args = mock_open_visual.call_args
+        assert call_args[0][0] is graph  # first positional arg is the graph
+        assert call_args[0][1] == set()  # no stalled tasks
+        assert call_args.kwargs["console"] is console
+
+    @pytest.mark.asyncio
+    @mock.patch("boilermaker.cli.inspect.open_visual")
+    async def test_visual_passes_stalled_task_ids(self, mock_open_visual):
+        graph, task_a, task_b, task_c = _make_graph_with_tasks()
+        _set_result(graph, task_a, TaskStatus.Success)
+        _set_result(graph, task_b, TaskStatus.Success)
+        _set_result(graph, task_c, TaskStatus.Scheduled)
+        storage = _mock_storage(graph)
+
+        await run_inspect(storage, str(graph.graph_id), console=_no_color_console(), visual=True)
+
+        mock_open_visual.assert_called_once()
+        stalled_ids = mock_open_visual.call_args[0][1]
+        assert task_c.task_id in stalled_ids
+
+
+# ---------------------------------------------------------------------------
+# TestVisualExitCodes
+# ---------------------------------------------------------------------------
+
+
+class TestVisualExitCodes:
+    @pytest.mark.asyncio
+    @mock.patch("boilermaker.cli.inspect.open_visual")
+    async def test_exit_healthy_when_no_stalled_tasks(self, mock_open_visual):
+        graph, task_a, task_b, task_c = _make_graph_with_tasks()
+        _set_result(graph, task_a, TaskStatus.Success)
+        _set_result(graph, task_b, TaskStatus.Success)
+        _set_result(graph, task_c, TaskStatus.Success)
+        storage = _mock_storage(graph)
+
+        exit_code = await run_inspect(
+            storage, str(graph.graph_id), console=_no_color_console(), visual=True,
+        )
+        assert exit_code == EXIT_HEALTHY
+
+    @pytest.mark.asyncio
+    @mock.patch("boilermaker.cli.inspect.open_visual")
+    async def test_exit_stalled_when_stalled_tasks_exist(self, mock_open_visual):
+        graph, task_a, task_b, task_c = _make_graph_with_tasks()
+        _set_result(graph, task_a, TaskStatus.Success)
+        _set_result(graph, task_b, TaskStatus.Success)
+        _set_result(graph, task_c, TaskStatus.Scheduled)
+        storage = _mock_storage(graph)
+
+        exit_code = await run_inspect(
+            storage, str(graph.graph_id), console=_no_color_console(), visual=True,
+        )
+        assert exit_code == EXIT_STALLED
+
+    @pytest.mark.asyncio
+    @mock.patch("boilermaker.cli.inspect.open_visual")
+    async def test_exit_error_when_graph_not_found(self, mock_open_visual):
+        storage = _mock_storage(None)
+
+        exit_code = await run_inspect(
+            storage, "nonexistent-graph-id", console=_no_color_console(), visual=True,
+        )
+        assert exit_code == EXIT_ERROR
+        mock_open_visual.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestVisualLoadGraphFullTrue
+# ---------------------------------------------------------------------------
+
+
+class TestVisualLoadGraphFullTrue:
+    @pytest.mark.asyncio
+    @mock.patch("boilermaker.cli.inspect.open_visual")
+    async def test_visual_calls_load_graph_with_full_true(self, mock_open_visual):
+        graph, task_a, task_b, task_c = _make_graph_with_tasks()
+        _set_result(graph, task_a, TaskStatus.Success)
+        _set_result(graph, task_b, TaskStatus.Success)
+        _set_result(graph, task_c, TaskStatus.Success)
+        storage = _mock_storage(graph)
+
+        await run_inspect(
+            storage, str(graph.graph_id), console=_no_color_console(), visual=True,
+        )
+
+        storage.load_graph.assert_called_once()
+        call_kwargs = storage.load_graph.call_args
+        assert call_kwargs.kwargs.get("full") is True or (
+            len(call_kwargs.args) > 1 and call_kwargs.args[1] is True
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_visual_calls_load_graph_without_full(self):
+        graph, task_a, task_b, task_c = _make_graph_with_tasks()
+        _set_result(graph, task_a, TaskStatus.Success)
+        _set_result(graph, task_b, TaskStatus.Success)
+        _set_result(graph, task_c, TaskStatus.Success)
+        storage = _mock_storage(graph)
+
+        await run_inspect(
+            storage, str(graph.graph_id), console=_no_color_console(),
+        )
+
+        storage.load_graph.assert_called_once()
+        call_kwargs = storage.load_graph.call_args
+        # Non-visual path should not pass full=True
+        assert call_kwargs.kwargs.get("full", False) is False

--- a/tests/test_cli_visual.py
+++ b/tests/test_cli_visual.py
@@ -1,6 +1,7 @@
 """Tests for boilermaker.cli._visual — HTML template, browser integration, and CLI wiring."""
 
 import json
+import os
 from io import StringIO
 from unittest import mock
 
@@ -461,12 +462,15 @@ class TestOpenVisual:
 
         path = open_visual(graph, set(), console)
 
-        assert path.endswith(".html")
-        assert "boilermaker-dag-" in path
-        mock_browser_open.assert_called_once()
-        call_url = mock_browser_open.call_args[0][0]
-        assert call_url.startswith("file://")
-        assert path in call_url
+        try:
+            assert path.endswith(".html")
+            assert "boilermaker-dag-" in path
+            mock_browser_open.assert_called_once()
+            call_url = mock_browser_open.call_args[0][0]
+            assert call_url.startswith("file:///")
+            assert call_url.endswith(".html")
+        finally:
+            os.unlink(path)
 
     @mock.patch("webbrowser.open")
     @mock.patch("boilermaker.cli._mermaid.generate_mermaid", return_value="flowchart LR\n    A-->B")
@@ -483,10 +487,13 @@ class TestOpenVisual:
 
         path = open_visual(graph, set(), console)
 
-        output = buf.getvalue()
-        assert "Opening DAG visualization in browser..." in output
-        assert path in output
-        assert "HTML file:" in output
+        try:
+            output = buf.getvalue()
+            assert "Opening DAG visualization in browser..." in output
+            assert path in output
+            assert "HTML file:" in output
+        finally:
+            os.unlink(path)
 
     @mock.patch("webbrowser.open")
     @mock.patch("boilermaker.cli._mermaid.generate_mermaid", return_value="flowchart LR\n    A-->B")
@@ -502,10 +509,13 @@ class TestOpenVisual:
 
         path = open_visual(graph, set(), console)
 
-        with open(path, encoding="utf-8") as f:
-            content = f.read()
-        assert "<html" in content
-        assert "mermaid" in content
+        try:
+            with open(path, encoding="utf-8") as f:
+                content = f.read()
+            assert "<html" in content
+            assert "mermaid" in content
+        finally:
+            os.unlink(path)
 
     @mock.patch("webbrowser.open")
     @mock.patch("boilermaker.cli._mermaid.generate_mermaid", return_value="flowchart LR\n    A-->B")
@@ -521,8 +531,11 @@ class TestOpenVisual:
 
         path = open_visual(graph, set(), console)
 
-        assert isinstance(path, str)
-        assert len(path) > 0
+        try:
+            assert isinstance(path, str)
+            assert len(path) > 0
+        finally:
+            os.unlink(path)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_visual.py
+++ b/tests/test_cli_visual.py
@@ -5,19 +5,16 @@ from io import StringIO
 from unittest import mock
 
 import pytest
-from rich.console import Console
-
-from boilermaker.cli import build_parser, _validate_inspect_args
+from boilermaker.cli import _validate_inspect_args, build_parser
 from boilermaker.cli._globals import EXIT_ERROR, EXIT_HEALTHY, EXIT_STALLED
 from boilermaker.cli._visual import (
     MERMAID_CDN_URL,
-    render_visual_html,
     open_visual,
+    render_visual_html,
 )
 from boilermaker.cli.inspect import run_inspect
 from boilermaker.task import Task, TaskGraph, TaskResultSlim, TaskStatus
-from boilermaker.task.task_id import TaskId
-
+from rich.console import Console
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -505,7 +502,7 @@ class TestOpenVisual:
 
         path = open_visual(graph, set(), console)
 
-        with open(path, "r", encoding="utf-8") as f:
+        with open(path, encoding="utf-8") as f:
             content = f.read()
         assert "<html" in content
         assert "mermaid" in content

--- a/uv.lock
+++ b/uv.lock
@@ -350,7 +350,7 @@ wheels = [
 
 [[package]]
 name = "boilermaker-servicebus"
-version = "1.1.0a6"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aio-azure-clients-toolbox" },


### PR DESCRIPTION
I changed the graph blob task results download so they run concurrently (mostly because I didn't like waiting to test this feature described below...).

In addition, this PR makes it possible to download a graph and all results into a locally-rendered html file:

<img width="2245" height="980" alt="Screenshot 2026-04-17 at 14 08 21" src="https://github.com/user-attachments/assets/bcfbbda9-7d00-49e6-a4cd-94f0f77602a6" />

The file is stored in tmp storage paths like this: 

```sh
uv run -- boilermaker inspect --graph 019d9c8f-6c86-7330-86ea-e6ef20f26d48 --visual
Opening DAG visualization in browser...
HTML file: /var/folders/6f/3qnvjcrj1s58bdcsgnggxzqr0000gp/T/boilermaker-dag-ujc6ed7j.html
```

Further, clicking on a node reveals return value, tracebacks, and any other results stored as part of task result storage:

<img width="2252" height="986" alt="Screenshot 2026-04-17 at 14 08 50" src="https://github.com/user-attachments/assets/1f653e2f-3780-4d16-8f09-3b0c9e418f1d" />

