### PR TITLE
TaskIds are Getting Duplicated  (always were)

### DIFF
--- a/boilermaker/app.py
+++ b/boilermaker/app.py
@@ -38,7 +38,7 @@ from .evaluators.task_graph import _MAX_DELIVERY_COUNT_FOR_ABANDON
 from .exc import BoilermakerAppException, BoilermakerStorageError
 from .retries import RetryPolicy
 from .storage import StorageInterface
-from .task import Task, TaskGraph, TaskId
+from .task import new_task_id, NullTaskId, Task, TaskGraph, TaskId
 
 tracer: trace.Tracer = trace.get_tracer(__name__)
 logger = logging.getLogger(__name__)
@@ -165,6 +165,7 @@ class Boilermaker:
 
         task = Task.default(fn_name, **options)
         self.function_registry[fn_name] = typing.cast(TaskHandler, fn)  # why must cast here
+        task.task_id = NullTaskId
         self.task_registry[fn_name] = task
         logger.info(f"Registered background function fn={fn_name}")
         return self
@@ -225,6 +226,7 @@ class Boilermaker:
         payload = {"args": args, "kwargs": kwargs}
         task_proto = self.task_registry[fn.__name__]
         task = copy.deepcopy(task_proto)
+        task.task_id = new_task_id()
         task.payload = payload
         if policy is not None:
             task.policy = policy
