### PR TITLE
Abandon instead of wait for redelivery

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
           hide_complexity: true
           indicators: true
           output: both
-          thresholds: '98 98'
+          thresholds: '96 96'
 
       - name: Add Coverage PR Comment
         uses: marocchino/sticky-pull-request-comment@v2

--- a/boilermaker/app.py
+++ b/boilermaker/app.py
@@ -34,6 +34,7 @@ from .evaluators import (
     TaskHandlerRegistry,
     TaskPublisher,
 )
+from .evaluators.task_graph import _MAX_DELIVERY_COUNT_FOR_ABANDON
 from .exc import BoilermakerAppException, BoilermakerStorageError
 from .retries import RetryPolicy
 from .storage import StorageInterface
@@ -535,6 +536,15 @@ class Boilermaker:
         Raises:
             Various Azure Service Bus exceptions for connection issues
         """
+        if self.results_storage is not None:
+            logger.warning(
+                "TaskGraph worker starting. Queue max_delivery_count must exceed "
+                f"{_MAX_DELIVERY_COUNT_FOR_ABANDON + 1} — messages with delivery_count "
+                f"<= {_MAX_DELIVERY_COUNT_FOR_ABANDON} are abandoned for fast redelivery; "
+                "higher counts fall back to lock-expiry. Lower max_delivery_count risks "
+                "dead-lettering graph tasks during sustained storage outages."
+            )
+
         async with create_task_group() as tg:
             async with self.service_bus_client.get_receiver() as receiver:
                 # Handle SIGTERM: when found -> instruct evaluator to abandon message

--- a/boilermaker/cli/_mermaid.py
+++ b/boilermaker/cli/_mermaid.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 
 from boilermaker.task import TaskGraph, TaskStatus
 from boilermaker.task.result import TaskResult
-from boilermaker.task.task_id import TaskId
+from boilermaker.task.task_id import TaskId, truncate_task_id
 
 # ---------------------------------------------------------------------------
 # Color mapping
@@ -51,12 +51,6 @@ def _sanitize_id(task_id: TaskId) -> str:
 def _escape_label(text: str) -> str:
     """Escape text for use inside a Mermaid quoted label."""
     return text.replace("\\", "\\\\").replace('"', "#quot;").replace("\n", " ")
-
-
-def _short_task_id(task_id: TaskId) -> str:
-    """Return the last 12 characters of a task ID for compact display."""
-    full = str(task_id)
-    return full[-12:] if len(full) > 12 else full
 
 
 def _node_class(status: TaskStatus | None, is_stalled: bool, has_blob: bool) -> str:
@@ -105,7 +99,7 @@ def generate_mermaid(graph: TaskGraph, stalled_task_ids: set[TaskId]) -> str:
         label_parts = [_escape_label(task.function_name)]
         if not has_blob:
             label_parts.append("NO BLOB")
-        label_parts.append(f"...{_short_task_id(task_id)}")
+        label_parts.append(truncate_task_id(task_id))
         label = "\\n".join(label_parts)
 
         lines.append(f'    {sanitized}["{label}"]:::{cls}')
@@ -127,7 +121,7 @@ def generate_mermaid(graph: TaskGraph, stalled_task_ids: set[TaskId]) -> str:
 
         if not has_blob:
             label_parts.append("NO BLOB")
-        label_parts.append(f"...{_short_task_id(task_id)}")
+        label_parts.append(truncate_task_id(task_id))
         label = "\\n".join(label_parts)
 
         lines.append(f'    {sanitized}{{{{"{label}"}}}}:::{cls}')

--- a/boilermaker/cli/_output.py
+++ b/boilermaker/cli/_output.py
@@ -9,13 +9,7 @@ from rich.table import Table
 from rich.text import Text
 
 from boilermaker.task import TaskGraph, TaskStatus
-from boilermaker.task.task_id import TaskId
-
-
-def _short_task_id(task_id: TaskId) -> str:
-    """Return the last 12 characters of a task ID for compact display."""
-    full = str(task_id)
-    return full[-12:] if len(full) > 12 else full
+from boilermaker.task.task_id import TaskId, truncate_task_id
 
 
 def status_style(status: TaskStatus, is_stalled: bool) -> tuple[str, str]:
@@ -108,7 +102,7 @@ def render_task_table(graph: TaskGraph) -> Table:
                 type_text = Text(task_type)
 
             table.add_row(
-                f"...{_short_task_id(task_id)}",
+                truncate_task_id(task_id),
                 task.function_name,
                 status_text,
                 type_text,
@@ -258,7 +252,7 @@ def render_task_detail(graph: TaskGraph, task_id: TaskId) -> Panel:
     detail.append("Dependents:   ", style="bold")
     detail.append(", ".join(sorted(dependents)) if dependents else "(none)")
 
-    return Panel(detail, title=f"Task: ...{_short_task_id(task_id)}")
+    return Panel(detail, title=f"Task: {truncate_task_id(task_id)}")
 
 
 def format_graph_table(graph: TaskGraph) -> str:

--- a/boilermaker/evaluators/eval.py
+++ b/boilermaker/evaluators/eval.py
@@ -41,7 +41,7 @@ async def eval_task(
     function = function_registry.get(task.function_name)
 
     # Look up function associated with the task
-    logger.info(f"[{task.function_name}] Begin Task {task.sequence_number=}")
+    logger.info(f"{task} Begin Task {task.sequence_number=}")
 
     if function is None:
         raise BoilermakerUnregisteredFunction(f"Function {task.function_name} not found in registry")
@@ -62,10 +62,7 @@ async def eval_task(
                 status=TaskStatus.Failure,
                 errors=["Task returned TaskFailureResult"],
             )
-            logger.warning(
-                f"[{task.function_name}] Task {task.sequence_number=} "
-                f"returned TaskFailureResult in {time.monotonic() - start:.3f}s"
-            )
+            logger.warning(f"{task} returned TaskFailureResult in {time.monotonic() - start:.3f}s")
         else:
             # Create success result
             task_result = TaskResult(
@@ -74,9 +71,7 @@ async def eval_task(
                 result=result,
                 status=TaskStatus.Success,
             )
-            logger.info(
-                f"[{task.function_name}] Completed Task {task.sequence_number=} in {time.monotonic() - start:.3f}s"
-            )
+            logger.info(f"{task} Completed Task {task.sequence_number=} in {time.monotonic() - start:.3f}s")
     except RetryException as retry:
         # A retry has been requested:
         # Calculate next delay and publish retry.
@@ -85,7 +80,7 @@ async def eval_task(
         if retry.policy and retry.policy != task.policy:
             # This will publish the *next* instance of the task using *this* policy
             task.policy = retry.policy
-            logger.warning(f"Task policy updated to retry policy {retry.policy}")
+            logger.warning(f"{task} retry policy updated to -> {retry.policy}")
 
         task_result = TaskResult(
             task_id=task.task_id,
@@ -96,7 +91,7 @@ async def eval_task(
         )
     except Exception as exc:
         # Some other exception has been thrown
-        err_msg = f"Exception in task sequence_number={task.sequence_number} {traceback.format_exc()}"
+        err_msg = f"Exception in {task} sequence_number={task.sequence_number} {traceback.format_exc()}"
         logger.error(err_msg)
         task_result = TaskResult(
             task_id=task.task_id,

--- a/boilermaker/evaluators/task_graph.py
+++ b/boilermaker/evaluators/task_graph.py
@@ -67,10 +67,18 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
         # Override type to indicate storage_interface is never None after validation
         self.storage_interface: StorageInterface = storage_interface
 
+    def _graph_tag(self) -> str:
+        return f"[Graph<{self.task.graph_id}>]" if self.task.graph_id else "[Graph<?>]"
+
+    def _task_tag(self, task: Task) -> str:
+        return f"{task.function_name}[{task.task_id}]"
+
     # The main message handler
     async def message_handler(self) -> TaskResult:
         """Individual message handler"""
         message_settled = False
+        _graph_tag = self._graph_tag()
+        _task_tag = self._task_tag(self.task)
 
         # Idempotent redelivery guard — if this task already reached a terminal state
         # (e.g. a prior execution succeeded before the SB lock expired and redelivered), skip
@@ -83,7 +91,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 # Transient read failure — proceed normally; do NOT skip execution on a read
                 # error, as that would permanently stall the graph.
                 logger.warning(
-                    f"Failed to read current status for task {self.task.task_id} before "
+                    f"{_graph_tag} Failed to read current status for task {_task_tag} before "
                     "writing Started; proceeding with execution",
                     exc_info=True,
                 )
@@ -93,7 +101,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
 
             if _existing is not None and _existing.status.finished:
                 logger.info(
-                    f"Task {self.task.task_id} already in terminal state {_existing.status!r} "
+                    f"{_graph_tag} Task {_task_tag} already in terminal state {_existing.status!r} "
                     "(SB redelivery); skipping re-execution"
                 )
                 _terminal_result = TaskResult(
@@ -105,7 +113,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                     await self.continue_graph(_terminal_result)
                 except exc.ContinueGraphError:
                     logger.error(
-                        f"continue_graph failed on redelivery for task {self.task.task_id}; "
+                        f"{_graph_tag} continue_graph failed on redelivery for task {_task_tag}; "
                         "abandoning for immediate redelivery",
                         exc_info=True,
                     )
@@ -113,8 +121,8 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                         await self.abandon_current_message()
                     except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
                         logger.warning(
-                            f"Failed to abandon message after continue_graph redelivery failure "
-                            f"for task {self.task.task_id}; SB will redeliver when lock expires",
+                            f"{_graph_tag} Failed to abandon message after continue_graph redelivery failure "
+                            f"for task {_task_tag}; SB will redeliver when lock expires",
                             exc_info=True,
                         )
                     return _terminal_result
@@ -122,7 +130,10 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                     await self.complete_message()
                 except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
                     logger.warning(
-                        f"Failed to complete message on redelivery for task {self.task.task_id}; SB will redeliver",
+                        (
+                            f"{_graph_tag} Failed to complete message on redelivery for task "
+                            f"{_task_tag}; Expect redelivery"
+                        ),
                         exc_info=True,
                     )
                 return _terminal_result
@@ -144,7 +155,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
             _is_precondition_failure = getattr(_started_err, "status_code", None) == 412
             if not _is_precondition_failure:
                 logger.warning(
-                    f"Non-precondition error writing Started for task {self.task.task_id}; proceeding with execution",
+                    f"{_graph_tag} Non-precondition error writing Started for task {_task_tag}; proceeding...",
                     exc_info=True,
                 )
             else:
@@ -153,13 +164,13 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 # _etag is only non-None when self.task.graph_id is set (see capture above),
                 # so this assertion is always true when we reach a 412.
                 assert self.task.graph_id is not None, (
-                    "412 on Started write implies _etag was set, which requires graph_id"
+                    f"{_graph_tag} 412 on Started write implies _etag was set, which requires graph_id"
                 )
                 try:
                     _reread = await self.storage_interface.load_task_result(self.task.task_id, self.task.graph_id)
                 except exc.BoilermakerStorageError:
                     logger.error(
-                        f"412 on Started write and re-read also failed for task {self.task.task_id}; "
+                        f"{_graph_tag} 412 on Started write and re-read also failed for task {_task_tag}; "
                         "abandoning for immediate redelivery",
                         exc_info=True,
                     )
@@ -167,8 +178,8 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                         await self.abandon_current_message()
                     except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
                         logger.warning(
-                            f"Failed to abandon message after 412+re-read failure for task "
-                            f"{self.task.task_id}; SB will redeliver when lock expires",
+                            f"{_graph_tag} Failed to abandon message after 412+re-read failure for task "
+                            f"{_task_tag}; SB will redeliver when lock expires",
                             exc_info=True,
                         )
                     return TaskResult(
@@ -182,9 +193,8 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                     # state, since a blob must exist once the graph is stored.  Returning
                     # Failure surfaces the anomaly rather than silently dropping the task.
                     logger.error(
-                        f"412 on Started write but re-read returned None for task "
-                        f"{self.task.task_id}; blob should always exist after graph creation. "
-                        "Returning Failure to avoid stalling the graph."
+                        f"{_graph_tag} 412 on Started write but re-read returned None for task {_task_tag}; "
+                        "blob should always exist after graph creation."
                     )
                     return TaskResult(
                         task_id=self.task.task_id,
@@ -196,14 +206,14 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 if _reread.status.finished:
                     # Another worker already reached a terminal state — skip execution.
                     logger.info(
-                        f"Task {self.task.task_id} reached terminal state {_reread.status!r} "
+                        f"{_graph_tag} Task {_task_tag} reached terminal state {_reread.status!r} "
                         "after 412 on Started write; skipping execution"
                     )
                     try:
                         await self.complete_message()
                     except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
                         logger.warning(
-                            f"Failed to complete message after 412 skip for task {self.task.task_id}; "
+                            f"{_graph_tag} Failed to complete message after 412 skip for task {_task_tag}; "
                             "SB will redeliver",
                             exc_info=True,
                         )
@@ -216,14 +226,14 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 if _reread.status == TaskStatus.Started:
                     # Another worker won the CAS and is executing — yield to that worker.
                     logger.info(
-                        f"Task {self.task.task_id} is already Started by another worker "
+                        f"{_graph_tag} Task {_task_tag} is already Started by another worker "
                         "(412 on Started write); completing message without executing"
                     )
                     try:
                         await self.complete_message()
                     except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
                         logger.warning(
-                            f"Failed to complete message after 412 yield for task {self.task.task_id}; "
+                            f"{_graph_tag} Failed to complete message after 412 yield for task {_task_tag}; "
                             "SB will redeliver",
                             exc_info=True,
                         )
@@ -251,11 +261,11 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                     #              RetryStartedAfterScheduled
                     if _reread.etag is None:
                         logger.warning(
-                            f"412 + {_reread.status.value} re-read for task {self.task.task_id}: "
+                            f"{_graph_tag} 412 + {_reread.status.value} re-read for task {_task_tag}: "
                             "re-read etag is None — degraded to unconditional retry write"
                         )
                     logger.warning(
-                        f"412 + {_reread.status.value} for task {self.task.task_id}; "
+                        f"{_graph_tag} 412 + {_reread.status.value} for task {_task_tag}; "
                         "retrying Started write with re-read etag"
                     )
                     try:
@@ -269,7 +279,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                         if not _retry_is_precondition_failure:
                             # RetryStartedWriteNon412Error: fail-open, fall through to execution.
                             logger.warning(
-                                f"Non-412 error on retry Started write for task {self.task.task_id}; "
+                                f"{_graph_tag} Non-412 error on retry Started write for task {_task_tag}; "
                                 "proceeding with execution",
                                 exc_info=True,
                             )
@@ -281,7 +291,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                             # the current state.
                             # Spec action: RetryStartedWrite412 → RereadAfterRetry412
                             logger.warning(
-                                f"Second 412 on retry Started write for task {self.task.task_id}; "
+                                f"{_graph_tag}  Second 412 on retry Started write for task {_task_tag}; "
                                 "re-reading to determine action"
                             )
                             try:
@@ -292,7 +302,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                                 # Blob state unknown — do NOT settle.  Let the SB lock
                                 # expire and redeliver so a fresh worker can retry.
                                 logger.error(
-                                    f"Second 412 + re-read also failed for task {self.task.task_id}; "
+                                    f"{_graph_tag} Second 412 + re-read also failed for task {_task_tag}; "
                                     "not settling — SB will redeliver",
                                     exc_info=True,
                                 )
@@ -305,8 +315,8 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                                     await self.complete_message()
                                 except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
                                     logger.warning(
-                                        f"Failed to complete message after second 412 (Started) "
-                                        f"for task {self.task.task_id}; SB will redeliver",
+                                        f"{_graph_tag} Failed to complete message after second 412 (Started) "
+                                        f"for task {_task_tag}; SB will redeliver",
                                         exc_info=True,
                                     )
                                 return TaskResult(
@@ -321,8 +331,8 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                                     await self.complete_message()
                                 except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
                                     logger.warning(
-                                        f"Failed to complete message after second 412 (terminal) "
-                                        f"for task {self.task.task_id}; SB will redeliver",
+                                        f"{_graph_tag} Failed to complete message after second 412 (terminal) "
+                                        f"for task {_task_tag}; SB will redeliver",
                                         exc_info=True,
                                     )
                                 return TaskResult(
@@ -338,15 +348,15 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                                 # Note: Retry is not modeled as a blob status in the TLA+ spec
                                 # (spec only produces Success/Failure from execution).
                                 logger.warning(
-                                    f"Second 412 + Retry re-read for task {self.task.task_id}; "
+                                    f"{_graph_tag} Second 412 + Retry re-read for task {_task_tag}; "
                                     "another worker published a retry message — settling our duplicate"
                                 )
                                 try:
                                     await self.complete_message()
                                 except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
                                     logger.warning(
-                                        f"Failed to complete message after second 412 (Retry) "
-                                        f"for task {self.task.task_id}; SB will redeliver",
+                                        f"{_graph_tag} Failed to complete message after second 412 (Retry) "
+                                        f"for task {_task_tag}; SB will redeliver",
                                         exc_info=True,
                                     )
                                 return TaskResult(
@@ -362,17 +372,17 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                                 # Spec action: RereadAfterRetry412 (Pending/Scheduled) → abandon
                                 _reread2_status = _reread2.status if _reread2 is not None else None
                                 logger.error(
-                                    f"Two 412s on Started write; second re-read returned "
+                                    f"{_graph_tag} Two 412s on Started write; second re-read returned "
                                     f"{_reread2_status!r} "
-                                    f"for task {self.task.task_id}. "
+                                    f"for task {_task_tag}. "
                                     "Abandoning for immediate redelivery.",
                                 )
                                 try:
                                     await self.abandon_current_message()
                                 except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
                                     logger.warning(
-                                        f"Failed to abandon message after two 412s for task "
-                                        f"{self.task.task_id}; SB will redeliver when lock expires",
+                                        f"{_graph_tag} Failed to abandon message after two 412s for task "
+                                        f"{_task_tag}; SB will redeliver when lock expires",
                                         exc_info=True,
                                     )
                                 return TaskResult(
@@ -386,14 +396,14 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                     # the retry message.
                     # Spec action: WriteStarted412 (Retry) → Completing
                     logger.warning(
-                        f"412 on Started write; re-read returned Retry for task {self.task.task_id}; "
+                        f"{_graph_tag} 412 on Started write; re-read returned Retry for task {_task_tag}; "
                         "another worker already retried — settling our duplicate"
                     )
                     try:
                         await self.complete_message()
                     except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
                         logger.warning(
-                            f"Failed to complete message after 412+Retry for task {self.task.task_id}; "
+                            f"{_graph_tag} Failed to complete message after 412+Retry for task {_task_tag}; "
                             "SB will redeliver",
                             exc_info=True,
                         )
@@ -408,16 +418,16 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                     # Scheduled, Pending, or Retry) — this branch should be unreachable
                     # for all currently defined statuses.  Abandon for immediate redelivery.
                     logger.error(
-                        f"412 on Started write but re-read returned unexpected status "
-                        f"{_reread.status!r} for task {self.task.task_id}; "
+                        f"{_graph_tag} 412 on Started write but re-read returned unexpected status "
+                        f"{_reread.status!r} for task {_task_tag}; "
                         "abandoning for immediate redelivery."
                     )
                     try:
                         await self.abandon_current_message()
                     except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
                         logger.warning(
-                            f"Failed to abandon message after 412+unexpected status for task "
-                            f"{self.task.task_id}; SB will redeliver when lock expires",
+                            f"{_graph_tag} Failed to abandon message after 412+unexpected status for task "
+                            f"{_task_tag}; SB will redeliver when lock expires",
                             exc_info=True,
                         )
                     return TaskResult(
@@ -440,7 +450,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 await self.complete_message()
                 message_settled = True
             except exc.BoilermakerTaskLeaseLost:
-                logger.error(f"Lost message lease when trying to complete early for task {self.task.function_name}")
+                logger.error(f"{_graph_tag} Lost message lease when trying to complete early for task {_task_tag}")
                 return TaskResult(
                     task_id=self.task.task_id,
                     graph_id=self.task.graph_id,
@@ -448,7 +458,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                     errors=["Lost message lease"],
                 )
             except exc.BoilermakerServiceBusError:
-                logger.error("Unknown ServiceBusError", exc_info=True)
+                logger.error(f"{_graph_tag} Unknown ServiceBusError", exc_info=True)
                 return TaskResult(
                     task_id=self.task.task_id,
                     graph_id=self.task.graph_id,
@@ -457,14 +467,15 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 )
 
         if not self.task.can_retry:
-            logger.error(f"Retries exhausted for event {self.task.function_name}")
+            logger.error(f"{_graph_tag} Retries exhausted for {self.task.function_name}")
             if not message_settled:
                 try:
                     await self.deadletter_or_complete_task("ProcessingError", detail="Retries exhausted")
                     message_settled = True
                 except exc.BoilermakerTaskLeaseLost:
                     logger.error(
-                        f"Lost message lease when trying to deadletter/complete  for task {self.task.function_name}"
+                        f"{_graph_tag} Lost message lease when trying to deadletter/complete {_task_tag}"
+                        " after retries exhausted"
                     )
                     return TaskResult(
                         task_id=self.task.task_id,
@@ -473,7 +484,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                         errors=["Lost message lease during retry exhaustion"],
                     )
                 except exc.BoilermakerServiceBusError:
-                    logger.error("Unknown ServiceBusError", exc_info=True)
+                    logger.error(f"{_graph_tag} Unknown ServiceBusError", exc_info=True)
                     return TaskResult(
                         task_id=self.task.task_id,
                         graph_id=self.task.graph_id,
@@ -496,7 +507,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 await self.continue_graph(task_result)
             except exc.ContinueGraphError:
                 logger.error(
-                    f"continue_graph failed after retries exhausted for task {self.task.task_id}; "
+                    f"{_graph_tag} continue_graph failed after retries exhausted for {_task_tag}; "
                     "failure callbacks may not be dispatched (message already deadlettered)",
                     exc_info=True,
                 )
@@ -519,16 +530,15 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 # The task result is already written; a fresh delivery will skip
                 # re-execution (idempotency guard) and retry continue_graph directly.
                 logger.error(
-                    f"continue_graph failed for task {self.task.task_id}; "
-                    "abandoning for immediate redelivery",
+                    f"{_graph_tag} continue_graph failed for task {_task_tag}; abandoning for immediate redelivery",
                     exc_info=True,
                 )
                 try:
                     await self.abandon_current_message()
                 except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
                     logger.warning(
-                        f"Failed to abandon message after continue_graph failure for task "
-                        f"{self.task.task_id}; SB will redeliver when lock expires",
+                        f"{_graph_tag} Failed to abandon message after continue_graph failure for task {_task_tag}; "
+                        "SB will redeliver when lock expires",
                         exc_info=True,
                     )
                 return result
@@ -537,7 +547,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
             delay = self.task.get_next_delay()
             retry_msg_id = f"{self.task.task_id}:{self.task.attempts.attempts}"
             warn_msg = (
-                f"{result.errors} "
+                f"{_graph_tag} {result.errors} {_task_tag}"
                 f"[attempt {self.task.attempts.attempts} of {self.task.policy.max_tries}] "
                 f"Publishing retry... {self.sequence_number=} "
                 f"<function={self.task.function_name}> with {delay=} {retry_msg_id=}"
@@ -561,12 +571,12 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 message_settled = True
             except exc.BoilermakerTaskLeaseLost:
                 logger.error(
-                    f"Lost message lease when trying to complete late for task {self.task.function_name} "
+                    f"{_graph_tag} Lost message lease when trying to complete late for task {_task_tag} "
                     "May result in multiple executions of this task and its callbacks!"
                 )
                 return result
             except exc.BoilermakerServiceBusError:
-                logger.error("Unknown ServiceBusError", exc_info=True)
+                logger.error(f"{_graph_tag} Unknown ServiceBusError", exc_info=True)
                 return result
 
         return result
@@ -614,7 +624,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 if getattr(e, "status_code", None) == 404:
                     # Permanent: graph blob does not exist. Redelivery will not help.
                     logger.critical(
-                        f"Graph {graph_id} not found in storage (404); downstream tasks will not be dispatched. "
+                        f"[Graph {graph_id}] not found in storage (404); downstream tasks will not be dispatched. "
                         "This graph may have been deleted.",
                         exc_info=True,
                     )
@@ -624,7 +634,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 if attempt < _LOAD_GRAPH_RETRY_POLICY.max_tries - 1:
                     delay = _LOAD_GRAPH_RETRY_POLICY.get_delay_interval(attempt)
                     logger.warning(
-                        f"load_graph failed for graph {graph_id} "
+                        f"[Graph {graph_id}] load_graph failed "
                         f"(attempt {attempt + 1}/{_LOAD_GRAPH_RETRY_POLICY.max_tries}); "
                         f"retrying in {delay}s",
                         exc_info=True,
@@ -632,23 +642,23 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                     await asyncio.sleep(delay)
                 else:
                     logger.error(
-                        f"load_graph failed for graph {graph_id} after "
+                        f"[Graph {graph_id}] load_graph failed after "
                         f"{_LOAD_GRAPH_RETRY_POLICY.max_tries} attempts; "
                         "raising ContinueGraphError to suppress message settlement",
                         exc_info=True,
                     )
                     raise exc.ContinueGraphError(
-                        f"load_graph failed for graph {graph_id} after {_LOAD_GRAPH_RETRY_POLICY.max_tries} attempts"
+                        f"[Graph {graph_id}] load_graph failed after {_LOAD_GRAPH_RETRY_POLICY.max_tries} attempts"
                     ) from last_exc
         else:
             # Should only be reached if max_tries == 0 (not expected).
-            raise exc.ContinueGraphError(f"load_graph not attempted for graph {graph_id}")
+            raise exc.ContinueGraphError(f"[Graph {graph_id}] load_graph not attempted")
 
         if not graph:
             # Permanent failure: graph blob does not exist.  Redelivery will not help.
             # Settling the upstream message is intentional here.
             logger.critical(
-                f"Graph {graph_id} not found after task completion — "
+                f"[Graph {graph_id}] not found after task completion — "
                 "downstream tasks will never be dispatched. "
                 "This is a permanent data loss; redelivery will not recover it."
             )
@@ -657,6 +667,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
         # Sanity check: did we load the result that was *just* stored?
         loaded_task_status = graph.get_status(completed_task_result.task_id)
         if loaded_task_status != completed_task_result.status:
+
             logger.error(
                 f"[Graph {graph_id}] Task status mismatch: "
                 f"expected {completed_task_result.task_id} to be {completed_task_result.status}, "
@@ -682,7 +693,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 ready_count += 1
 
         if ready_count == 0:
-            logger.info(f"[Graph {graph_id}] No new tasks ready after task {completed_task_result.task_id}")
+            logger.debug(f"[Graph {graph_id}] No new tasks ready after task {completed_task_result.task_id}")
 
         return ready_count
 
@@ -760,8 +771,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
 
         except Exception:
             logger.error(
-                f"[Graph {graph_id}] Failed to publish task {task.task_id}; "
-                "remains Pending, will retry on redelivery.",
+                f"[Graph {graph_id}] Failed to publish task {task.task_id}; remains Pending, will retry on redelivery.",
                 exc_info=True,
             )
             return False

--- a/boilermaker/evaluators/task_graph.py
+++ b/boilermaker/evaluators/task_graph.py
@@ -222,13 +222,14 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                     # No other worker holds Started yet — retry the CAS with the
                     # re-read etag.
                     #
-                    # Scheduled: normal publish-before-store window; scheduler wrote
-                    #   Scheduled and released its lease before this worker consumed
-                    #   the SB message.
-                    # Pending:   lease acquire bumped the blob ETag (Azure advances the
-                    #   ETag on BlobLeaseClient.acquire() even without a content write)
-                    #   but the scheduler has not yet written Scheduled (or
-                    #   WriteScheduledFail left the blob Pending).  Either way no other
+                    # Scheduled: normal publish-before-store window; the scheduler's
+                    #   Scheduled content write (E→E+1) raced with this worker's
+                    #   initial Started write.
+                    # Pending:   the scheduler acquired the lease (Azure does NOT
+                    #   advance ETag on lease acquire) and published to SB, but has
+                    #   not yet written Scheduled — or WriteScheduledFail left the
+                    #   blob Pending.  The content write that bumped the ETag was
+                    #   something other than a lease operation.  Either way no other
                     #   worker holds Started, so this worker is the legitimate claimant.
                     #
                     # Spec action: WriteStarted412 (Scheduled/Pending branch) →
@@ -340,23 +341,29 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                                 )
                             else:
                                 # Pending, Scheduled, None, or any other unclaimed state:
-                                # no other worker holds Started.  Do NOT settle — let the
-                                # SB lock expire so a fresh worker can retry from scratch.
-                                # Spec action: RereadAfterRetry412 (Pending/Scheduled) → no-settle
+                                # no other worker holds Started.  Abandon for immediate
+                                # redelivery — a fresh delivery will pre-read the current
+                                # ETag and succeed without hitting the two-412 window.
+                                # Spec action: RereadAfterRetry412 (Pending/Scheduled) → abandon
                                 _reread2_status = _reread2.status if _reread2 is not None else None
                                 logger.error(
                                     f"Two 412s on Started write; second re-read returned "
                                     f"{_reread2_status!r} "
                                     f"for task {self.task.task_id}. "
-                                    "Not settling — SB will redeliver.",
+                                    "Abandoning for immediate redelivery.",
                                 )
+                                try:
+                                    await self.abandon_current_message()
+                                except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
+                                    logger.warning(
+                                        f"Failed to abandon message after two 412s for task "
+                                        f"{self.task.task_id}; SB will redeliver when lock expires",
+                                        exc_info=True,
+                                    )
                                 return TaskResult(
                                     task_id=self.task.task_id,
                                     graph_id=self.task.graph_id,
-                                    status=TaskStatus.Failure,
-                                    errors=[
-                                        f"two 412s on Started write; second re-read returned {_reread2_status!r}"
-                                    ],
+                                    status=TaskStatus.Scheduled,
                                 )
                 elif _reread.status == TaskStatus.Retry:
                     # Another worker executed the task and published a delayed retry

--- a/boilermaker/evaluators/task_graph.py
+++ b/boilermaker/evaluators/task_graph.py
@@ -14,6 +14,11 @@ from .eval import eval_task
 
 logger = logging.getLogger("boilermaker.app")
 
+# Maximum SB delivery_count at which we actively abandon for fast redelivery.
+# Above this threshold we let the lock expire naturally to avoid burning through
+# the queue's max_delivery_count (typically ~5) during sustained outages.
+_MAX_DELIVERY_COUNT_FOR_ABANDON = 3
+
 # Retry policy used when load_graph raises a transient exception.
 # Up to 3 attempts total (initial + 2 retries) with exponential backoff.
 _LOAD_GRAPH_RETRY_POLICY = retries.RetryPolicy(
@@ -68,17 +73,25 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
         self.storage_interface: StorageInterface = storage_interface
 
     def _graph_tag(self) -> str:
-        return f"[Graph {self.task.graph_id}]" if self.task.graph_id else "[Graph ?]"
+        return f"Graph<{self.task.graph_id}>" if self.task.graph_id else "Graph<?>"
 
-    def _task_tag(self, task: Task) -> str:
-        return f"{task.function_name}[{task.task_id}]"
+    async def _abandon_or_let_expire(self) -> None:
+        """Abandon for fast redelivery while delivery_count <= _MAX_DELIVERY_COUNT_FOR_ABANDON.
+
+        Once the count exceeds the threshold we let the lock expire naturally instead,
+        so a sustained storage outage cannot burn through the queue's max_delivery_count
+        and dead-letter the message prematurely.
+        """
+        delivery_count = self.task.msg.delivery_count if self.task.msg and self.task.msg.delivery_count else 0
+        if delivery_count <= _MAX_DELIVERY_COUNT_FOR_ABANDON:
+            await self.abandon_current_message()
 
     # The main message handler
     async def message_handler(self) -> TaskResult:
         """Individual message handler"""
         message_settled = False
         _graph_tag = self._graph_tag()
-        _task_tag = self._task_tag(self.task)
+        _task_tag = str(self.task)
 
         # Idempotent redelivery guard — if this task already reached a terminal state
         # (e.g. a prior execution succeeded before the SB lock expired and redelivered), skip
@@ -91,7 +104,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 # Transient read failure — proceed normally; do NOT skip execution on a read
                 # error, as that would permanently stall the graph.
                 logger.warning(
-                    f"{_graph_tag} Failed to read current status for task {_task_tag} before "
+                    f"{_graph_tag} Failed to read current status for {_task_tag} before "
                     "writing Started; proceeding with execution",
                     exc_info=True,
                 )
@@ -101,7 +114,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
 
             if _existing is not None and _existing.status.finished:
                 logger.info(
-                    f"{_graph_tag} Task {_task_tag} already in terminal state {_existing.status!r} "
+                    f"{_graph_tag} {_task_tag} already in terminal state {_existing.status!r} "
                     "(SB redelivery); skipping re-execution"
                 )
                 _terminal_result = TaskResult(
@@ -113,16 +126,16 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                     await self.continue_graph(_terminal_result)
                 except exc.ContinueGraphError:
                     logger.error(
-                        f"{_graph_tag} continue_graph failed on redelivery for task {_task_tag}; "
+                        f"{_graph_tag} continue_graph failed on redelivery for {_task_tag}; "
                         "abandoning for immediate redelivery",
                         exc_info=True,
                     )
                     try:
-                        await self.abandon_current_message()
+                        await self._abandon_or_let_expire()
                     except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
                         logger.warning(
                             f"{_graph_tag} Failed to abandon message after continue_graph redelivery failure "
-                            f"for task {_task_tag}; SB will redeliver when lock expires",
+                            f"for {_task_tag}; SB will redeliver when lock expires",
                             exc_info=True,
                         )
                     return _terminal_result
@@ -130,10 +143,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                     await self.complete_message()
                 except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
                     logger.warning(
-                        (
-                            f"{_graph_tag} Failed to complete message on redelivery for task "
-                            f"{_task_tag}; Expect redelivery"
-                        ),
+                        f"{_graph_tag} Failed to complete message on redelivery for {_task_tag}. Expect redelivery",
                         exc_info=True,
                     )
                 return _terminal_result
@@ -155,7 +165,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
             _is_precondition_failure = getattr(_started_err, "status_code", None) == 412
             if not _is_precondition_failure:
                 logger.warning(
-                    f"{_graph_tag} Non-precondition error writing Started for task {_task_tag}; proceeding...",
+                    f"{_graph_tag} Non-precondition error writing Started for {_task_tag}; proceeding...",
                     exc_info=True,
                 )
             else:
@@ -170,16 +180,16 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                     _reread = await self.storage_interface.load_task_result(self.task.task_id, self.task.graph_id)
                 except exc.BoilermakerStorageError:
                     logger.error(
-                        f"{_graph_tag} 412 on Started write and re-read also failed for task {_task_tag}; "
+                        f"{_graph_tag} 412 on Started write and re-read also failed for {_task_tag}; "
                         "abandoning for immediate redelivery",
                         exc_info=True,
                     )
                     try:
-                        await self.abandon_current_message()
+                        await self._abandon_or_let_expire()
                     except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
                         logger.warning(
-                            f"{_graph_tag} Failed to abandon message after 412+re-read failure for task "
-                            f"{_task_tag}; SB will redeliver when lock expires",
+                            f"{_graph_tag} Failed to abandon message after 412+re-read failure for {_task_tag}; "
+                            "SB will redeliver when lock expires",
                             exc_info=True,
                         )
                     return TaskResult(
@@ -193,7 +203,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                     # state, since a blob must exist once the graph is stored.  Returning
                     # Failure surfaces the anomaly rather than silently dropping the task.
                     logger.error(
-                        f"{_graph_tag} 412 on Started write but re-read returned None for task {_task_tag}; "
+                        f"{_graph_tag} 412 on Started write but re-read returned None for {_task_tag}; "
                         "blob should always exist after graph creation."
                     )
                     return TaskResult(
@@ -206,14 +216,14 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 if _reread.status.finished:
                     # Another worker already reached a terminal state — skip execution.
                     logger.info(
-                        f"{_graph_tag} Task {_task_tag} reached terminal state {_reread.status!r} "
+                        f"{_graph_tag} {_task_tag} reached terminal state {_reread.status!r} "
                         "after 412 on Started write; skipping execution"
                     )
                     try:
                         await self.complete_message()
                     except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
                         logger.warning(
-                            f"{_graph_tag} Failed to complete message after 412 skip for task {_task_tag}; "
+                            f"{_graph_tag} Failed to complete message after 412 skip for {_task_tag}; "
                             "SB will redeliver",
                             exc_info=True,
                         )
@@ -226,14 +236,14 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 if _reread.status == TaskStatus.Started:
                     # Another worker won the CAS and is executing — yield to that worker.
                     logger.info(
-                        f"{_graph_tag} Task {_task_tag} is already Started by another worker "
+                        f"{_graph_tag} {_task_tag} is already Started by another worker "
                         "(412 on Started write); completing message without executing"
                     )
                     try:
                         await self.complete_message()
                     except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
                         logger.warning(
-                            f"{_graph_tag} Failed to complete message after 412 yield for task {_task_tag}; "
+                            f"{_graph_tag} Failed to complete message after 412 yield for {_task_tag}; "
                             "SB will redeliver",
                             exc_info=True,
                         )
@@ -261,11 +271,11 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                     #              RetryStartedAfterScheduled
                     if _reread.etag is None:
                         logger.warning(
-                            f"{_graph_tag} 412 + {_reread.status.value} re-read for task {_task_tag}: "
+                            f"{_graph_tag} 412 + {_reread.status.value} re-read for {_task_tag}: "
                             "re-read etag is None — degraded to unconditional retry write"
                         )
                     logger.warning(
-                        f"{_graph_tag} 412 + {_reread.status.value} for task {_task_tag}; "
+                        f"{_graph_tag} 412 + {_reread.status.value} for {_task_tag}; "
                         "retrying Started write with re-read etag"
                     )
                     try:
@@ -279,7 +289,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                         if not _retry_is_precondition_failure:
                             # RetryStartedWriteNon412Error: fail-open, fall through to execution.
                             logger.warning(
-                                f"{_graph_tag} Non-412 error on retry Started write for task {_task_tag}; "
+                                f"{_graph_tag} Non-412 error on retry Started write for {_task_tag}; "
                                 "proceeding with execution",
                                 exc_info=True,
                             )
@@ -291,7 +301,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                             # the current state.
                             # Spec action: RetryStartedWrite412 → RereadAfterRetry412
                             logger.warning(
-                                f"{_graph_tag}  Second 412 on retry Started write for task {_task_tag}; "
+                                f"{_graph_tag}  Second 412 on retry Started write for {_task_tag}; "
                                 "re-reading to determine action"
                             )
                             try:
@@ -302,7 +312,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                                 # Blob state unknown — abandon for immediate redelivery.
                                 # Falls through to the else branch below which calls abandon.
                                 logger.error(
-                                    f"{_graph_tag} Second 412 + re-read also failed for task {_task_tag}; "
+                                    f"{_graph_tag} Second 412 + re-read also failed for {_task_tag}; "
                                     "abandoning for immediate redelivery",
                                     exc_info=True,
                                 )
@@ -316,7 +326,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                                 except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
                                     logger.warning(
                                         f"{_graph_tag} Failed to complete message after second 412 (Started) "
-                                        f"for task {_task_tag}; SB will redeliver",
+                                        f"for {_task_tag}; SB will redeliver",
                                         exc_info=True,
                                     )
                                 return TaskResult(
@@ -332,7 +342,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                                 except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
                                     logger.warning(
                                         f"{_graph_tag} Failed to complete message after second 412 (terminal) "
-                                        f"for task {_task_tag}; SB will redeliver",
+                                        f"for {_task_tag}; SB will redeliver",
                                         exc_info=True,
                                     )
                                 return TaskResult(
@@ -348,7 +358,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                                 # Note: Retry is not modeled as a blob status in the TLA+ spec
                                 # (spec only produces Success/Failure from execution).
                                 logger.warning(
-                                    f"{_graph_tag} Second 412 + Retry re-read for task {_task_tag}; "
+                                    f"{_graph_tag} Second 412 + Retry re-read for {_task_tag}; "
                                     "another worker published a retry message — settling our duplicate"
                                 )
                                 try:
@@ -356,7 +366,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                                 except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
                                     logger.warning(
                                         f"{_graph_tag} Failed to complete message after second 412 (Retry) "
-                                        f"for task {_task_tag}; SB will redeliver",
+                                        f"for {_task_tag}; SB will redeliver",
                                         exc_info=True,
                                     )
                                 return TaskResult(
@@ -373,16 +383,15 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                                 _reread2_status = _reread2.status if _reread2 is not None else None
                                 logger.error(
                                     f"{_graph_tag} Two 412s on Started write; second re-read returned "
-                                    f"{_reread2_status!r} "
-                                    f"for task {_task_tag}. "
+                                    f"{_reread2_status!r} for {_task_tag}. "
                                     "Abandoning for immediate redelivery.",
                                 )
                                 try:
-                                    await self.abandon_current_message()
+                                    await self._abandon_or_let_expire()
                                 except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
                                     logger.warning(
-                                        f"{_graph_tag} Failed to abandon message after two 412s for task "
-                                        f"{_task_tag}; SB will redeliver when lock expires",
+                                        f"{_graph_tag} Failed to abandon message after two 412s for {_task_tag}; "
+                                        "SB will redeliver when lock expires",
                                         exc_info=True,
                                     )
                                 return TaskResult(
@@ -396,14 +405,14 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                     # the retry message.
                     # Spec action: WriteStarted412 (Retry) → Completing
                     logger.warning(
-                        f"{_graph_tag} 412 on Started write; re-read returned Retry for task {_task_tag}; "
+                        f"{_graph_tag} 412 on Started write; re-read returned Retry for {_task_tag}; "
                         "another worker already retried — settling our duplicate"
                     )
                     try:
                         await self.complete_message()
                     except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
                         logger.warning(
-                            f"{_graph_tag} Failed to complete message after 412+Retry for task {_task_tag}; "
+                            f"{_graph_tag} Failed to complete message after 412+Retry for {_task_tag}; "
                             "SB will redeliver",
                             exc_info=True,
                         )
@@ -419,15 +428,15 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                     # for all currently defined statuses.  Abandon for immediate redelivery.
                     logger.error(
                         f"{_graph_tag} 412 on Started write but re-read returned unexpected status "
-                        f"{_reread.status!r} for task {_task_tag}; "
+                        f"{_reread.status!r} for {_task_tag}; "
                         "abandoning for immediate redelivery."
                     )
                     try:
-                        await self.abandon_current_message()
+                        await self._abandon_or_let_expire()
                     except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
                         logger.warning(
-                            f"{_graph_tag} Failed to abandon message after 412+unexpected status for task "
-                            f"{_task_tag}; SB will redeliver when lock expires",
+                            f"{_graph_tag} Failed to abandon message after 412+unexpected status for {_task_tag}; "
+                            "SB will redeliver when lock expires",
                             exc_info=True,
                         )
                     return TaskResult(
@@ -450,7 +459,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 await self.complete_message()
                 message_settled = True
             except exc.BoilermakerTaskLeaseLost:
-                logger.error(f"{_graph_tag} Lost message lease when trying to complete early for task {_task_tag}")
+                logger.error(f"{_graph_tag} Lost message lease when trying to complete early for {_task_tag}")
                 return TaskResult(
                     task_id=self.task.task_id,
                     graph_id=self.task.graph_id,
@@ -530,14 +539,14 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 # The task result is already written; a fresh delivery will skip
                 # re-execution (idempotency guard) and retry continue_graph directly.
                 logger.error(
-                    f"{_graph_tag} continue_graph failed for task {_task_tag}; abandoning for immediate redelivery",
+                    f"{_graph_tag} continue_graph failed for {_task_tag}; abandoning for immediate redelivery",
                     exc_info=True,
                 )
                 try:
-                    await self.abandon_current_message()
+                    await self._abandon_or_let_expire()
                 except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
                     logger.warning(
-                        f"{_graph_tag} Failed to abandon message after continue_graph failure for task {_task_tag}; "
+                        f"{_graph_tag} Failed to abandon message after continue_graph failure for {_task_tag}; "
                         "SB will redeliver when lock expires",
                         exc_info=True,
                     )
@@ -547,7 +556,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
             delay = self.task.get_next_delay()
             retry_msg_id = f"{self.task.task_id}:{self.task.attempts.attempts}"
             warn_msg = (
-                f"{_graph_tag} {result.errors} {_task_tag} "
+                f"{_graph_tag} [{result.errors}] {_task_tag} "
                 f"[attempt {self.task.attempts.attempts} of {self.task.policy.max_tries}] "
                 f"Publishing retry... {self.sequence_number=} "
                 f"<function={self.task.function_name}> with {delay=} {retry_msg_id=}"
@@ -571,7 +580,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 message_settled = True
             except exc.BoilermakerTaskLeaseLost:
                 logger.error(
-                    f"{_graph_tag} Lost message lease when trying to complete late for task {_task_tag} "
+                    f"{_graph_tag} Lost message lease when trying to complete late for {_task_tag} "
                     "May result in multiple executions of this task and its callbacks!"
                 )
                 return result
@@ -729,23 +738,23 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
             )
         except exc.BoilermakerStorageError:
             logger.warning(
-                f"[Graph {graph_id}] try_acquire_lease raised unexpected error for task "
+                f"Graph<{graph_id}> try_acquire_lease raised unexpected error for task "
                 f"{task.task_id}; skipping — will be retried on redelivery.",
                 exc_info=True,
             )
             return False
         if lease_id is None:
             logger.debug(
-                f"[Graph {graph_id}] Skipping task {task.task_id}: "
+                f"Graph<{graph_id}> Skipping task {task.task_id}: "
                 "lease not acquired (another worker holds it or blob was modified)."
             )
             return False
 
         try:
             # Publish task to SB (message_id = task_id for fan-in dedup).
-            _task_tag = self._task_tag(task)
+            _task_tag = str(task)
             await self.publish_task(task)
-            logger.info(f"[Graph {graph_id}] Published task {_task_tag}")
+            logger.info(f"Graph<{graph_id}> Published {_task_tag}")
 
             # Write Scheduled status under the held lease. The lease prevents a
             # racing worker (that picked up the just-published SB message) from
@@ -755,14 +764,14 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 await self.storage_interface.store_task_result(result, lease_id=lease_id)
             except exc.BoilermakerStorageError as err:
                 logger.warning(
-                    f"[Graph {graph_id}] Failed to write Scheduled for task {_task_tag}. "
+                    f"Graph<{graph_id}> Failed to write Scheduled for {_task_tag}. "
                     f"Task published to Service Bus. Error: {err}",
                     exc_info=True,
                 )
                 return True  # published successfully, blob write failed
             except ValueError:
                 logger.error(
-                    f"[Graph {graph_id}] schedule_task raised ValueError for task {_task_tag}. "
+                    f"Graph<{graph_id}> schedule_task raised ValueError for {_task_tag}. "
                     f"Task published; blob write skipped.",
                     exc_info=True,
                 )
@@ -772,7 +781,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
 
         except Exception:
             logger.error(
-                f"[Graph {graph_id}] Failed to publish task {_task_tag}; remains Pending, will retry on redelivery.",
+                f"Graph<{graph_id}> Failed to publish {_task_tag}; remains Pending, will retry on redelivery.",
                 exc_info=True,
             )
             return False

--- a/boilermaker/evaluators/task_graph.py
+++ b/boilermaker/evaluators/task_graph.py
@@ -106,9 +106,17 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 except exc.ContinueGraphError:
                     logger.error(
                         f"continue_graph failed on redelivery for task {self.task.task_id}; "
-                        "suppressing settlement to allow redelivery",
+                        "abandoning for immediate redelivery",
                         exc_info=True,
                     )
+                    try:
+                        await self.abandon_current_message()
+                    except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
+                        logger.warning(
+                            f"Failed to abandon message after continue_graph redelivery failure "
+                            f"for task {self.task.task_id}; SB will redeliver when lock expires",
+                            exc_info=True,
+                        )
                     return _terminal_result
                 try:
                     await self.complete_message()
@@ -152,14 +160,21 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 except exc.BoilermakerStorageError:
                     logger.error(
                         f"412 on Started write and re-read also failed for task {self.task.task_id}; "
-                        "returning Failure to avoid stalling graph",
+                        "abandoning for immediate redelivery",
                         exc_info=True,
                     )
+                    try:
+                        await self.abandon_current_message()
+                    except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
+                        logger.warning(
+                            f"Failed to abandon message after 412+re-read failure for task "
+                            f"{self.task.task_id}; SB will redeliver when lock expires",
+                            exc_info=True,
+                        )
                     return TaskResult(
                         task_id=self.task.task_id,
                         graph_id=self.task.graph_id,
-                        status=TaskStatus.Failure,
-                        errors=["412 on Started write; re-read failed"],
+                        status=TaskStatus.Scheduled,
                     )
 
                 if _reread is None:
@@ -390,20 +405,25 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
 
                 else:
                     # Truly unexpected status after 412 (not None, finished, Started,
-                    # Scheduled, Pending, or Retry).  Do NOT settle — we don't know
-                    # whether another worker will continue the graph, so stalling here
-                    # is safer than consuming the message and orphaning the task.
-                    # Let the SB lock expire so a fresh worker can retry from scratch.
+                    # Scheduled, Pending, or Retry) — this branch should be unreachable
+                    # for all currently defined statuses.  Abandon for immediate redelivery.
                     logger.error(
                         f"412 on Started write but re-read returned unexpected status "
                         f"{_reread.status!r} for task {self.task.task_id}; "
-                        "not settling — SB will redeliver."
+                        "abandoning for immediate redelivery."
                     )
+                    try:
+                        await self.abandon_current_message()
+                    except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
+                        logger.warning(
+                            f"Failed to abandon message after 412+unexpected status for task "
+                            f"{self.task.task_id}; SB will redeliver when lock expires",
+                            exc_info=True,
+                        )
                     return TaskResult(
                         task_id=self.task.task_id,
                         graph_id=self.task.graph_id,
-                        status=TaskStatus.Failure,
-                        errors=[f"412 on Started write; re-read returned unexpected status {_reread.status!r}"],
+                        status=_reread.status,
                     )
 
         # We successfully wrote Started — we own execution from here.
@@ -495,13 +515,22 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
             try:
                 await self.continue_graph(result)
             except exc.ContinueGraphError:
-                # Transient load_graph failure — do NOT settle the message.
-                # Allow Service Bus redelivery so downstream dispatch can be retried.
+                # Transient load_graph failure — abandon for immediate redelivery.
+                # The task result is already written; a fresh delivery will skip
+                # re-execution (idempotency guard) and retry continue_graph directly.
                 logger.error(
                     f"continue_graph failed for task {self.task.task_id}; "
-                    "suppressing message settlement to allow redelivery",
+                    "abandoning for immediate redelivery",
                     exc_info=True,
                 )
+                try:
+                    await self.abandon_current_message()
+                except (exc.BoilermakerTaskLeaseLost, exc.BoilermakerServiceBusError):
+                    logger.warning(
+                        f"Failed to abandon message after continue_graph failure for task "
+                        f"{self.task.task_id}; SB will redeliver when lock expires",
+                        exc_info=True,
+                    )
                 return result
         elif result.status == TaskStatus.Retry:
             # Retry requested: republish the same task with delay

--- a/boilermaker/evaluators/task_graph.py
+++ b/boilermaker/evaluators/task_graph.py
@@ -73,7 +73,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
         self.storage_interface: StorageInterface = storage_interface
 
     def _graph_tag(self) -> str:
-        return f"Graph<{self.task.graph_id}>" if self.task.graph_id else "Graph<?>"
+        return f"[Graph(id={self.task.graph_id})]" if self.task.graph_id else "[Graph(id=<?>)]"
 
     async def _abandon_or_let_expire(self) -> None:
         """Abandon for fast redelivery while delivery_count <= _MAX_DELIVERY_COUNT_FOR_ABANDON.
