### PR TITLE
Improve performance of cli and purge --force deletes one-offs

### DIFF
--- a/boilermaker/cli/__init__.py
+++ b/boilermaker/cli/__init__.py
@@ -117,7 +117,7 @@ def _add_purge_subparser(subparsers: argparse._SubParsersAction) -> None:  # noq
     purge_parser.add_argument(
         "--force",
         action="store_true",
-        help="Delete graphs that have in-progress tasks",
+        help="Delete graphs that have in-progress tasks, and purge orphaned blobs that have no graph.json",
     )
     purge_parser.add_argument(
         "--all-graphs",

--- a/boilermaker/cli/inspect.py
+++ b/boilermaker/cli/inspect.py
@@ -63,7 +63,7 @@ async def run_inspect(
         open_visual(graph, stalled_task_ids, console=console)
         return exit_code
 
-    graph = await storage.load_graph(GraphId(graph_id))
+    graph = await storage.load_graph_slim_from_tags(GraphId(graph_id))
     if graph is None:
         print(f"ERROR: Graph {graph_id} not found in storage.", file=sys.stderr)
         return EXIT_ERROR

--- a/boilermaker/cli/purge.py
+++ b/boilermaker/cli/purge.py
@@ -168,7 +168,8 @@ async def run_purge(
         all_graphs: When True, discovers graphs via UUID7 timestamp ordering
             (_stream_all_graphs). When False, uses tag-based discovery
             (_stream_eligible_graphs).
-        force: When True, also delete graphs with in-progress tasks.
+        force: When True, also delete graphs with in-progress tasks, and purge
+            orphaned task-result blobs that have no accompanying graph.json.
         console: Rich Console for output. When None, a default Console is created.
 
     Returns:
@@ -199,10 +200,13 @@ async def run_purge(
             graph_blob_path = f"{storage.task_result_prefix}/{graph_id}{graph_path_suffix}"
             has_graph_json = any(blob.name == graph_blob_path for blob in blobs)
             if not has_graph_json:
-                print(
-                    f"SKIP: Graph {graph_id} has no graph.json — cannot verify in-progress status. Skipping.",
-                    file=sys.stderr,
-                )
+                if force:
+                    eligible_graphs.append((graph_id, blobs))
+                else:
+                    print(
+                        f"SKIP: Graph {graph_id} has no graph.json — cannot verify in-progress status. Skipping.",
+                        file=sys.stderr,
+                    )
                 continue
 
             try:

--- a/boilermaker/storage/blob_storage.py
+++ b/boilermaker/storage/blob_storage.py
@@ -21,7 +21,7 @@ from pydantic import ValidationError
 
 from boilermaker.exc import BoilermakerStorageError
 from boilermaker.storage import StorageInterface
-from boilermaker.task import GraphId, TaskGraph, TaskId, TaskResult, TaskResultSlim
+from boilermaker.task import GraphId, TaskGraph, TaskId, TaskResult, TaskResultSlim, TaskStatus
 
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
@@ -334,6 +334,133 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
                     status_code=None,
                     reason="DeserializationError",
                 ) from e
+
+    async def load_graph_slim_from_tags(self, graph_id: GraphId) -> TaskGraph | None:
+        """Load a TaskGraph for display only, using blob tags to avoid content downloads.
+
+        Intended exclusively for the inspect CLI command. Do NOT use in the evaluator
+        or any code that needs authoritative status values: blob tags can lag behind
+        blob content by several seconds, which would cause stale reads in the
+        scheduling and ETag-guard paths.
+
+        Builds TaskResultSlim from the 'status' tag on each blob instead of
+        downloading the blob body. Falls back to content download for any blob
+        that pre-dates tag support (missing 'status' tag).
+
+        Args:
+            graph_id: The GraphId to load.
+        Returns:
+            The loaded TaskGraph, or None if graph.json is not found.
+        Raises:
+            BoilermakerStorageError: On storage or deserialization failures.
+        """
+        if not graph_id:
+            raise ValueError("`graph_id` must be provided to load a TaskGraph.")
+        with tracer.start_as_current_span("load_graph_slim_from_tags"):
+            graph_path = f"{self.task_result_prefix}/{TaskGraph.graph_path(graph_id)}"
+            graph_dir = f"{self.task_result_prefix}/{graph_id}"
+            try:
+                graph_contents = await self.download_blob(graph_path)
+            except AzureBlobError as exc:
+                raise BoilermakerStorageError(
+                    f"Failed to load TaskGraph {graph_id}",
+                    task_id=None,
+                    graph_id=graph_id,
+                    status_code=exc.status_code,
+                    reason=exc.reason,
+                ) from exc
+            if graph_contents is None:
+                return None
+
+            try:
+                graph = TaskGraph.model_validate_json(graph_contents)
+            except ValidationError as e:
+                raise BoilermakerStorageError(
+                    f"Failed to deserialize graph {graph_id}: {e}",
+                    status_code=None,
+                ) from e
+
+            limiter = CapacityLimiter(10)
+
+            async def _download_result(blob_name: str) -> None:
+                async with limiter:
+                    try:
+                        async with self.get_blob_download_stream(blob_name) as stream:
+                            blob_etag = stream.properties.etag
+                            contents = await stream.readall()
+                        tr = TaskResultSlim.model_validate_json(contents)
+                        tr.etag = blob_etag
+                    except AzureBlobError as exc:
+                        raise BoilermakerStorageError(
+                            f"Failed to load task result blob {blob_name} in graph {graph_id}",
+                            name=blob_name,
+                            graph_id=graph_id,
+                            status_code=exc.status_code,
+                            reason=exc.reason,
+                        ) from exc
+                    except ValidationError as e:
+                        raise BoilermakerStorageError(
+                            f"Failed to deserialize task result in graph {graph_id}: {e}",
+                            name=blob_name,
+                            graph_id=graph_id,
+                            status_code=None,
+                            reason="DeserializationError",
+                        ) from e
+                    if tr.graph_id == graph_id:
+                        graph.results[tr.task_id] = tr
+                    else:
+                        logger.warning(
+                            f"TaskResult {tr.task_id} in graph {graph_dir} with wrong graph_id {tr.graph_id}!"
+                        )
+
+            blob_names_to_download: list[str] = []
+            try:
+                async for blob in self.list_blobs(prefix=graph_dir, include=["tags"]):
+                    if blob.name == graph_path:
+                        continue
+                    tags = blob.tags or {}
+                    status_tag = tags.get("status")
+                    if status_tag:
+                        raw_graph_id = tags.get("graph_id")
+                        blob_graph_id = GraphId(raw_graph_id) if raw_graph_id and raw_graph_id != "none" else None
+                        task_id = TaskId(blob.name.split("/")[-1].removesuffix(".json"))
+                        tr = TaskResultSlim(
+                            task_id=task_id,
+                            graph_id=blob_graph_id,
+                            status=TaskStatus(status_tag),
+                            etag=blob.etag,
+                        )
+                        if tr.graph_id == graph_id:
+                            graph.results[tr.task_id] = tr
+                        else:
+                            logger.warning(
+                                f"TaskResult {tr.task_id} in graph {graph_dir} with wrong graph_id {tr.graph_id}!"
+                            )
+                    else:
+                        blob_names_to_download.append(blob.name)
+            except AzureBlobError as exc:
+                raise BoilermakerStorageError(
+                    f"Failed to list blobs for graph {graph_id}",
+                    graph_id=graph_id,
+                    status_code=exc.status_code,
+                    reason=exc.reason,
+                ) from exc
+            except HttpResponseError as exc:
+                raise BoilermakerStorageError(
+                    f"Failed to list blobs for graph {graph_id}",
+                    graph_id=graph_id,
+                    status_code=exc.status_code,
+                    reason=str(exc),
+                ) from exc
+
+            try:
+                async with create_task_group() as tg:
+                    for blob_name in blob_names_to_download:
+                        tg.start_soon(_download_result, blob_name)
+            except* BoilermakerStorageError as exc_group:
+                raise exc_group.exceptions[0] from exc_group.exceptions[0].__cause__
+
+            return graph
 
     async def store_task_result(
         self,

--- a/boilermaker/storage/blob_storage.py
+++ b/boilermaker/storage/blob_storage.py
@@ -49,6 +49,43 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
             credentials=credentials,
         )
 
+    async def _download_result_with_limiter(
+        self,
+        graph_id: GraphId,
+        blob_name: str,
+        limiter: CapacityLimiter,
+        model: type[TaskResultSlim] | type[TaskResult] = TaskResultSlim,
+    ) -> TaskResultSlim | TaskResult:
+        """Download a single task-result blob, parse it, and return it.
+
+        Raises BoilermakerStorageError on network or deserialization failure.
+        Does NOT check graph_id — callers are responsible for filtering.
+        """
+        async with limiter:
+            try:
+                async with self.get_blob_download_stream(blob_name) as stream:
+                    blob_etag = stream.properties.etag
+                    contents = await stream.readall()
+                tr = model.model_validate_json(contents)
+                tr.etag = blob_etag
+                return tr
+            except AzureBlobError as exc:
+                raise BoilermakerStorageError(
+                    f"Failed to load task result blob {blob_name} in graph {graph_id}",
+                    name=blob_name,
+                    graph_id=graph_id,
+                    status_code=exc.status_code,
+                    reason=exc.reason,
+                ) from exc
+            except ValidationError as e:
+                raise BoilermakerStorageError(
+                    f"Failed to deserialize task result in graph {graph_id}: {e}",
+                    name=blob_name,
+                    graph_id=graph_id,
+                    status_code=None,
+                    reason="DeserializationError",
+                ) from e
+
     async def load_graph(self, graph_id: GraphId, full: bool = False) -> TaskGraph | None:
         """Loads a TaskGraph from Azure Blob Storage.
 
@@ -90,43 +127,6 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
                     status_code=None,
                 ) from e
 
-            # Load all task result instances associated with this graph.
-            # Downloads run concurrently (up to 10 at a time) for speed.
-            model = TaskResult if full else TaskResultSlim
-            limiter = CapacityLimiter(10)
-
-            async def _download_result(blob_name: str) -> None:
-                async with limiter:
-                    try:
-                        async with self.get_blob_download_stream(blob_name) as stream:
-                            blob_etag = stream.properties.etag
-                            contents = await stream.readall()
-                        tr = model.model_validate_json(contents)
-                        tr.etag = blob_etag
-                    except AzureBlobError as exc:
-                        raise BoilermakerStorageError(
-                            f"Failed to load task result blob {blob_name} in graph {graph_id}",
-                            name=blob_name,
-                            graph_id=graph_id,
-                            status_code=exc.status_code,
-                            reason=exc.reason,
-                        ) from exc
-                    except ValidationError as e:
-                        raise BoilermakerStorageError(
-                            f"Failed to deserialize task result in graph {graph_id}: {e}",
-                            name=blob_name,
-                            graph_id=graph_id,
-                            status_code=None,
-                            reason="DeserializationError",
-                        ) from e
-
-                    if tr.graph_id == graph_id:
-                        graph.results[tr.task_id] = tr
-                    else:
-                        logger.warning(
-                            f"TaskResult {tr.task_id} in graph {graph_dir} with wrong graph_id {tr.graph_id}!"
-                        )
-
             # Collect blob names first (sequential), then download concurrently.
             # This keeps list_blobs errors outside the task group so they are
             # caught by the existing AzureBlobError/HttpResponseError handlers.
@@ -151,10 +151,20 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
                 ) from exc
 
             # Download result blobs concurrently (up to 10 at a time).
+            model = TaskResult if full else TaskResultSlim
+            limiter = CapacityLimiter(10)
+
+            async def _download_and_store(blob_name: str) -> None:
+                tr = await self._download_result_with_limiter(graph_id, blob_name, limiter, model=model)
+                if tr.graph_id == graph_id:
+                    graph.results[tr.task_id] = tr
+                else:
+                    logger.warning(f"TaskResult {tr.task_id} in graph {graph_dir} with wrong graph_id {tr.graph_id}!")
+
             try:
                 async with create_task_group() as tg:
                     for blob_name in blob_names:
-                        tg.start_soon(_download_result, blob_name)
+                        tg.start_soon(_download_and_store, blob_name)
             except* BoilermakerStorageError as exc_group:
                 # Unwrap the ExceptionGroup — raise the first storage error
                 # directly to preserve the existing API contract.
@@ -189,9 +199,7 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
                     if etag:
                         acquire_kwargs["etag"] = etag
                         acquire_kwargs["match_condition"] = MatchConditions.IfNotModified
-                    await lease_client.acquire(
-                        lease_duration=lease_duration, **acquire_kwargs
-                    )
+                    await lease_client.acquire(lease_duration=lease_duration, **acquire_kwargs)
                     return lease_client.id
             except AzureBlobError as exc:
                 # 409 Conflict = blob is already leased by another worker
@@ -206,9 +214,7 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
                     reason=exc.reason,
                 ) from exc
 
-    async def release_lease(
-        self, task_id: TaskId, graph_id: GraphId, lease_id: str
-    ) -> None:
+    async def release_lease(self, task_id: TaskId, graph_id: GraphId, lease_id: str) -> None:
         """Release a previously acquired lease. Best-effort — logs warning on failure."""
         fname = f"{self.task_result_prefix}/{graph_id}/{task_id}.json"
         with tracer.start_as_current_span("release_lease"):
@@ -235,7 +241,6 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
         """
         with tracer.start_as_current_span("store_graph"):
             created_date_tag = datetime.now(UTC).strftime("%Y-%m-%d")
-            lease = None
             async with self.get_blob_service_client() as blob_service_client:
                 container_client = blob_service_client.get_container_client(self.container_name)
                 # Store the graph itself first
@@ -290,9 +295,6 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
                         status_code=500,
                         reason="Unknown",
                     ) from excgroup
-                finally:
-                    if lease is not None:
-                        await lease.release()
             return graph
 
     async def load_task_result(self, task_id: TaskId, graph_id: GraphId) -> TaskResultSlim | None:
@@ -309,43 +311,18 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
         with tracer.start_as_current_span("load_task_result"):
             fname = f"{self.task_result_prefix}/{graph_id}/{task_id}.json"
             try:
-                async with self.get_blob_download_stream(fname) as stream:
-                    blob_etag = stream.properties.etag
-                    contents = await stream.readall()
-            except AzureBlobError as exc:
+                return await self._download_result_with_limiter(graph_id, fname, CapacityLimiter(1))
+            except BoilermakerStorageError as exc:
                 if exc.status_code == 404:
                     return None
-                raise BoilermakerStorageError(
-                    f"Failed to load task result {task_id}",
-                    task_id=task_id,
-                    graph_id=graph_id,
-                    status_code=exc.status_code,
-                    reason=exc.reason,
-                ) from exc
-            try:
-                result = TaskResultSlim.model_validate_json(contents)
-                result.etag = blob_etag
-                return result
-            except ValidationError as e:
-                raise BoilermakerStorageError(
-                    f"Failed to deserialize task result {task_id}: {e}",
-                    task_id=task_id,
-                    graph_id=graph_id,
-                    status_code=None,
-                    reason="DeserializationError",
-                ) from e
+                raise
 
     async def load_graph_slim_from_tags(self, graph_id: GraphId) -> TaskGraph | None:
         """Load a TaskGraph for display only, using blob tags to avoid content downloads.
 
-        Intended exclusively for the inspect CLI command. Do NOT use in the evaluator
-        or any code that needs authoritative status values: blob tags can lag behind
-        blob content by several seconds, which would cause stale reads in the
-        scheduling and ETag-guard paths.
-
         Builds TaskResultSlim from the 'status' tag on each blob instead of
         downloading the blob body. Falls back to content download for any blob
-        that pre-dates tag support (missing 'status' tag).
+        that is missing 'status' tag (older blobs that pre-date tag support).
 
         Args:
             graph_id: The GraphId to load.
@@ -379,39 +356,6 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
                     f"Failed to deserialize graph {graph_id}: {e}",
                     status_code=None,
                 ) from e
-
-            limiter = CapacityLimiter(10)
-
-            async def _download_result(blob_name: str) -> None:
-                async with limiter:
-                    try:
-                        async with self.get_blob_download_stream(blob_name) as stream:
-                            blob_etag = stream.properties.etag
-                            contents = await stream.readall()
-                        tr = TaskResultSlim.model_validate_json(contents)
-                        tr.etag = blob_etag
-                    except AzureBlobError as exc:
-                        raise BoilermakerStorageError(
-                            f"Failed to load task result blob {blob_name} in graph {graph_id}",
-                            name=blob_name,
-                            graph_id=graph_id,
-                            status_code=exc.status_code,
-                            reason=exc.reason,
-                        ) from exc
-                    except ValidationError as e:
-                        raise BoilermakerStorageError(
-                            f"Failed to deserialize task result in graph {graph_id}: {e}",
-                            name=blob_name,
-                            graph_id=graph_id,
-                            status_code=None,
-                            reason="DeserializationError",
-                        ) from e
-                    if tr.graph_id == graph_id:
-                        graph.results[tr.task_id] = tr
-                    else:
-                        logger.warning(
-                            f"TaskResult {tr.task_id} in graph {graph_dir} with wrong graph_id {tr.graph_id}!"
-                        )
 
             blob_names_to_download: list[str] = []
             try:
@@ -453,10 +397,19 @@ class BlobClientStorage(AzureBlobStorageClient, StorageInterface):
                     reason=str(exc),
                 ) from exc
 
+            limiter = CapacityLimiter(10)
+
+            async def _download_and_store(blob_name: str) -> None:
+                tr = await self._download_result_with_limiter(graph_id, blob_name, limiter)
+                if tr.graph_id == graph_id:
+                    graph.results[tr.task_id] = tr
+                else:
+                    logger.warning(f"TaskResult {tr.task_id} in graph {graph_dir} with wrong graph_id {tr.graph_id}!")
+
             try:
                 async with create_task_group() as tg:
                     for blob_name in blob_names_to_download:
-                        tg.start_soon(_download_result, blob_name)
+                        tg.start_soon(_download_and_store, blob_name)
             except* BoilermakerStorageError as exc_group:
                 raise exc_group.exceptions[0] from exc_group.exceptions[0].__cause__
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boilermaker-servicebus"
-version = "1.2.0"
+version = "1.2.1"
 description = "An async python Background task system using Azure Service Bus Queues"
 authors = [{ "name" = "Erik Aker", "email" = "eaker@mulliganfunding.com" }]
 license = { file = "LICENSE" }

--- a/tests/storage/test_blob_storage.py
+++ b/tests/storage/test_blob_storage.py
@@ -1,6 +1,7 @@
 import re
 from contextlib import asynccontextmanager
 from datetime import datetime, UTC
+from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -542,6 +543,130 @@ async def test_store_and_load_task_result_round_trip(mock_azureblob, blob_storag
 
     assert loaded is not None, "load_task_result returned None — blob path mismatch between store and load"
     assert loaded.status == sample_task_result.status
+
+
+# Tests for load_graph_slim_from_tags (inspect-only tag-based loading)
+
+
+def _tagged_blob(name: str, graph_id: str, status: str, etag: str = "etag-abc") -> mock.MagicMock:
+    """Create a BlobProperties-like mock with tags set."""
+    blob = mock.MagicMock()
+    blob.name = name
+    blob.etag = etag
+    blob.tags = {"graph_id": graph_id, "status": status, "created_date": "2026-01-01"}
+    return blob
+
+
+async def test_load_graph_slim_from_tags_builds_from_tags_without_download(
+    mock_azureblob,
+    blob_storage,
+    sample_task_graph,
+    sample_task,
+):
+    """load_graph_slim_from_tags must build TaskResultSlim from blob tags without
+    downloading blob content when the 'status' tag is present."""
+    sample_task_graph.add_task(sample_task)
+    graph_json = sample_task_graph.model_dump_json()
+    _, mockblobc, set_return = mock_azureblob
+    set_return.download_blob_returns(graph_json)
+
+    blob_name = f"task-results/{sample_task_graph.graph_id}/{sample_task.task_id}.json"
+    set_return.list_blobs_returns(
+        [_tagged_blob(blob_name, str(sample_task_graph.graph_id), "success", etag="etag-123")]
+    )
+
+    result = await blob_storage.load_graph_slim_from_tags(sample_task_graph.graph_id)
+
+    assert result is not None
+    assert sample_task.task_id in result.results
+    tr = result.results[sample_task.task_id]
+    assert isinstance(tr, TaskResultSlim)
+    assert tr.status == TaskStatus.Success
+    assert tr.etag == "etag-123"
+    # No blob content download should have occurred — only graph.json
+    assert mockblobc.download_blob.call_count == 1
+
+
+async def test_load_graph_slim_from_tags_falls_back_to_download_for_untagged_blob(
+    mock_azureblob,
+    blob_storage,
+    sample_task_graph,
+    sample_task,
+):
+    """load_graph_slim_from_tags must fall back to content download for blobs that
+    have no 'status' tag (written before tag support was added)."""
+    sample_task_graph.add_task(sample_task)
+    slim_result = TaskResultSlim(
+        task_id=sample_task.task_id,
+        graph_id=sample_task.graph_id,
+        status=TaskStatus.Success,
+    )
+    graph_json = sample_task_graph.model_dump_json()
+    task_result_json = slim_result.model_dump_json()
+    _, mockblobc, set_return = mock_azureblob
+    set_return.download_blob_returns(None, side_effect=[graph_json, task_result_json])
+
+    blob = mock.MagicMock()
+    blob.name = f"task-results/{sample_task_graph.graph_id}/{sample_task.task_id}.json"
+    blob.etag = "etag-old"
+    blob.tags = None
+    set_return.list_blobs_returns([blob])
+
+    result = await blob_storage.load_graph_slim_from_tags(sample_task_graph.graph_id)
+
+    assert result is not None
+    assert sample_task.task_id in result.results
+    # download_blob called twice: graph.json + task result fallback
+    assert mockblobc.download_blob.call_count == 2
+
+
+async def test_load_graph_slim_from_tags_passes_include_tags_to_list_blobs(
+    mock_azureblob,
+    blob_storage,
+    sample_task_graph,
+):
+    """load_graph_slim_from_tags must pass include=['tags'] to list_blobs."""
+    graph_json = sample_task_graph.model_dump_json()
+    container_client, _, set_return = mock_azureblob
+    set_return.download_blob_returns(graph_json)
+    set_return.list_blobs_returns([])
+
+    await blob_storage.load_graph_slim_from_tags(sample_task_graph.graph_id)
+
+    container_client.list_blobs.assert_called_once()
+    assert container_client.list_blobs.call_args.kwargs.get("include") == ["tags"]
+
+
+async def test_load_graph_unchanged_does_not_use_tags(
+    mock_azureblob,
+    blob_storage,
+    sample_task_graph,
+    sample_task,
+):
+    """load_graph must NOT pass include=['tags'] — evaluator path is unchanged."""
+    sample_task_graph.add_task(sample_task)
+    slim_result = TaskResultSlim(
+        task_id=sample_task.task_id,
+        graph_id=sample_task.graph_id,
+        status=TaskStatus.Success,
+    )
+    graph_json = sample_task_graph.model_dump_json()
+    task_result_json = slim_result.model_dump_json()
+    container_client, _, set_return = mock_azureblob
+    set_return.download_blob_returns(None, side_effect=[graph_json, task_result_json])
+    set_return.list_blobs_returns(
+        [
+            BlobProperties(
+                name=f"task-results/{sample_task_graph.graph_id}/{sample_task.task_id}.json",
+                last_modified="2023-01-01T00:00:00Z",
+            )
+        ]
+    )
+
+    await blob_storage.load_graph(sample_task_graph.graph_id)
+
+    call_kwargs = container_client.list_blobs.call_args.kwargs
+    assert "include" not in call_kwargs
 
 
 # Tests for load_graph full=True parameter

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -610,6 +610,28 @@ class TestPurgeMissingGraphJson:
         storage.load_graph.assert_not_called()
         storage.delete_blob.assert_not_called()
 
+    async def test_orphaned_blobs_purged_when_force(self, capsys):
+        """--force must purge task-result blobs that have no graph.json."""
+        graph_id = "019d8c0c-bd9b-7c23-be84-4d0799d7ecd4"
+        blob_name = f"task-results/{graph_id}/task-1.json"
+        blobs = [_make_blob(blob_name, _old(10))]
+        storage = _make_purge_storage(blob_list=blobs)
+        code = await run_purge(storage, older_than_days=7, force=True)
+        assert code == EXIT_HEALTHY
+        storage.load_graph.assert_not_called()
+        storage.delete_blobs_batch.assert_called()
+        deleted = [name for call in storage.delete_blobs_batch.call_args_list for name in call.args[0]]
+        assert blob_name in deleted
+
+    async def test_orphaned_blobs_not_purged_without_force(self, capsys):
+        """Without --force orphaned blobs (no graph.json) must still be skipped."""
+        graph_id = "019d8c0c-bd9b-7c23-be84-4d0799d7ecd4"
+        blobs = [_make_blob(f"task-results/{graph_id}/task-1.json", _old(10))]
+        storage = _make_purge_storage(blob_list=blobs)
+        code = await run_purge(storage, older_than_days=7, force=False)
+        assert code == EXIT_HEALTHY
+        storage.delete_blobs_batch.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # run_purge: in-progress safety check

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,6 +46,7 @@ def _mock_storage(graph: TaskGraph | None = None) -> mock.AsyncMock:
     """Return a mock storage whose load_graph returns the given graph."""
     storage = mock.AsyncMock()
     storage.load_graph = mock.AsyncMock(return_value=graph)
+    storage.load_graph_slim_from_tags = mock.AsyncMock(return_value=graph)
     return storage
 
 

--- a/tests/test_cli_inspect.py
+++ b/tests/test_cli_inspect.py
@@ -38,9 +38,10 @@ def _set_result(graph: TaskGraph, task: Task, status: TaskStatus) -> None:
 
 
 def _mock_storage(graph: TaskGraph | None = None) -> mock.AsyncMock:
-    """Return a mock storage whose load_graph returns the given graph."""
+    """Return a mock storage whose load_graph_slim_from_tags returns the given graph."""
     storage = mock.AsyncMock()
     storage.load_graph = mock.AsyncMock(return_value=graph)
+    storage.load_graph_slim_from_tags = mock.AsyncMock(return_value=graph)
     return storage
 
 
@@ -456,7 +457,7 @@ class TestRunInspectJsonExitCodes:
         json_exit_code = await run_inspect(storage, str(graph.graph_id), output_json=True)
         capsys.readouterr()  # flush captured output
 
-        storage.load_graph.return_value = graph
+        storage.load_graph_slim_from_tags.return_value = graph
         rich_exit_code = await run_inspect(storage, str(graph.graph_id), console=_no_color_console())
         assert json_exit_code == rich_exit_code == EXIT_HEALTHY
 
@@ -471,7 +472,7 @@ class TestRunInspectJsonExitCodes:
         json_exit_code = await run_inspect(storage, str(graph.graph_id), output_json=True)
         capsys.readouterr()  # flush captured output
 
-        storage.load_graph.return_value = graph
+        storage.load_graph_slim_from_tags.return_value = graph
         rich_exit_code = await run_inspect(storage, str(graph.graph_id), console=_no_color_console())
         assert json_exit_code == rich_exit_code == EXIT_STALLED
 

--- a/tests/test_cli_visual.py
+++ b/tests/test_cli_visual.py
@@ -554,9 +554,10 @@ _GLOBAL_OPTS = [
 
 
 def _mock_storage(graph: TaskGraph | None = None) -> mock.AsyncMock:
-    """Return a mock storage whose load_graph returns the given graph."""
+    """Return a mock storage whose load_graph/load_graph_slim_from_tags return the given graph."""
     storage = mock.AsyncMock()
     storage.load_graph = mock.AsyncMock(return_value=graph)
+    storage.load_graph_slim_from_tags = mock.AsyncMock(return_value=graph)
     return storage
 
 
@@ -722,7 +723,7 @@ class TestVisualLoadGraphFullTrue:
         )
 
     @pytest.mark.asyncio
-    async def test_non_visual_calls_load_graph_without_full(self):
+    async def test_non_visual_calls_load_graph_slim_from_tags(self):
         graph, task_a, task_b, task_c = _make_graph_with_tasks()
         _set_result(graph, task_a, TaskStatus.Success)
         _set_result(graph, task_b, TaskStatus.Success)
@@ -733,7 +734,6 @@ class TestVisualLoadGraphFullTrue:
             storage, str(graph.graph_id), console=_no_color_console(),
         )
 
-        storage.load_graph.assert_called_once()
-        call_kwargs = storage.load_graph.call_args
-        # Non-visual path should not pass full=True
-        assert call_kwargs.kwargs.get("full", False) is False
+        storage.load_graph_slim_from_tags.assert_called_once()
+        # The evaluator's load_graph must not be called by the non-visual path
+        storage.load_graph.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -350,7 +350,7 @@ wheels = [
 
 [[package]]
 name = "boilermaker-servicebus"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "aio-azure-clients-toolbox" },


### PR DESCRIPTION
This PR includes two updates to the CLI commands `purge` and `inspect`:
- `inspect`: now list tasks only using tags to render a status table, no need to download full which should make it a lot more responsive.
- `purge --force`: should also delete orphaned or one-off tasks now too.

In addition, I took a pass through the BlobStorageClient and cleaned up a few things:
- refactored out the downloader into a shared function instead of duplicating
- removed an unused lease.release