@@ -355,6 +357,13 @@ class Boilermaker:
             published = await app.publish_task(task, delay=60)  # 1 minute delay
             print(f"Published with sequence: {published.sequence_number}")
         """
+        if task.task_id == NullTaskId:
+            raise BoilermakerAppException(
+                "Refusing to publish task with NullTaskId — "
+                "this is a prototype task that was never assigned a unique ID",
+                [],
+            )
+
         encountered_errors = []
         for _i in range(publish_attempts):
             try:

--- a/boilermaker/evaluators/results_store.py
+++ b/boilermaker/evaluators/results_store.py
@@ -139,12 +139,13 @@ class ResultsStorageTaskEvaluator(TaskEvaluatorBase):
                 f"{result.errors} "
                 f"[attempt {self.task.attempts.attempts} of {self.task.policy.max_tries}] "
                 f"Publishing retry... {self.sequence_number=} "
-                f"<function={self.task.function_name}> with {delay=}"
+                f"<function={self.task.function_name}> with {delay=} {self.task.retry_task_id=}"
             )
             logger.warning(warn_msg)
             await self.publish_task(
                 self.task,
                 delay=delay,
+                unique_msg_id=self.task.retry_task_id,
             )
 
         # At-least once: settle at the end.

--- a/boilermaker/evaluators/simple.py
+++ b/boilermaker/evaluators/simple.py
@@ -119,12 +119,13 @@ class NoStorageEvaluator(TaskEvaluatorBase):
                 f"{result.errors} "
                 f"[attempt {self.task.attempts.attempts} of {self.task.policy.max_tries}] "
                 f"Publishing retry... {self.sequence_number=} "
-                f"<function={self.task.function_name}> with {delay=}"
+                f"<function={self.task.function_name}> with {delay=} {self.task.retry_task_id=}"
             )
             logger.warning(warn_msg)
             await self.publish_task(
                 self.task,
                 delay=delay,
+                unique_msg_id=self.task.retry_task_id,
             )
 
         # At-least once: settle at the end.

--- a/boilermaker/evaluators/task_graph.py
+++ b/boilermaker/evaluators/task_graph.py
@@ -554,18 +554,17 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
         elif result.status == TaskStatus.Retry:
             # Retry requested: republish the same task with delay
             delay = self.task.get_next_delay()
-            retry_msg_id = f"{self.task.task_id}:{self.task.attempts.attempts}"
             warn_msg = (
                 f"{_graph_tag} [{result.errors}] {_task_tag} "
                 f"[attempt {self.task.attempts.attempts} of {self.task.policy.max_tries}] "
                 f"Publishing retry... {self.sequence_number=} "
-                f"<function={self.task.function_name}> with {delay=} {retry_msg_id=}"
+                f"<function={self.task.function_name}> with {delay=} {self.task.retry_task_id=}"
             )
             logger.warning(warn_msg)
             await self.publish_task(
                 self.task,
                 delay=delay,
-                unique_msg_id=retry_msg_id,
+                unique_msg_id=self.task.retry_task_id,
             )
 
         # At-least once: settle at the end.

--- a/boilermaker/task/__init__.py
+++ b/boilermaker/task/__init__.py
@@ -1,7 +1,7 @@
 from .graph import LAST_ADDED, LastAddedSingleton, TaskChain, TaskGraph, TaskGraphBuilder
 from .result import TaskResult, TaskResultSlim, TaskStatus
 from .task import Task
-from .task_id import GraphId, TaskId
+from .task_id import GraphId, new_task_id, NullTaskId, TaskId
 from .types import TaskHandler
 
 __all__ = [
@@ -16,5 +16,7 @@ __all__ = [
     "Task",
     "TaskId",
     "GraphId",
+    "NullTaskId",
+    "new_task_id",
     "TaskHandler",
 ]

--- a/boilermaker/task/task.py
+++ b/boilermaker/task/task.py
@@ -262,6 +262,19 @@ class Task(BaseModel):
         other.on_success = self
         return self
 
+    @property
+    def retry_task_id(self) -> str:
+        """Generate a unique identifier for retry attempts.
+
+        Combines the task ID with the current attempt count to create
+        a unique identifier for each retry attempt. This is useful for
+        tracking and logging retries.
+
+        Returns:
+            str: A unique identifier for the current retry attempt
+        """
+        return f"{self.task_id}:{self.attempts.attempts}"
+
     @classmethod
     def si(
         cls,

--- a/boilermaker/task/task_id.py
+++ b/boilermaker/task/task_id.py
@@ -7,11 +7,18 @@ TaskId = typing.NewType("TaskId", str)
 GraphId = typing.NewType("GraphId", str)
 
 
+NullTaskId = TaskId("00000000-0000-0000-0000-000000000000")
+
+
 def truncate_task_id(task_id: TaskId, limit: int = 12) -> str:
     full = str(task_id)
     trunc = full[-limit:] if len(full) > limit else full
     return f"...{trunc}"
 
 
+def new_task_id() -> TaskId:
+    return TaskId(str(uuid.uuid7()))
+
+
 def ident_field():
-    return Field(default_factory=lambda: TaskId(str(uuid.uuid7())))
+    return Field(default_factory=new_task_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boilermaker-servicebus"
-version = "1.3.0"
+version = "1.3.1"
 description = "An async python Background task system using Azure Service Bus Queues"
 authors = [{ "name" = "Erik Aker", "email" = "eaker@mulliganfunding.com" }]
 license = { file = "LICENSE" }

--- a/tests/evaluators/test_results_store.py
+++ b/tests/evaluators/test_results_store.py
@@ -302,6 +302,43 @@ async def test_retry_policy_update_with_storage(acks_late, store_evaluator_conte
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Fix F0: Retry publish uses differentiated message_id
+# # # # # # # # # # # # # # # # # # # # # # # # # # #
+async def test_retry_publish_uses_differentiated_message_id(store_evaluator_context):
+    """Retry publishes must use message_id '{task_id}:{attempt_number}' so that
+    Azure Service Bus duplicate detection does not silently drop retry messages.
+
+    The original publish uses bare task_id as message_id. A retry for the same
+    task_id would be deduped without a differentiated ID.
+    """
+
+    async def retrytask(state):
+        raise retries.RetryException("Retry me")
+
+    store_evaluator_context.app.register_async(retrytask, policy=retries.RetryPolicy.default())
+    task = store_evaluator_context.app.create_task(retrytask)
+    store_evaluator_context.current_task = task
+
+    async with store_evaluator_context.with_regular_assertions(
+        compare_result=None,
+        compare_status=TaskStatus.Retry,
+        check_graph_loaded=False,
+    ) as ctx:
+        ctx.assert_messages_scheduled(1)
+        scheduled = ctx.get_scheduled_messages()
+        retry_msg = scheduled[0]
+        task = retry_msg.task
+        kwargs = retry_msg.kwargs
+
+        expected_msg_id = f"{task.task_id}:{task.attempts.attempts}"
+        actual_msg_id = kwargs.get("unique_msg_id")
+        assert actual_msg_id == expected_msg_id, (
+            f"Retry publish must use differentiated message_id. "
+            f"Expected '{expected_msg_id}', got '{actual_msg_id}'"
+        )
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Exception Handling Coverage Tests
 # # # # # # # # # # # # # # # # # # # # # # # # # # #
 @pytest.mark.parametrize("acks_late", [True, False])

--- a/tests/evaluators/test_simple.py
+++ b/tests/evaluators/test_simple.py
@@ -383,6 +383,44 @@ async def test_task_retries_acks_late(
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Fix F0: Retry publish uses differentiated message_id
+# # # # # # # # # # # # # # # # # # # # # # # # # # #
+async def test_retry_publish_uses_differentiated_message_id(app, mockservicebus, make_message):
+    """Retry publishes must use message_id '{task_id}:{attempt_number}' so that
+    Azure Service Bus duplicate detection does not silently drop retry messages.
+
+    The original publish uses bare task_id as message_id. A retry for the same
+    task_id would be deduped without a differentiated ID.
+    """
+    published = []
+
+    async def mock_publisher(task, *args, **kwargs):
+        published.append((task, args, kwargs))
+
+    async def retrytask(state):
+        raise retries.RetryException("Retry me")
+
+    app.register_async(retrytask, policy=retries.RetryPolicy.default())
+    task = app.create_task(retrytask)
+    task.msg = make_message(task)
+
+    ev = NoStorageEvaluator(
+        mockservicebus._receiver, task, mock_publisher, app.function_registry, state=app.state
+    )
+    result = await ev.message_handler()
+    assert result.status == TaskStatus.Retry
+
+    assert len(published) == 1
+    retry_task, _, kwargs = published[0]
+    expected_msg_id = f"{retry_task.task_id}:{retry_task.attempts.attempts}"
+    actual_msg_id = kwargs.get("unique_msg_id")
+    assert actual_msg_id == expected_msg_id, (
+        f"Retry publish must use differentiated message_id. "
+        f"Expected '{expected_msg_id}', got '{actual_msg_id}'"
+    )
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # #
 # test task-handling with exceptions
 # # # # # # # # # # # # # # # # # # # # # # # # # # #
 @pytest.mark.parametrize("acks_late", [True, False])

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -16,7 +16,7 @@ from boilermaker import retries
 from boilermaker.app import Boilermaker, BoilermakerAppException
 from boilermaker.evaluators import NoStorageEvaluator
 from boilermaker.exc import BoilermakerStorageError
-from boilermaker.task import Task, TaskGraph
+from boilermaker.task import NullTaskId, Task, TaskGraph
 
 
 class State:
@@ -821,3 +821,85 @@ async def test_renew_message_lock_via_state_app(sbus, mockservicebus, make_messa
         "Boilermaker.message_handler to fix this."
     )
     mockservicebus._receiver.renew_message_lock.assert_awaited_once()
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # #
+# NullTaskId / duplicate task_id safety
+# # # # # # # # # # # # # # # # # # # # # # # # # # #
+async def test_task_proto_has_null_task_id(app):
+    """Registered task prototypes must carry NullTaskId, not a real UUID."""
+
+    async def somefunc(state):
+        return "ok"
+
+    app.register_async(somefunc)
+    proto = app.task_registry["somefunc"]
+    assert proto.task_id == NullTaskId, (
+        f"Task prototype should have NullTaskId but got {proto.task_id}"
+    )
+
+
+async def test_create_task_assigns_unique_id(app):
+    """Every call to create_task must produce a unique, non-null task_id."""
+
+    async def somefunc(state):
+        return "ok"
+
+    app.register_async(somefunc)
+    task1 = app.create_task(somefunc)
+    task2 = app.create_task(somefunc)
+
+    assert task1.task_id != NullTaskId
+    assert task2.task_id != NullTaskId
+    assert task1.task_id != task2.task_id, (
+        "Two tasks created from the same function must have different task_ids"
+    )
+
+
+async def test_publish_task_rejects_null_task_id(app, mockservicebus):
+    """publish_task must refuse to send a task that still carries NullTaskId."""
+
+    async def somefunc(state):
+        return "ok"
+
+    app.register_async(somefunc)
+    # Manually build a task with NullTaskId (simulating the old bug)
+    proto = app.task_registry["somefunc"]
+    import copy
+
+    bad_task = copy.deepcopy(proto)
+    # Don't assign a new task_id — it should still be NullTaskId
+    bad_task.payload = {"args": (), "kwargs": {}}
+
+    with pytest.raises(BoilermakerAppException, match="NullTaskId"):
+        await app.publish_task(bad_task)
+
+    # Nothing should have been sent
+    mockservicebus._sender.assert_not_called()
+
+
+async def test_apply_async_never_publishes_duplicate_ids(app, mockservicebus):
+    """Multiple apply_async calls for the same function must produce distinct message IDs."""
+
+    async def somefunc(state):
+        return "ok"
+
+    app.register_async(somefunc)
+    t1 = await app.apply_async(somefunc)
+    t2 = await app.apply_async(somefunc)
+    t3 = await app.apply_async(somefunc)
+
+    ids = {t1.task_id, t2.task_id, t3.task_id}
+    assert len(ids) == 3, f"Expected 3 unique task_ids, got {len(ids)}: {ids}"
+    assert NullTaskId not in ids
+
+    # Verify the unique_msg_id sent to ServiceBus is also unique per call
+    calls = mockservicebus._sender.method_calls
+    assert len(calls) == 3
+    msg_ids = set()
+    for call in calls:
+        # schedule_messages is the underlying method; extract the message body
+        published_task = Task.model_validate_json(str(call[1][0]))
+        msg_ids.add(published_task.task_id)
+    assert len(msg_ids) == 3
+    assert NullTaskId not in msg_ids

--- a/uv.lock
+++ b/uv.lock
@@ -350,7 +350,7 @@ wheels = [
 
 [[package]]
 name = "boilermaker-servicebus"
-version = "1.3.0"
+version = "1.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "aio-azure-clients-toolbox" },


### PR DESCRIPTION
This pull request makes it so that every task instance receives a unique TaskId and blcoks accidental reuse of prototype or null IDs. 

Previously _all_ Boilermaker tasks were published with the same TaskId: this didn't matter much until we started using the TaskId as the unique message ID for ServiceBus messages. The latter change means that ServiceBus with duplicate-detection enabled will not send those messages to subscribers. We added this to make TaskGraphs more safe: sometimes workers will race to publish the same tasks, and duplicate-detection **is** working for these because TaskGraphs are built with unique task-ids from the start (because they are typically using `Task.si(...)` instead of `Boilermaker.create_task(...)` would not have this issue in fact).

However, for _non_-TaskGraph work, _every_ instance of a background task will get rejected as a duplicate after the first. 

**Changes**

* Introduced `NullTaskId` as a sentinel value for uninitialized/prototype tasks, and a `new_task_id` function to generate unique task IDs using UUIDv7. 
* Updated task-proto registration to assign `NullTaskId` to task prototypes and ensured that every call to `create_task` assigns a fresh unique ID using `new_task_id`.
* Raise an exception if `publish_task` is called with a task still carrying `NullTaskId`, preventing accidental publication of prototype tasks. (`boilermaker/app.py`)

**Testing and Validation:**

* Added comprehensive tests to verify that:
  - Task prototypes always have `NullTaskId`
  - Created tasks always have unique, non-null IDs
  - Publishing a task with `NullTaskId` is rejected
  - Multiple async applications of the same function always produce distinct task IDs and message IDs (`tests/test_app.py`)

**Project Metadata:**

* Bumped the project version to `1.3.1` to reflect these changes. (`pyproject.toml`)