@@ -633,7 +633,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 if getattr(e, "status_code", None) == 404:
                     # Permanent: graph blob does not exist. Redelivery will not help.
                     logger.critical(
-                        f"[Graph {graph_id}] not found in storage (404); downstream tasks will not be dispatched. "
+                        f"[Graph(id={graph_id})] not found in storage (404); downstream tasks will not be dispatched. "
                         "This graph may have been deleted.",
                         exc_info=True,
                     )
@@ -643,7 +643,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 if attempt < _LOAD_GRAPH_RETRY_POLICY.max_tries - 1:
                     delay = _LOAD_GRAPH_RETRY_POLICY.get_delay_interval(attempt)
                     logger.warning(
-                        f"[Graph {graph_id}] load_graph failed "
+                        f"[Graph(id={graph_id})] load_graph failed "
                         f"(attempt {attempt + 1}/{_LOAD_GRAPH_RETRY_POLICY.max_tries}); "
                         f"retrying in {delay}s",
                         exc_info=True,
@@ -651,23 +651,23 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                     await asyncio.sleep(delay)
                 else:
                     logger.error(
-                        f"[Graph {graph_id}] load_graph failed after "
+                        f"[Graph(id={graph_id})] load_graph failed after "
                         f"{_LOAD_GRAPH_RETRY_POLICY.max_tries} attempts; "
                         "raising ContinueGraphError to suppress message settlement",
                         exc_info=True,
                     )
                     raise exc.ContinueGraphError(
-                        f"[Graph {graph_id}] load_graph failed after {_LOAD_GRAPH_RETRY_POLICY.max_tries} attempts"
+                        f"[Graph(id={graph_id})] load_graph failed after {_LOAD_GRAPH_RETRY_POLICY.max_tries} attempts"
                     ) from last_exc
         else:
             # Should only be reached if max_tries == 0 (not expected).
-            raise exc.ContinueGraphError(f"[Graph {graph_id}] load_graph not attempted")
+            raise exc.ContinueGraphError(f"[Graph(id={graph_id})] load_graph not attempted")
 
         if not graph:
             # Permanent failure: graph blob does not exist.  Redelivery will not help.
             # Settling the upstream message is intentional here.
             logger.critical(
-                f"[Graph {graph_id}] not found after task completion — "
+                f"[Graph(id={graph_id})] not found after task completion — "
                 "downstream tasks will never be dispatched. "
                 "This is a permanent data loss; redelivery will not recover it."
             )
@@ -678,12 +678,12 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
         if loaded_task_status != completed_task_result.status:
 
             logger.error(
-                f"[Graph {graph_id}] Task status mismatch: "
+                f"[Graph(id={graph_id})] Task status mismatch: "
                 f"expected {completed_task_result.task_id} to be {completed_task_result.status}, "
                 f"but got {loaded_task_status}. Suppressing settlement to allow redelivery."
             )
             raise exc.ContinueGraphError(
-                f"[Graph {graph_id}] Status mismatch for task {completed_task_result.task_id}: "
+                f"[Graph(id={graph_id})] Status mismatch for task {completed_task_result.task_id}: "
                 f"expected {completed_task_result.status}, got {loaded_task_status}"
             )
 
@@ -702,7 +702,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 ready_count += 1
 
         if ready_count == 0:
-            logger.debug(f"[Graph {graph_id}] No new tasks ready after task {completed_task_result.task_id}")
+            logger.debug(f"[Graph(id={graph_id})] No new tasks ready after task {completed_task_result.task_id}")
 
         return ready_count
 
@@ -738,23 +738,21 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
             )
         except exc.BoilermakerStorageError:
             logger.warning(
-                f"Graph<{graph_id}> try_acquire_lease raised unexpected error for task "
-                f"{task.task_id}; skipping — will be retried on redelivery.",
+                f"[{graph}] try_acquire_lease raised unexpected error for task "
+                f"{task}; skipping — will be retried on redelivery.",
                 exc_info=True,
             )
             return False
         if lease_id is None:
             logger.debug(
-                f"Graph<{graph_id}> Skipping task {task.task_id}: "
-                "lease not acquired (another worker holds it or blob was modified)."
+                f"[{graph}] Skipping task {task}: lease not acquired (another worker holds it or blob was modified)."
             )
             return False
 
         try:
             # Publish task to SB (message_id = task_id for fan-in dedup).
-            _task_tag = str(task)
             await self.publish_task(task)
-            logger.info(f"Graph<{graph_id}> Published {_task_tag}")
+            logger.info(f"[{graph}] Published {task}")
 
             # Write Scheduled status under the held lease. The lease prevents a
             # racing worker (that picked up the just-published SB message) from
@@ -764,15 +762,13 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 await self.storage_interface.store_task_result(result, lease_id=lease_id)
             except exc.BoilermakerStorageError as err:
                 logger.warning(
-                    f"Graph<{graph_id}> Failed to write Scheduled for {_task_tag}. "
-                    f"Task published to Service Bus. Error: {err}",
+                    f"[{graph}] Failed to write Scheduled for {task}. Task published to Service Bus. Error: {err}",
                     exc_info=True,
                 )
                 return True  # published successfully, blob write failed
             except ValueError:
                 logger.error(
-                    f"Graph<{graph_id}> schedule_task raised ValueError for {_task_tag}. "
-                    f"Task published; blob write skipped.",
+                    f"[{graph}] schedule_task raised ValueError for {task}. Task published; blob write skipped.",
                     exc_info=True,
                 )
                 return True  # published successfully, schedule_task rejected it
@@ -781,7 +777,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
 
         except Exception:
             logger.error(
-                f"Graph<{graph_id}> Failed to publish {_task_tag}; remains Pending, will retry on redelivery.",
+                f"[{graph}] Failed to publish {task}; remains Pending, will retry on redelivery.",
                 exc_info=True,
             )
             return False

--- a/boilermaker/evaluators/task_graph.py
+++ b/boilermaker/evaluators/task_graph.py
@@ -68,7 +68,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
         self.storage_interface: StorageInterface = storage_interface
 
     def _graph_tag(self) -> str:
-        return f"[Graph<{self.task.graph_id}>]" if self.task.graph_id else "[Graph<?>]"
+        return f"[Graph {self.task.graph_id}]" if self.task.graph_id else "[Graph ?]"
 
     def _task_tag(self, task: Task) -> str:
         return f"{task.function_name}[{task.task_id}]"
@@ -299,11 +299,11 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                                     self.task.task_id, self.task.graph_id
                                 )
                             except exc.BoilermakerStorageError:
-                                # Blob state unknown — do NOT settle.  Let the SB lock
-                                # expire and redeliver so a fresh worker can retry.
+                                # Blob state unknown — abandon for immediate redelivery.
+                                # Falls through to the else branch below which calls abandon.
                                 logger.error(
                                     f"{_graph_tag} Second 412 + re-read also failed for task {_task_tag}; "
-                                    "not settling — SB will redeliver",
+                                    "abandoning for immediate redelivery",
                                     exc_info=True,
                                 )
                                 _reread2 = None
@@ -467,7 +467,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 )
 
         if not self.task.can_retry:
-            logger.error(f"{_graph_tag} Retries exhausted for {self.task.function_name}")
+            logger.error(f"{_graph_tag} Retries exhausted for {_task_tag}")
             if not message_settled:
                 try:
                     await self.deadletter_or_complete_task("ProcessingError", detail="Retries exhausted")
@@ -547,7 +547,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
             delay = self.task.get_next_delay()
             retry_msg_id = f"{self.task.task_id}:{self.task.attempts.attempts}"
             warn_msg = (
-                f"{_graph_tag} {result.errors} {_task_tag}"
+                f"{_graph_tag} {result.errors} {_task_tag} "
                 f"[attempt {self.task.attempts.attempts} of {self.task.policy.max_tries}] "
                 f"Publishing retry... {self.sequence_number=} "
                 f"<function={self.task.function_name}> with {delay=} {retry_msg_id=}"
@@ -743,8 +743,9 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
 
         try:
             # Publish task to SB (message_id = task_id for fan-in dedup).
+            _task_tag = self._task_tag(task)
             await self.publish_task(task)
-            logger.info(f"[Graph {graph_id}] Published task {task.task_id}")
+            logger.info(f"[Graph {graph_id}] Published task {_task_tag}")
 
             # Write Scheduled status under the held lease. The lease prevents a
             # racing worker (that picked up the just-published SB message) from
@@ -754,15 +755,15 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 await self.storage_interface.store_task_result(result, lease_id=lease_id)
             except exc.BoilermakerStorageError as err:
                 logger.warning(
-                    f"[Graph {graph_id}] Failed to write Scheduled for task {task.task_id}. "
+                    f"[Graph {graph_id}] Failed to write Scheduled for task {_task_tag}. "
                     f"Task published to Service Bus. Error: {err}",
                     exc_info=True,
                 )
                 return True  # published successfully, blob write failed
             except ValueError:
                 logger.error(
-                    f"[Graph {graph_id}] schedule_task raised ValueError for task "
-                    f"{task.task_id}. Task published; blob write skipped.",
+                    f"[Graph {graph_id}] schedule_task raised ValueError for task {_task_tag}. "
+                    f"Task published; blob write skipped.",
                     exc_info=True,
                 )
                 return True  # published successfully, schedule_task rejected it
@@ -771,7 +772,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
 
         except Exception:
             logger.error(
-                f"[Graph {graph_id}] Failed to publish task {task.task_id}; remains Pending, will retry on redelivery.",
+                f"[Graph {graph_id}] Failed to publish task {_task_tag}; remains Pending, will retry on redelivery.",
                 exc_info=True,
             )
             return False

--- a/boilermaker/task/graph.py
+++ b/boilermaker/task/graph.py
@@ -80,6 +80,12 @@ class TaskGraph(BaseModel):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
+    def __str__(self) -> str:
+        return f"Graph(id={self.graph_id})"
+
+    def __repr__(self) -> str:
+        return f"TaskGraph<{self.graph_id}>"
+
     @classmethod
     def graph_path(cls, graph_id: GraphId) -> Path:
         """Returns the storage path for an arbitrary GraphId."""

--- a/boilermaker/task/task.py
+++ b/boilermaker/task/task.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, ConfigDict
 
 from boilermaker import retries, tracing
 
-from .task_id import GraphId, ident_field, TaskId
+from .task_id import GraphId, ident_field, TaskId, truncate_task_id
 from .types import TaskHandler
 
 logger = logging.getLogger(__name__)
@@ -210,6 +210,10 @@ class Task(BaseModel):
         return self.attempts.inc(now)
 
     def __str__(self) -> str:
+        truncated_id = truncate_task_id(self.task_id)
+        return f"[{self.function_name}(id={truncated_id})]"
+
+    def __repr__(self) -> str:
         return f"Task<{self.function_name}: {self.task_id}>"
 
     def __hash__(self) -> int:

--- a/boilermaker/task/task.py
+++ b/boilermaker/task/task.py
@@ -210,7 +210,7 @@ class Task(BaseModel):
         return self.attempts.inc(now)
 
     def __str__(self) -> str:
-        return f"Task<{self.task_id}: {self.function_name}>"
+        return f"Task<{self.function_name}: {self.task_id}>"
 
     def __hash__(self) -> int:
         """Hash based on unique task_id for use in sets and dicts."""

--- a/boilermaker/task/task.py
+++ b/boilermaker/task/task.py
@@ -209,6 +209,9 @@ class Task(BaseModel):
         now = datetime.datetime.now(datetime.UTC)
         return self.attempts.inc(now)
 
+    def __str__(self) -> str:
+        return f"Task<{self.task_id}: {self.function_name}>"
+
     def __hash__(self) -> int:
         """Hash based on unique task_id for use in sets and dicts."""
         return hash(self.task_id)

--- a/boilermaker/task/task_id.py
+++ b/boilermaker/task/task_id.py
@@ -7,5 +7,11 @@ TaskId = typing.NewType("TaskId", str)
 GraphId = typing.NewType("GraphId", str)
 
 
+def truncate_task_id(task_id: TaskId, limit: int = 12) -> str:
+    full = str(task_id)
+    trunc = full[-limit:] if len(full) > limit else full
+    return f"...{trunc}"
+
+
 def ident_field():
     return Field(default_factory=lambda: TaskId(str(uuid.uuid7())))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ testpaths = ["tests"]
 filterwarnings = ["error"]
 
 [tool.coverage.report]
+fail_under = 96
 exclude_also = [
     "def __repr__",
     "if self.debug",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boilermaker-servicebus"
-version = "1.2.1"
+version = "1.3.0"
 description = "An async python Background task system using Azure Service Bus Queues"
 authors = [{ "name" = "Erik Aker", "email" = "eaker@mulliganfunding.com" }]
 license = { file = "LICENSE" }

--- a/specs/TaskGraphSpecBase.tla
+++ b/specs/TaskGraphSpecBase.tla
@@ -41,16 +41,17 @@
 \*      - CAS 412 again: re-read a second time:
 \*          Started   -> complete message, return (another worker won)
 \*          terminal  -> complete message, return terminal result
-\*          other     -> complete message, return Failure (always settle)
+\*          Pending/Scheduled -> abandon_message() for immediate redelivery, return Scheduled
 \*      - Non-412 storage error: proceed with execution anyway (fail-open)
 \*   3. Execute task (nondeterministic)
 \*   4. Write result unconditionally
 \*   5. Run continue_graph
 \*   6. Complete (settle) message
 \*
-\* KEY INVARIANT: always settle the SB message. Never rely on SB redelivery for
-\* correctness of the 412 branch. The Scheduled -> retry -> Started path is the
-\* forward move that eliminates orphaned-Scheduled bug.
+\* KEY INVARIANT: settle the SB message on the normal forward path. For the
+\* double-412 Pending/Scheduled case, abandon the message for immediate SB
+\* redelivery — this is the mechanism that prevents permanent stalls when the
+\* blob is unclaimed after two consecutive CAS misses.
 
 EXTENDS Naturals, Sequences, FiniteSets, TLC
 
@@ -303,8 +304,10 @@ WriteStartedSuccess(w) ==
 \*   Started   -> Completing (complete message; another worker won)
 \*   Scheduled -> RetryStartedAfterScheduled (retry with re-read etag)
 \*   Pending   -> RetryStartedAfterScheduled (retry with re-read etag; same as Scheduled)
-\*               Lease acquire bumped the ETag without changing content.  No other
-\*               worker holds Started, so this worker is the legitimate claimant.
+\*               NOTE: under corrected Azure semantics lease acquire does NOT bump the
+\*               ETag, so this Pending branch is unreachable in normal operation —
+\*               the consumer's etag still matches while the blob is leased and the
+\*               write gets 409, not 412.  The branch is retained defensively.
 \*   other     -> Completing (always settle)
 \*
 \* Since blobStatus[t] is always defined (never None) in this model, the
@@ -334,8 +337,10 @@ WriteStarted412(w) ==
                              workerReadySet, workerCurrentReady>>
           \/ \* Re-read is Scheduled or Pending: no worker owns Started yet —
              \* retry the Started write with the re-read etag.
-             \* Pending:   lease acquire bumped the ETag (AcquireLeaseSuccess) but the
-             \*             Scheduled write has not yet happened (or WriteScheduledFail).
+             \* Pending:   Under corrected Azure semantics (lease acquire does NOT bump
+             \*             ETag) this branch is unreachable in normal operation: the
+             \*             consumer's etag matches while the blob is leased, so the
+             \*             write gets 409 instead.  Retained defensively.
              \* Scheduled: normal publish-before-store window.
              /\ rereadStatus \in {"Scheduled", "Pending"}
              /\ workerPhase' = [workerPhase EXCEPT ![w] = "RetryStartedAfterScheduled"]
@@ -554,12 +559,14 @@ StatusMismatchCheck(w) ==
 \* On failure: remove from readySet (skip), stay in AcquiringLease.
 \* When readySet is empty: transition to Completing.
 \*
-\* ETag bump on lease acquire: Azure Blob Storage advances the blob's ETag when
-\* BlobLeaseClient.acquire() succeeds, even though the blob content (status) does
-\* not change.  We model this as blobEtag[child] + 1.  This is the root cause of
-\* the 412+Pending race: a worker that read the blob before the lease acquire will
-\* hold a stale ETag and get a 412 on its Started write, with the re-read returning
-\* Pending (status unchanged by the lease acquire).  See WriteStarted412 below.
+\* ETag on lease acquire: Azure Blob Storage does NOT advance the blob's ETag when
+\* BlobLeaseClient.acquire() succeeds — lease state is separate from blob content.
+\* We therefore leave blobEtag unchanged in AcquireLeaseSuccess.
+\* Consequence: a worker that captured the blob's ETag before the lease acquire
+\* will still hold a valid ETag and its Started write will receive 409 (blob is
+\* leased, non-lease write rejected) rather than 412 (ETag mismatch).  The
+\* 412+Pending scenario modeled in WriteStarted412 is therefore unreachable under
+\* correct Azure semantics; the branch is retained defensively.
 
 AcquireLeaseSuccess(w) ==
     /\ workerPhase[w] = "AcquiringLease"
@@ -572,12 +579,11 @@ AcquireLeaseSuccess(w) ==
         /\ blobStatus[child] = "Pending"
         /\ ~blobLeased[child]
         /\ blobLeased' = [blobLeased EXCEPT ![child] = TRUE]
-        \* Azure bumps the ETag on lease acquire even with no content change.
-        /\ blobEtag'   = [blobEtag   EXCEPT ![child] = blobEtag[child] + 1]
+        \* Lease acquire does NOT advance the ETag (Azure docs: only content writes do).
         /\ workerCurrentReady' = [workerCurrentReady EXCEPT ![w] = child]
         /\ workerReadySet' = [workerReadySet EXCEPT ![w] = workerReadySet[w] \ {child}]
         /\ workerPhase' = [workerPhase EXCEPT ![w] = "PublishingTask"]
-        /\ UNCHANGED <<blobStatus, blobDeadLettered, sbMessages, workerMsg, workerTask,
+        /\ UNCHANGED <<blobStatus, blobEtag, blobDeadLettered, sbMessages, workerMsg, workerTask,
                         workerResult, workerCapturedEtag,
                         workerSnapshot, workerSnapshotEtags>>
 
@@ -940,10 +946,17 @@ EventualResultWrite ==
 \* State constraint for bounded model checking
 \* ---------------------------------------------------------------------------
 
-\* Etag values are protocol-bounded: each task is written at most
-\* ~(2*MaxDeliveryCount + 3) times.  Making the bound explicit lets TLC
-\* prune unreachable high-etag states and dramatically shrinks the state
-\* space.  If TLC ever reports a CONSTRAINT violation, increase the bound.
+\* Etag values are protocol-bounded.  With lease acquire no longer bumping the
+\* ETag, the maximum number of ETag advances per task is:
+\*   1  (Pending write in Init or continue_graph)
+\* + 1  (Scheduled write by continue_graph)
+\* + MaxDeliveryCount * 2  (Started + result write per delivery attempt)
+\* = 2 * MaxDeliveryCount + 2
+\*
+\* The bound of 2 * MaxDeliveryCount + 4 retains two extra slots of buffer
+\* above the tightest derivation to accommodate model-checking edge cases and
+\* any future protocol extensions.  If TLC ever reports a CONSTRAINT violation,
+\* increase the bound.
 EtagBound == \A t \in Tasks : blobEtag[t] <= 2 * MaxDeliveryCount + 4
 
 \* ---------------------------------------------------------------------------

--- a/tests/evaluators/test_task_graphs.py
+++ b/tests/evaluators/test_task_graphs.py
@@ -2075,14 +2075,14 @@ async def test_412_scheduled_retry_second_412_sees_terminal_settles(evaluator_co
 
 
 @pytest.mark.parametrize("second_reread_value", [None, "scheduled", "pending"])
-async def test_412_scheduled_retry_second_412_sees_unclaimed_does_not_settle(
+async def test_412_scheduled_retry_second_412_sees_unclaimed_abandons(
     evaluator_context, mock_storage, second_reread_value
 ):
     """When the retry Started write gets a second 412 and the second re-read returns an
-    unclaimed status (None, Scheduled, Pending), the handler does NOT call complete_message
-    — it lets the SB lock expire for redelivery instead of permanently stalling the graph.
+    unclaimed status (None, Scheduled, Pending), the handler abandons for immediate redelivery
+    — it does NOT call complete_message, which would permanently stall the graph.
 
-    Spec action: RereadAfterRetry412 (Pending/Scheduled) → RereadAfterRetryNoSettle.
+    Spec action: RereadAfterRetry412 (Pending/Scheduled) → abandon.
     Parameterized over: None, Scheduled, Pending second re-reads.
     """
     from unittest.mock import patch
@@ -2538,9 +2538,9 @@ async def test_non_412_started_write_error_falls_through_to_execution(evaluator_
 # ----- 412 + re-read also fails (lines 152-158) -----
 
 
-async def test_412_started_write_reread_also_fails_returns_failure(evaluator_context, mock_storage):
+async def test_412_started_write_reread_also_fails_abandons(evaluator_context, mock_storage):
     """When the Started write gets a 412 and the re-read also raises a storage error,
-    the evaluator must return Failure without settling (lines 152-158).
+    the evaluator abandons for immediate redelivery and returns Scheduled.
     """
     from unittest.mock import patch
 
@@ -2702,9 +2702,9 @@ async def test_412_reread_with_none_etag_logs_warning_and_retries(evaluator_cont
 # ----- Second 412 paths (lines 275-283, 290-291, 306-307, 324-336) -----
 
 
-async def test_second_412_reread_also_fails_returns_failure_no_settle(evaluator_context, mock_storage):
+async def test_second_412_reread_also_fails_abandons(evaluator_context, mock_storage):
     """When the second 412 + second re-read also raises a storage error, _reread2 is set
-    to None and the evaluator returns Failure without settling (lines 275-283).
+    to None and the evaluator abandons for immediate redelivery and returns Scheduled.
     """
     from unittest.mock import patch
 

--- a/tests/evaluators/test_task_graphs.py
+++ b/tests/evaluators/test_task_graphs.py
@@ -535,9 +535,10 @@ async def test_graph_workflow_exception_handling(evaluator_context):
 
     assert evaluator_context.mock_storage.load_graph.call_count == _LOAD_GRAPH_RETRY_POLICY.max_tries
 
-    # Message must NOT be settled — suppress settlement to allow Service Bus redelivery
-    assert len(evaluator_context.mockservicebus._receiver.method_calls) == 0, (
-        "Message should NOT be settled when load_graph raises (transient error path)"
+    # Message must be abandoned (not completed/deadlettered) — allow immediate redelivery
+    evaluator_context.mockservicebus._receiver.abandon_message.assert_called_once()
+    assert not evaluator_context.mockservicebus._receiver.complete_message.called, (
+        "Message should NOT be completed when load_graph raises (transient error path)"
     )
 
 
@@ -845,9 +846,10 @@ async def test_load_graph_storage_error_no_settlement(evaluator_context, mock_st
     # load_graph was retried the configured number of times
     assert mock_storage.load_graph.call_count == _LOAD_GRAPH_RETRY_POLICY.max_tries
 
-    # Message must NOT be settled — allow Service Bus redelivery
-    assert len(evaluator_context.mockservicebus._receiver.method_calls) == 0, (
-        "Message must not be settled when load_graph raises a transient error"
+    # Message must be abandoned (not completed/deadlettered) — allow immediate redelivery
+    evaluator_context.mockservicebus._receiver.abandon_message.assert_called_once()
+    assert not evaluator_context.mockservicebus._receiver.complete_message.called, (
+        "Message must not be completed when load_graph raises a transient error"
     )
 
     # No downstream tasks must be published
@@ -920,9 +922,10 @@ async def test_non404_storage_error_retried_raises_continue_graph_error_no_settl
         f"Expected {_LOAD_GRAPH_RETRY_POLICY.max_tries} load_graph attempts, got {mock_storage.load_graph.call_count}"
     )
 
-    # Message must NOT be settled — Service Bus should redeliver
-    assert len(evaluator_context.mockservicebus._receiver.method_calls) == 0, (
-        "Message must not be settled when load_graph raises a transient 503 error"
+    # Message must be abandoned (not completed/deadlettered) — allow immediate redelivery
+    evaluator_context.mockservicebus._receiver.abandon_message.assert_called_once()
+    assert not evaluator_context.mockservicebus._receiver.complete_message.called, (
+        "Message must not be completed when load_graph raises a transient 503 error"
     )
 
     # No downstream tasks published
@@ -1033,9 +1036,10 @@ async def test_validation_error_in_load_graph_raises_continue_graph_error(evalua
         f"Expected {_LOAD_GRAPH_RETRY_POLICY.max_tries} load_graph attempts, got {mock_storage.load_graph.call_count}"
     )
 
-    # Message must NOT be settled — allow Service Bus redelivery
-    assert len(evaluator_context.mockservicebus._receiver.method_calls) == 0, (
-        "Message must not be settled when load_graph raises (wrapping ValidationError)"
+    # Message must be abandoned (not completed/deadlettered) — allow immediate redelivery
+    evaluator_context.mockservicebus._receiver.abandon_message.assert_called_once()
+    assert not evaluator_context.mockservicebus._receiver.complete_message.called, (
+        "Message must not be completed when load_graph raises (wrapping ValidationError)"
     )
 
     # No downstream tasks must be published
@@ -2135,13 +2139,14 @@ async def test_412_scheduled_retry_second_412_sees_unclaimed_does_not_settle(
     mock_eval_task.assert_not_called()
 
     assert result is not None
-    assert result.status == TaskStatus.Failure, (
-        f"Expected Failure for unclaimed second re-read value {second_reread_value!r}, got {result.status}"
+    assert result.status == TaskStatus.Scheduled, (
+        f"Expected Scheduled for unclaimed second re-read value {second_reread_value!r}, got {result.status}"
     )
 
+    evaluator_context.mockservicebus._receiver.abandon_message.assert_called_once()
     assert not evaluator_context.mockservicebus._receiver.complete_message.called, (
         "complete_message must NOT be called for unclaimed second re-read status — "
-        "let SB redeliver rather than permanently stalling the graph"
+        "abandon for immediate redelivery rather than letting the lock expire"
     )
 
 
@@ -2565,7 +2570,8 @@ async def test_412_started_write_reread_also_fails_returns_failure(evaluator_con
         result = await evaluator_context.evaluator()
 
     mock_eval_task.assert_not_called()
-    assert result.status == TaskStatus.Failure
+    assert result.status == TaskStatus.Scheduled
+    evaluator_context.mockservicebus._receiver.abandon_message.assert_called_once()
     assert not evaluator_context.mockservicebus._receiver.complete_message.called
 
 
@@ -2729,7 +2735,8 @@ async def test_second_412_reread_also_fails_returns_failure_no_settle(evaluator_
         result = await evaluator_context.evaluator()
 
     mock_eval_task.assert_not_called()
-    assert result.status == TaskStatus.Failure
+    assert result.status == TaskStatus.Scheduled
+    evaluator_context.mockservicebus._receiver.abandon_message.assert_called_once()
     assert not evaluator_context.mockservicebus._receiver.complete_message.called
 
 

--- a/tests/storage/test_blob_storage.py
+++ b/tests/storage/test_blob_storage.py
@@ -1079,3 +1079,323 @@ class TestFindBlobsByTags:
             results.append(blob)
 
         assert results == []
+
+
+# ---------------------------------------------------------------------------
+# load_graph: AzureBlobError from list_blobs (line 139)
+# ---------------------------------------------------------------------------
+
+
+async def test_load_graph_azure_blob_error_from_list_blobs_raises_storage_error(
+    mock_azureblob,
+    blob_storage,
+    sample_task_graph,
+):
+    """AzureBlobError raised by list_blobs (after graph.json downloads) must be
+    wrapped as BoilermakerStorageError, same as HttpResponseError."""
+    graph_json = sample_task_graph.model_dump_json()
+    _, _, set_return = mock_azureblob
+    set_return.download_blob_returns(graph_json)
+    azure_error = AzureBlobError(
+        MagicMock(message="Service Unavailable", status_code=503, reason="Service Unavailable")
+    )
+    set_return.list_blobs_returns(azure_error)
+
+    with pytest.raises(BoilermakerStorageError) as exc_info:
+        await blob_storage.load_graph(sample_task_graph.graph_id)
+
+    assert "Failed to list blobs" in str(exc_info.value)
+    assert exc_info.value.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# release_lease: AzureBlobError is logged, not raised (lines 219-227)
+# ---------------------------------------------------------------------------
+
+
+async def test_release_lease_warns_and_does_not_raise_on_azure_blob_error(blob_storage, caplog):
+    """release_lease must log a warning and swallow AzureBlobError — the lease
+    will auto-expire and a raised exception would break the finally block in
+    _lease_publish_schedule."""
+    import logging
+    from contextlib import asynccontextmanager
+
+    error = AzureBlobError(MagicMock(status_code=409, reason="Conflict"))
+
+    @asynccontextmanager
+    async def _fake_client(_fname):
+        yield MagicMock()
+
+    with (
+        patch.object(blob_storage, "get_blob_client", _fake_client),
+        patch("boilermaker.storage.blob_storage.BlobLeaseClient") as mock_blc,
+    ):
+        mock_lease = AsyncMock()
+        mock_lease.release.side_effect = error
+        mock_blc.return_value = mock_lease
+
+        with caplog.at_level(logging.WARNING, logger="boilermaker.storage.blob_storage"):
+            await blob_storage.release_lease("task-1", "graph-1", "lease-id")
+
+    assert any("Failed to release lease" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# load_task_result: non-404 error must re-raise (lines 315-318)
+# ---------------------------------------------------------------------------
+
+
+async def test_load_task_result_returns_none_on_404(blob_storage):
+    """load_task_result must return None when the blob is not found (404).
+    This is the 'not yet written' case used by the idempotency guard."""
+    error = BoilermakerStorageError("not found", status_code=404, reason="Not Found")
+    with patch.object(blob_storage, "_download_result_with_limiter", new_callable=AsyncMock) as mock_dl:
+        mock_dl.side_effect = error
+        result = await blob_storage.load_task_result("task-1", GraphId("graph-1"))
+
+    assert result is None
+
+
+async def test_load_task_result_non_404_storage_error_reraises(blob_storage):
+    """load_task_result must re-raise BoilermakerStorageError for non-404 errors.
+    Only 404 is absorbed as 'not found'; other codes indicate transient failures."""
+    error = BoilermakerStorageError(
+        "Service unavailable",
+        task_id=None,
+        graph_id=None,
+        status_code=503,
+        reason="Service Unavailable",
+    )
+    with patch.object(blob_storage, "_download_result_with_limiter", new_callable=AsyncMock) as mock_dl:
+        mock_dl.side_effect = error
+        with pytest.raises(BoilermakerStorageError) as exc_info:
+            await blob_storage.load_task_result("task-1", GraphId("graph-1"))
+
+    assert exc_info.value.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# load_graph_slim_from_tags: various error paths
+# ---------------------------------------------------------------------------
+
+
+async def test_load_graph_slim_from_tags_empty_graph_id_raises_value_error(blob_storage):
+    """Empty graph_id must raise ValueError before touching storage."""
+    with pytest.raises(ValueError, match="`graph_id` must be provided"):
+        await blob_storage.load_graph_slim_from_tags(GraphId(""))
+
+
+async def test_load_graph_slim_from_tags_azure_blob_error_on_download_raises_storage_error(blob_storage):
+    """AzureBlobError from download_blob in load_graph_slim_from_tags must be wrapped
+    as BoilermakerStorageError."""
+    error = AzureBlobError(MagicMock(message="Not found", status_code=404, reason="Not found"))
+    with patch.object(blob_storage, "download_blob", new_callable=AsyncMock) as mock_dl:
+        mock_dl.side_effect = error
+        with pytest.raises(BoilermakerStorageError) as exc_info:
+            await blob_storage.load_graph_slim_from_tags(GraphId("some-graph"))
+
+    assert "Failed to load TaskGraph" in str(exc_info.value)
+    assert exc_info.value.status_code == 404
+
+
+async def test_load_graph_slim_from_tags_returns_none_when_graph_not_found(blob_storage):
+    """load_graph_slim_from_tags returns None when download_blob returns None."""
+    with patch.object(blob_storage, "download_blob", new_callable=AsyncMock) as mock_dl:
+        mock_dl.return_value = None
+        result = await blob_storage.load_graph_slim_from_tags(GraphId("some-graph"))
+
+    assert result is None
+
+
+async def test_load_graph_slim_from_tags_validation_error_wrapped_as_storage_error(blob_storage):
+    """ValidationError from model_validate_json on the graph blob must be wrapped
+    as BoilermakerStorageError in load_graph_slim_from_tags."""
+    from pydantic import ValidationError
+
+    with (
+        patch.object(blob_storage, "download_blob", new_callable=AsyncMock) as mock_dl,
+        patch(
+            "boilermaker.storage.blob_storage.TaskGraph.model_validate_json",
+            side_effect=ValidationError.from_exception_data("TaskGraph", [], input_type="json"),
+        ),
+    ):
+        mock_dl.return_value = '{"corrupt": "data"}'
+        with pytest.raises(BoilermakerStorageError) as exc_info:
+            await blob_storage.load_graph_slim_from_tags(GraphId("some-graph"))
+
+    assert "Failed to deserialize graph" in str(exc_info.value)
+
+
+async def test_load_graph_slim_from_tags_skips_graph_json_blob_in_listing(
+    mock_azureblob, blob_storage, sample_task_graph, sample_task
+):
+    """The graph.json blob must be skipped during listing — it must not be parsed
+    as a TaskResultSlim."""
+    sample_task_graph.add_task(sample_task)
+    graph_json = sample_task_graph.model_dump_json()
+    _, _, set_return = mock_azureblob
+
+    set_return.download_blob_returns(graph_json)
+
+    graph_path = f"task-results/{sample_task_graph.storage_path}"
+    # Include the graph.json blob in the listing — it should be skipped
+    set_return.list_blobs_returns([_tagged_blob(graph_path, str(sample_task_graph.graph_id), "success")])
+
+    result = await blob_storage.load_graph_slim_from_tags(sample_task_graph.graph_id)
+
+    assert result is not None
+    # graph.json was skipped — no task results loaded
+    assert len(result.results) == 0
+
+
+async def test_load_graph_slim_from_tags_warns_on_wrong_graph_id_in_tag_path(
+    mock_azureblob, blob_storage, sample_task_graph, sample_task, caplog
+):
+    """A blob whose 'graph_id' tag doesn't match the loaded graph_id must be
+    excluded from results with a warning — not silently dropped."""
+    import logging
+
+    sample_task_graph.add_task(sample_task)
+    graph_json = sample_task_graph.model_dump_json()
+    _, _, set_return = mock_azureblob
+    set_return.download_blob_returns(graph_json)
+
+    blob_name = f"task-results/{sample_task_graph.graph_id}/{sample_task.task_id}.json"
+    # Use a different graph_id in the tag
+    wrong_graph_id = "wrong-graph-id"
+    set_return.list_blobs_returns([_tagged_blob(blob_name, wrong_graph_id, "success")])
+
+    with caplog.at_level(logging.WARNING, logger="boilermaker.storage.blob_storage"):
+        result = await blob_storage.load_graph_slim_from_tags(sample_task_graph.graph_id)
+
+    assert result is not None
+    assert sample_task.task_id not in result.results
+    assert any("wrong graph_id" in r.message for r in caplog.records)
+
+
+async def test_load_graph_slim_from_tags_azure_blob_error_from_list_blobs_raises_storage_error(
+    mock_azureblob, blob_storage, sample_task_graph
+):
+    """AzureBlobError raised by list_blobs in load_graph_slim_from_tags must be
+    wrapped as BoilermakerStorageError."""
+    graph_json = sample_task_graph.model_dump_json()
+    _, _, set_return = mock_azureblob
+    set_return.download_blob_returns(graph_json)
+    azure_error = AzureBlobError(
+        MagicMock(message="Service Unavailable", status_code=503, reason="Service Unavailable")
+    )
+    set_return.list_blobs_returns(azure_error)
+
+    with pytest.raises(BoilermakerStorageError) as exc_info:
+        await blob_storage.load_graph_slim_from_tags(sample_task_graph.graph_id)
+
+    assert "Failed to list blobs" in str(exc_info.value)
+    assert exc_info.value.status_code == 503
+
+
+async def test_load_graph_slim_from_tags_http_response_error_from_list_blobs_raises_storage_error(
+    mock_azureblob, blob_storage, sample_task_graph
+):
+    """HttpResponseError raised by list_blobs in load_graph_slim_from_tags must be
+    wrapped as BoilermakerStorageError."""
+    from azure.core.exceptions import HttpResponseError
+
+    graph_json = sample_task_graph.model_dump_json()
+    _, _, set_return = mock_azureblob
+    set_return.download_blob_returns(graph_json)
+    set_return.list_blobs_returns(HttpResponseError(message="Auth failure", response=None))
+
+    with pytest.raises(BoilermakerStorageError) as exc_info:
+        await blob_storage.load_graph_slim_from_tags(sample_task_graph.graph_id)
+
+    assert "Failed to list blobs" in str(exc_info.value)
+
+
+async def test_load_graph_slim_from_tags_warns_on_wrong_graph_id_in_fallback_download(
+    mock_azureblob, blob_storage, sample_task_graph, sample_task, caplog
+):
+    """When a blob has no status tag and the fallback download returns a TaskResultSlim
+    with a mismatched graph_id, a warning must be logged and the result excluded."""
+    import logging
+
+    sample_task_graph.add_task(sample_task)
+    slim_result = TaskResultSlim(
+        task_id=sample_task.task_id,
+        graph_id=GraphId("completely-different-graph"),
+        status=TaskStatus.Success,
+    )
+    graph_json = sample_task_graph.model_dump_json()
+    task_result_json = slim_result.model_dump_json()
+    _, _, set_return = mock_azureblob
+    set_return.download_blob_returns(None, side_effect=[graph_json, task_result_json])
+
+    blob = mock.MagicMock()
+    blob.name = f"task-results/{sample_task_graph.graph_id}/{sample_task.task_id}.json"
+    blob.etag = "etag-x"
+    blob.tags = None  # no status tag → triggers fallback download
+    set_return.list_blobs_returns([blob])
+
+    with caplog.at_level(logging.WARNING, logger="boilermaker.storage.blob_storage"):
+        result = await blob_storage.load_graph_slim_from_tags(sample_task_graph.graph_id)
+
+    assert result is not None
+    assert sample_task.task_id not in result.results
+    assert any("wrong graph_id" in r.message for r in caplog.records)
+
+
+async def test_load_graph_slim_from_tags_storage_error_from_fallback_download_propagates(
+    mock_azureblob, blob_storage, sample_task_graph, sample_task
+):
+    """BoilermakerStorageError raised by _download_result_with_limiter inside the
+    task group must be unwrapped from the ExceptionGroup and re-raised (lines 413-414)."""
+    sample_task_graph.add_task(sample_task)
+    graph_json = sample_task_graph.model_dump_json()
+    _, _, set_return = mock_azureblob
+    set_return.download_blob_returns(graph_json)
+
+    storage_error = BoilermakerStorageError("blob download failed", status_code=503, reason="Error")
+
+    blob = mock.MagicMock()
+    blob.name = f"task-results/{sample_task_graph.graph_id}/{sample_task.task_id}.json"
+    blob.etag = "etag-x"
+    blob.tags = None  # no status tag → enters blob_names_to_download list
+    set_return.list_blobs_returns([blob])
+
+    # Patch _download_result_with_limiter to raise inside the task group — this
+    # ensures the exception goes through anyio's ExceptionGroup machinery and
+    # exercises the except* handler at lines 413-414.
+    with patch.object(
+        blob_storage,
+        "_download_result_with_limiter",
+        new_callable=AsyncMock,
+        side_effect=storage_error,
+    ):
+        with pytest.raises(BoilermakerStorageError) as exc_info:
+            await blob_storage.load_graph_slim_from_tags(sample_task_graph.graph_id)
+
+    assert exc_info.value.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# delete_blobs_batch: result-count mismatch warning (line 488)
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_blobs_batch_warns_when_result_count_mismatches(
+    mock_azureblob, blob_storage, caplog
+):
+    """When the batch delete response has fewer results than blobs submitted,
+    a warning must be logged about inaccurate failure attribution."""
+    import logging
+
+    container_client, _, _ = mock_azureblob
+    blob_names = ["blob-a", "blob-b", "blob-c"]
+    # Only return 2 results for 3 blobs
+    container_client.delete_blobs.return_value = _AsyncDeleteResults(
+        [_DeleteResult(202), _DeleteResult(202)]
+    )
+
+    with caplog.at_level(logging.WARNING, logger="boilermaker.storage.blob_storage"):
+        await blob_storage.delete_blobs_batch(blob_names)
+
+    assert any("inaccurate" in r.message for r in caplog.records)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1297,3 +1297,277 @@ class TestPurgeAllGraphsRouting:
 
         mock_eligible.assert_called_once()
         mock_all.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _validate_global_required_options (cli/__init__.py lines 162-168)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateGlobalRequiredOptions:
+    from boilermaker.cli import _validate_global_required_options
+
+    def test_missing_storage_url_calls_parser_error(self):
+        from boilermaker.cli import _validate_global_required_options
+
+        parser = build_parser()
+        args = parser.parse_args(["inspect", "--graph", "g"])
+        args.storage_url = None
+        args.container = "my-container"
+        with pytest.raises(SystemExit):
+            _validate_global_required_options(args, parser)
+
+    def test_missing_container_calls_parser_error(self):
+        from boilermaker.cli import _validate_global_required_options
+
+        parser = build_parser()
+        args = parser.parse_args(["inspect", "--graph", "g"])
+        args.storage_url = "https://x.blob.core.windows.net"
+        args.container = None
+        with pytest.raises(SystemExit):
+            _validate_global_required_options(args, parser)
+
+    def test_both_missing_calls_parser_error(self):
+        from boilermaker.cli import _validate_global_required_options
+
+        parser = build_parser()
+        args = parser.parse_args(["inspect", "--graph", "g"])
+        args.storage_url = None
+        args.container = None
+        with pytest.raises(SystemExit):
+            _validate_global_required_options(args, parser)
+
+    def test_both_present_does_not_raise(self):
+        from boilermaker.cli import _validate_global_required_options
+
+        parser = build_parser()
+        args = parser.parse_args(["inspect", "--graph", "g"])
+        args.storage_url = "https://x.blob.core.windows.net"
+        args.container = "c"
+        _validate_global_required_options(args, parser)  # no exception
+
+
+# ---------------------------------------------------------------------------
+# _validate_inspect_args: --visual requires --graph (cli/__init__.py line 179)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateInspectArgs:
+    def test_visual_without_graph_calls_parser_error(self):
+        from boilermaker.cli import _validate_inspect_args
+
+        parser = build_parser()
+        args = parser.parse_args(["inspect"])
+        args.graph = None
+        args.task = None
+        args.json = False
+        args.visual = True
+        with pytest.raises(SystemExit):
+            _validate_inspect_args(args, parser)
+
+    def test_visual_with_json_calls_parser_error(self):
+        from boilermaker.cli import _validate_inspect_args
+
+        parser = build_parser()
+        args = parser.parse_args(["inspect", "--graph", "g"])
+        args.json = True
+        args.visual = True
+        args.task = None
+        with pytest.raises(SystemExit):
+            _validate_inspect_args(args, parser)
+
+    def test_visual_with_task_calls_parser_error(self):
+        from boilermaker.cli import _validate_inspect_args
+
+        parser = build_parser()
+        args = parser.parse_args(["inspect", "--graph", "g"])
+        args.json = False
+        args.visual = True
+        args.task = "some-task-id"
+        with pytest.raises(SystemExit):
+            _validate_inspect_args(args, parser)
+
+
+# ---------------------------------------------------------------------------
+# run_recover: graph not found (cli/recover.py lines 46-47)
+# ---------------------------------------------------------------------------
+
+
+class TestRecoverGraphNotFound:
+    async def test_returns_error_when_graph_not_found(self, capsys):
+        storage = _mock_storage(graph=None)
+        code = await run_recover(
+            storage,
+            "missing-graph-id",
+            sb_namespace_url="https://test.servicebus.windows.net",
+            sb_queue_name="test-queue",
+        )
+        assert code == EXIT_ERROR
+        captured = capsys.readouterr()
+        assert "not found in storage" in captured.err
+
+    async def test_task_not_in_graph_is_skipped(self, capsys):
+        """If detect_stalled_tasks returns a task_id that isn't in children or
+        fail_children (defensive guard), it must be skipped with a message to stderr."""
+        from boilermaker.task.task_id import TaskId
+
+        graph, task_a, task_b, task_c = _make_graph_with_tasks()
+        _set_result(graph, task_a, TaskStatus.Success)
+        _set_result(graph, task_b, TaskStatus.Success)
+        _set_result(graph, task_c, TaskStatus.Success)
+
+        storage = _mock_storage(graph)
+        mock_sb = _mock_service_bus()
+
+        # Inject a phantom stalled task_id that doesn't exist in graph.children
+        phantom_id = TaskId("00000000-0000-0000-0000-phantom000001")
+        stalled = [(phantom_id, "phantom_fn", TaskStatus.Scheduled)]
+
+        with (
+            mock.patch("boilermaker.task.graph.TaskGraph.detect_stalled_tasks", return_value=stalled),
+            mock.patch("boilermaker.cli.recover.AzureServiceBus", return_value=mock_sb),
+        ):
+            code = await run_recover(
+                storage,
+                str(graph.graph_id),
+                sb_namespace_url="https://test.servicebus.windows.net",
+                sb_queue_name="test-queue",
+            )
+
+        assert code == EXIT_STALLED
+        captured = capsys.readouterr()
+        assert "SKIP" in captured.err
+        mock_sb.send_message.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _stream_all_graphs: early exit when current group is too recent (line 103)
+# ---------------------------------------------------------------------------
+
+
+class TestStreamAllGraphsEarlyExitOnRecentGroup:
+    def _make_storage(self, blobs):
+        storage = mock.AsyncMock()
+        storage.task_result_prefix = "task-results"
+        storage.list_blobs = lambda prefix: _async_gen(blobs)
+        return storage
+
+    async def test_early_exit_when_previous_group_is_too_recent(self):
+        """When flushing a group whose UUID7 timestamp >= cutoff, _stream_all_graphs
+        must return immediately (not yield it). This tests the `return` at line 103
+        inside the flush-previous-group branch."""
+        # new_uuid1 is just over the cutoff; new_uuid2 is even newer.
+        # When we transition from new_uuid1 to new_uuid2, we flush new_uuid1 and
+        # find it's >= cutoff → early exit, new_uuid1 is NOT yielded.
+        new_ts_ms = int(datetime.now(UTC).timestamp() * 1000)
+        new_uuid1 = _make_uuid7_str(new_ts_ms - 100)
+        new_uuid2 = _make_uuid7_str(new_ts_ms)
+
+        blobs = [
+            _make_blob(f"task-results/{new_uuid1}/graph.json", _new(0)),
+            _make_blob(f"task-results/{new_uuid2}/graph.json", _new(0)),
+        ]
+        storage = self._make_storage(blobs)
+        cutoff = datetime.now(UTC) - timedelta(days=7)
+
+        yielded = []
+        async for graph_id, _ in _stream_all_graphs(storage, cutoff):
+            yielded.append(graph_id)
+
+        assert yielded == []
+
+
+# ---------------------------------------------------------------------------
+# _stream_all_graphs: non-UUID7 in final flush (lines 119-125)
+# ---------------------------------------------------------------------------
+
+
+class TestStreamAllGraphsNonUuidFinalFlush:
+    def _make_storage(self, blobs):
+        storage = mock.AsyncMock()
+        storage.task_result_prefix = "task-results"
+        storage.list_blobs = lambda prefix: _async_gen(blobs)
+        return storage
+
+    async def test_non_uuid_final_group_is_skipped_with_warning(self, caplog):
+        """A non-UUID7 graph_id appearing as the LAST group (final flush after
+        the loop) must be skipped with a warning — not crash."""
+        import logging
+
+        # "zzz-not-a-uuid" sorts after all real UUID7 strings starting with "0"
+        blobs = [
+            _make_blob("task-results/zzz-not-a-uuid/graph.json", _old(10)),
+        ]
+        storage = self._make_storage(blobs)
+        cutoff = datetime.now(UTC) - timedelta(days=7)
+
+        with caplog.at_level(logging.WARNING, logger="boilermaker.cli"):
+            yielded = []
+            async for graph_id, _ in _stream_all_graphs(storage, cutoff):
+                yielded.append(graph_id)
+
+        assert yielded == []
+        assert any("zzz-not-a-uuid" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# run_purge: BoilermakerStorageError from load_graph (lines 214-216)
+# run_purge: graph is None from load_graph (lines 219-220)
+# run_purge: force=True with in-progress graphs (line 236)
+# ---------------------------------------------------------------------------
+
+
+class TestPurgeLoadGraphEdgeCases:
+    def _make_graph_blob(self, graph_id: str) -> mock.MagicMock:
+        return _make_blob(f"task-results/{graph_id}/graph.json", _old(10))
+
+    async def test_load_graph_storage_error_skips_graph(self, capsys):
+        """BoilermakerStorageError from load_graph must skip that graph with a
+        SKIP message to stderr and continue processing others."""
+        from boilermaker.exc import BoilermakerStorageError
+
+        graph_id = "019d8c0c-bd9b-7c23-be84-4d0799d7ecd5"
+        blobs = [self._make_graph_blob(graph_id)]
+        storage = _make_purge_storage(blob_list=blobs)
+        storage.load_graph = mock.AsyncMock(
+            side_effect=BoilermakerStorageError(
+                "load failed", status_code=503, reason="Service Unavailable"
+            )
+        )
+
+        code = await run_purge(storage, older_than_days=7)
+        assert code == EXIT_HEALTHY
+        captured = capsys.readouterr()
+        assert "SKIP" in captured.err
+        assert "failed to load graph" in captured.err
+
+    async def test_load_graph_returns_none_skips_graph(self, capsys):
+        """None returned by load_graph (graph.json missing or unreadable) must
+        skip that graph with a SKIP message to stderr."""
+        graph_id = "019d8c0c-bd9b-7c23-be84-4d0799d7ecd6"
+        blobs = [self._make_graph_blob(graph_id)]
+        storage = _make_purge_storage(blob_list=blobs, graph=None)
+
+        code = await run_purge(storage, older_than_days=7)
+        assert code == EXIT_HEALTHY
+        captured = capsys.readouterr()
+        assert "SKIP" in captured.err
+
+    async def test_force_true_deletes_in_progress_graphs(self):
+        """With force=True, graphs with in-progress tasks must be added to the
+        eligible list and their blobs deleted."""
+        graph = TaskGraph()
+        task = Task.default("work")
+        graph.add_task(task)
+        _set_result(graph, task, TaskStatus.Started)
+        graph_id = str(graph.graph_id)
+
+        blobs = [
+            _make_blob(f"task-results/{graph_id}/graph.json", _old(10)),
+            _make_blob(f"task-results/{graph_id}/task-1.json", _old(10)),
+        ]
+        storage = _make_purge_storage(blob_list=blobs, graph=graph)
+
+        code = await run_purge(storage, older_than_days=7, force=True)
+        assert code == EXIT_HEALTHY
+        storage.delete_blobs_batch.assert_called()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,12 +8,11 @@ from unittest import mock
 import pytest
 from boilermaker.cli import build_parser
 from boilermaker.cli._globals import EXIT_ERROR, EXIT_HEALTHY, EXIT_STALLED
-from boilermaker.cli._output import _short_task_id, format_graph_table
+from boilermaker.cli._output import format_graph_table
 from boilermaker.cli.inspect import run_inspect
 from boilermaker.cli.purge import _stream_all_graphs, _stream_eligible_graphs, _validate_older_than, run_purge
 from boilermaker.cli.recover import run_recover
 from boilermaker.task import Task, TaskGraph, TaskResultSlim, TaskStatus
-from boilermaker.task.task_id import TaskId
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -48,21 +47,6 @@ def _mock_storage(graph: TaskGraph | None = None) -> mock.AsyncMock:
     storage.load_graph = mock.AsyncMock(return_value=graph)
     storage.load_graph_slim_from_tags = mock.AsyncMock(return_value=graph)
     return storage
-
-
-# ---------------------------------------------------------------------------
-# _short_task_id
-# ---------------------------------------------------------------------------
-
-
-class TestShortTaskId:
-    def test_truncates_long_id(self):
-        tid = TaskId("019750a3-bfac-7e3a-b4cd-4c3102c9f3f2")
-        assert _short_task_id(tid) == "4c3102c9f3f2"
-
-    def test_preserves_short_id(self):
-        tid = TaskId("abcd1234")
-        assert _short_task_id(tid) == "abcd1234"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_mermaid.py
+++ b/tests/test_cli_mermaid.py
@@ -6,13 +6,12 @@ import pytest
 from boilermaker.cli._mermaid import (
     _node_class,
     _sanitize_id,
-    _short_task_id,
     build_task_data_json,
     generate_mermaid,
 )
 from boilermaker.task import Task, TaskGraph, TaskStatus
 from boilermaker.task.result import TaskResult, TaskResultSlim
-from boilermaker.task.task_id import TaskId
+from boilermaker.task.task_id import TaskId, truncate_task_id
 
 
 # Helper to look up an entry in the dict-keyed task data JSON by function name.
@@ -72,21 +71,6 @@ class TestSanitizeId:
     def test_no_hyphens_unchanged(self):
         tid = TaskId("abcdef123")
         assert _sanitize_id(tid) == "abcdef123"
-
-
-# ---------------------------------------------------------------------------
-# TestShortTaskId
-# ---------------------------------------------------------------------------
-
-
-class TestShortTaskId:
-    def test_returns_last_12_chars(self):
-        tid = TaskId("0192f5e0-abcd-7def-8901-234567890abc")
-        assert _short_task_id(tid) == "234567890abc"
-
-    def test_short_id_returned_as_is(self):
-        tid = TaskId("short")
-        assert _short_task_id(tid) == "short"
 
 
 # ---------------------------------------------------------------------------
@@ -463,7 +447,7 @@ class TestTaskIdSanitization:
         assert "-" not in sanitized
         assert sanitized in mermaid
         # Last 12 chars of original ID are in the label
-        assert _short_task_id(a.task_id) in mermaid
+        assert truncate_task_id(a.task_id) in mermaid
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -3,14 +3,13 @@
 from io import StringIO
 
 from boilermaker.cli._output import (
-    _short_task_id,
     render_graph_summary,
     render_purge_plan,
     render_task_table,
     status_style,
 )
 from boilermaker.task import Task, TaskGraph, TaskResultSlim, TaskStatus
-from boilermaker.task.task_id import TaskId
+from boilermaker.task.task_id import truncate_task_id
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
@@ -48,21 +47,6 @@ def _render_to_str(renderable, width: int = 120) -> str:
     console = Console(file=buf, no_color=True, width=width)
     console.print(renderable)
     return buf.getvalue()
-
-
-# ---------------------------------------------------------------------------
-# TestShortTaskId
-# ---------------------------------------------------------------------------
-
-
-class TestShortTaskId:
-    def test_truncates_long_id(self):
-        tid = TaskId("019750a3-bfac-7e3a-b4cd-4c3102c9f3f2")
-        assert _short_task_id(tid) == "4c3102c9f3f2"
-
-    def test_preserves_short_id(self):
-        tid = TaskId("abcd1234")
-        assert _short_task_id(tid) == "abcd1234"
 
 
 # ---------------------------------------------------------------------------
@@ -260,7 +244,7 @@ class TestRenderTaskTable:
     def test_task_id_is_truncated_to_last_12_chars(self):
         graph, task_a, task_b, task_c = _make_graph_with_tasks()
         _set_result(graph, task_a, TaskStatus.Success)
-        short_id = _short_task_id(task_a.task_id)
+        short_id = truncate_task_id(task_a.task_id)
         output = _render_to_str(render_task_table(graph))
         assert short_id in output
 

--- a/uv.lock
+++ b/uv.lock
@@ -350,7 +350,7 @@ wheels = [
 
 [[package]]
 name = "boilermaker-servicebus"
-version = "1.2.1"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aio-azure-clients-toolbox" },


### PR DESCRIPTION
Azure ServiceBus will redeliver when a message lease has been lost. The lease timeout is typically 1m-5m. The latter (5m) is a long time to wait, though, in cases where we want to make progress on our graphs, but we are blocked by the etag+lease of another process.

Instead of waiting the full message lease timeout, we can immediately call `abandon_message` and this will signal to ServiceBus that the message should be _redelivered_. This is a useful efficiency boost when workers and schedulers are frequently overlapping. 

In addition, there's a UX-change here: we found that log messages that included a graph ID were very useful. We had a mixture of log messages in the task-graph evaluator: some included graph id, some had task id (and no graph id), some had function name (and not hte other two). Our goal here is to include all three pieces of information where possible so that our logs are a) consistently organized, and b) more useful!