### PR TITLE
fix(task_graph): redeliver parent when a child dispatch fails (graph stall fix)

### DIFF
--- a/boilermaker/evaluators/task_graph.py
+++ b/boilermaker/evaluators/task_graph.py
@@ -1,4 +1,5 @@
 import asyncio
+import enum
 import itertools
 import logging
 import typing
@@ -13,6 +14,25 @@ from .common import TaskEvaluatorBase, TaskHandlerRegistry, TaskPublisher
 from .eval import eval_task
 
 logger = logging.getLogger("boilermaker.app")
+
+
+class _DispatchOutcome(enum.Enum):
+    """Result of attempting to dispatch one ready task in ``continue_graph``.
+
+    PUBLISHED: the task was published to Service Bus (counts toward ready_count).
+    SKIPPED:   the lease was not acquired because another worker holds it or the
+               blob was modified since load — another worker owns this dispatch,
+               so it is safe to do nothing here.
+    FAILED:    publishing genuinely failed (e.g. Service Bus unavailable, connection
+               pool exhausted) or the lease could not be checked due to a storage
+               error. The dispatch was lost. The parent message MUST NOT be settled,
+               so that Service Bus redelivers it and the dispatch is retried.
+    """
+
+    PUBLISHED = "published"
+    SKIPPED = "skipped"
+    FAILED = "failed"
+
 
 # Maximum SB delivery_count at which we actively abandon for fast redelivery.
 # Above this threshold we let the lock expire naturally to avoid burning through
@@ -675,7 +695,6 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
         # Sanity check: did we load the result that was *just* stored?
         loaded_task_status = graph.get_status(completed_task_result.task_id)
         if loaded_task_status != completed_task_result.status:
-
             logger.error(
                 f"[Graph(id={graph_id})] Task status mismatch: "
                 f"expected {completed_task_result.task_id} to be {completed_task_result.status}, "
@@ -686,19 +705,42 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                 f"expected {completed_task_result.status}, got {loaded_task_status}"
             )
 
-        # Find and publish newly ready tasks
+        # Find and publish newly ready tasks. We attempt every ready task (best
+        # effort) and only afterwards decide whether to suppress settlement, so a
+        # single transient publish failure does not strand the other ready tasks.
         ready_count = 0
+        dispatch_failed = False
         for ready_task in itertools.chain.from_iterable(
             (graph.generate_ready_tasks(), graph.generate_failure_ready_tasks())
         ):
-            if await self._lease_publish_schedule(ready_task, graph, graph_id):
+            outcome = await self._lease_publish_schedule(ready_task, graph, graph_id)
+            if outcome is _DispatchOutcome.PUBLISHED:
                 ready_count += 1
+            elif outcome is _DispatchOutcome.FAILED:
+                dispatch_failed = True
 
         # Dispatch the all_failed_callback if the graph has reached terminal-failed state.
         # This loop yields at most one task.
         for callback_task in graph.generate_all_failed_callback_task():
-            if await self._lease_publish_schedule(callback_task, graph, graph_id):
+            outcome = await self._lease_publish_schedule(callback_task, graph, graph_id)
+            if outcome is _DispatchOutcome.PUBLISHED:
                 ready_count += 1
+            elif outcome is _DispatchOutcome.FAILED:
+                dispatch_failed = True
+
+        # If any ready task could not be published, the dispatch was lost. We must
+        # NOT settle the parent message: raise so message_handler abandons it for
+        # redelivery (bounded by the queue's max_delivery_count). On redelivery the
+        # idempotent guard skips re-executing the already-finished parent and retries
+        # this dispatch; SB duplicate-detection suppresses re-publishing tasks that
+        # did succeed. Without this, a publish failure here (e.g. Service Bus
+        # connection-pool exhaustion) silently orphans the child task in Pending and
+        # permanently stalls the graph — no terminal state, no callbacks ever fire.
+        if dispatch_failed:
+            raise exc.ContinueGraphError(
+                f"[Graph(id={graph_id})] One or more ready tasks failed to publish; "
+                "suppressing settlement so the parent message is redelivered and the dispatch retried."
+            )
 
         if ready_count == 0:
             logger.debug(f"[Graph(id={graph_id})] No new tasks ready after task {completed_task_result.task_id}")
@@ -710,7 +752,7 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
         task: Task,
         graph: TaskGraph,
         graph_id: GraphId,
-    ) -> bool:
+    ) -> _DispatchOutcome:
         """Acquire a lease, publish a task to Service Bus, and write Scheduled status.
 
         Implements the four-step dispatch protocol used by ``continue_graph()``:
@@ -721,11 +763,15 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
         4. Release the lease (always, via ``finally``).
 
         If the lease cannot be acquired (another worker holds it, or the blob was
-        modified since ``load_graph``), the task is silently skipped — it will be
-        retried on redelivery.
+        modified since ``load_graph``), the task is silently skipped — another
+        worker owns the dispatch.
 
         Returns:
-            True if the task was successfully published, False otherwise.
+            ``_DispatchOutcome.PUBLISHED`` if the task was published to Service Bus,
+            ``_DispatchOutcome.SKIPPED`` if the lease was not acquired (another worker
+            owns it), or ``_DispatchOutcome.FAILED`` if publishing/lease-acquisition
+            genuinely failed. A FAILED outcome means the dispatch was lost and the
+            caller must suppress settlement of the parent so it is redelivered.
         """
         task_result_slim = graph.results.get(task.task_id)
         lease_id = None
@@ -738,15 +784,15 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
         except exc.BoilermakerStorageError:
             logger.warning(
                 f"[{graph}] try_acquire_lease raised unexpected error for task "
-                f"{task}; skipping — will be retried on redelivery.",
+                f"{task}; dispatch lost, parent will be redelivered to retry.",
                 exc_info=True,
             )
-            return False
+            return _DispatchOutcome.FAILED
         if lease_id is None:
             logger.debug(
                 f"[{graph}] Skipping task {task}: lease not acquired (another worker holds it or blob was modified)."
             )
-            return False
+            return _DispatchOutcome.SKIPPED
 
         try:
             # Publish task to SB (message_id = task_id for fan-in dedup).
@@ -764,22 +810,23 @@ class TaskGraphEvaluator(TaskEvaluatorBase):
                     f"[{graph}] Failed to write Scheduled for {task}. Task published to Service Bus. Error: {err}",
                     exc_info=True,
                 )
-                return True  # published successfully, blob write failed
+                return _DispatchOutcome.PUBLISHED  # published successfully, blob write failed
             except ValueError:
                 logger.error(
                     f"[{graph}] schedule_task raised ValueError for {task}. Task published; blob write skipped.",
                     exc_info=True,
                 )
-                return True  # published successfully, schedule_task rejected it
+                return _DispatchOutcome.PUBLISHED  # published successfully, schedule_task rejected it
 
-            return True
+            return _DispatchOutcome.PUBLISHED
 
         except Exception:
             logger.error(
-                f"[{graph}] Failed to publish {task}; remains Pending, will retry on redelivery.",
+                f"[{graph}] Failed to publish {task}; remains Pending. Parent will be "
+                "redelivered to retry the dispatch (settlement suppressed).",
                 exc_info=True,
             )
-            return False
+            return _DispatchOutcome.FAILED
         finally:
             if lease_id is not None:
                 await self.storage_interface.release_lease(task.task_id, graph_id, lease_id)

--- a/specs/TaskGraphSpecBase.tla
+++ b/specs/TaskGraphSpecBase.tla
@@ -141,13 +141,18 @@ VARIABLES
     workerReadySet,         \* workerReadySet[w]: set of task IDs
 
     \* The task currently being scheduled (lease acquired, publish pending / Scheduled pending)
-    workerCurrentReady      \* workerCurrentReady[w]: task ID or Nil
+    workerCurrentReady,     \* workerCurrentReady[w]: task ID or Nil
+
+    \* TRUE if any dispatch in the current continue_graph pass returned FAILED.
+    \* When TRUE at the end of the scheduling loop, the parent message MUST NOT
+    \* be settled — it is returned to SB for redelivery (ContinueGraphError).
+    workerDispatchFailed    \* workerDispatchFailed[w] \in BOOLEAN
 
 vars == <<blobStatus, blobEtag, blobLeased, blobDeadLettered, sbMessages,
           workerPhase, workerMsg, workerTask, workerResult,
           workerCapturedEtag,
           workerSnapshot, workerSnapshotEtags,
-          workerReadySet, workerCurrentReady>>
+          workerReadySet, workerCurrentReady, workerDispatchFailed>>
 
 \* ---------------------------------------------------------------------------
 \* Type invariant
@@ -173,6 +178,7 @@ TypeOK ==
     /\ \A w \in Workers : workerResult[w] \in {"Success", "Failure", Nil}
     /\ \A w \in Workers : workerCapturedEtag[w] \in Nat \cup {0}
     /\ \A w \in Workers : workerCurrentReady[w] \in Tasks \cup {Nil}
+    /\ workerDispatchFailed \in [Workers -> BOOLEAN]
 
 \* ---------------------------------------------------------------------------
 \* Initial state
@@ -199,6 +205,7 @@ Init ==
     /\ workerSnapshotEtags = [w \in Workers |-> [t \in Tasks |-> 0]]
     /\ workerReadySet = [w \in Workers |-> {}]
     /\ workerCurrentReady = [w \in Workers |-> Nil]
+    /\ workerDispatchFailed = [w \in Workers |-> FALSE]
 
 \* ---------------------------------------------------------------------------
 \* Helper: reset worker to Idle
@@ -214,6 +221,7 @@ WorkerReset(w) ==
     /\ workerSnapshotEtags' = [workerSnapshotEtags EXCEPT ![w] = [t \in Tasks |-> 0]]
     /\ workerReadySet' = [workerReadySet EXCEPT ![w] = {}]
     /\ workerCurrentReady' = [workerCurrentReady EXCEPT ![w] = Nil]
+    /\ workerDispatchFailed' = [workerDispatchFailed EXCEPT ![w] = FALSE]
 
 \* ---------------------------------------------------------------------------
 \* Actions
@@ -232,7 +240,7 @@ ReceiveMessage(w) ==
         /\ UNCHANGED <<blobStatus, blobEtag, blobLeased, blobDeadLettered, workerResult,
                         workerCapturedEtag,
                         workerSnapshot, workerSnapshotEtags,
-                        workerReadySet, workerCurrentReady>>
+                        workerReadySet, workerCurrentReady, workerDispatchFailed>>
 
 \* ===== ReadForIdempotency =====
 \* Worker reads the blob before writing Started.
@@ -254,20 +262,20 @@ ReadForIdempotency(w) ==
           /\ workerCapturedEtag' = [workerCapturedEtag EXCEPT ![w] = currentEtag]
           /\ UNCHANGED <<blobStatus, blobEtag, blobLeased, blobDeadLettered, sbMessages, workerMsg, workerTask,
                           workerSnapshot, workerSnapshotEtags,
-                          workerReadySet, workerCurrentReady>>
+                          workerReadySet, workerCurrentReady, workerDispatchFailed>>
        \/ \* Read succeeds and status is non-terminal: capture etag, proceed to Started write
           /\ currentStatus \notin TerminalStatuses
           /\ workerCapturedEtag' = [workerCapturedEtag EXCEPT ![w] = currentEtag]
           /\ workerPhase' = [workerPhase EXCEPT ![w] = "WroteStarted"]
           /\ UNCHANGED <<blobStatus, blobEtag, blobLeased, blobDeadLettered, sbMessages, workerMsg, workerTask,
                           workerResult, workerSnapshot, workerSnapshotEtags,
-                          workerReadySet, workerCurrentReady>>
+                          workerReadySet, workerCurrentReady, workerDispatchFailed>>
        \/ \* Read fails (transient): proceed with etag=0 (unconditional write, fail-open)
           /\ workerCapturedEtag' = [workerCapturedEtag EXCEPT ![w] = 0]
           /\ workerPhase' = [workerPhase EXCEPT ![w] = "WroteStarted"]
           /\ UNCHANGED <<blobStatus, blobEtag, blobLeased, blobDeadLettered, sbMessages, workerMsg, workerTask,
                           workerResult, workerSnapshot, workerSnapshotEtags,
-                          workerReadySet, workerCurrentReady>>
+                          workerReadySet, workerCurrentReady, workerDispatchFailed>>
 
 \* ===== WriteStarted =====
 \* Worker attempts to write Started with an ETag CAS.
@@ -294,7 +302,7 @@ WriteStartedSuccess(w) ==
        /\ UNCHANGED <<blobLeased, blobDeadLettered, sbMessages, workerMsg, workerTask, workerResult,
                        workerCapturedEtag,
                        workerSnapshot, workerSnapshotEtags,
-                       workerReadySet, workerCurrentReady>>
+                       workerReadySet, workerCurrentReady, workerDispatchFailed>>
 
 \* Sub-action: 412 — etag mismatch; re-read blob and branch
 \* We model the re-read as instantaneous (reading current blobStatus).
@@ -334,7 +342,7 @@ WriteStarted412(w) ==
              /\ UNCHANGED <<blobStatus, blobEtag, blobLeased, blobDeadLettered, sbMessages,
                              workerMsg, workerTask, workerResult, workerCapturedEtag,
                              workerSnapshot, workerSnapshotEtags,
-                             workerReadySet, workerCurrentReady>>
+                             workerReadySet, workerCurrentReady, workerDispatchFailed>>
           \/ \* Re-read is Scheduled or Pending: no worker owns Started yet —
              \* retry the Started write with the re-read etag.
              \* Pending:   Under corrected Azure semantics (lease acquire does NOT bump
@@ -349,7 +357,7 @@ WriteStarted412(w) ==
              /\ UNCHANGED <<blobStatus, blobEtag, blobLeased, blobDeadLettered, sbMessages,
                              workerMsg, workerTask, workerResult,
                              workerSnapshot, workerSnapshotEtags,
-                             workerReadySet, workerCurrentReady>>
+                             workerReadySet, workerCurrentReady, workerDispatchFailed>>
           \/ \* Re-read is some other non-terminal, non-Started, non-Scheduled, non-Pending status:
              \* always settle (complete message, return Failure)
              /\ rereadStatus \notin TerminalStatuses \cup {"Started", "Scheduled", "Pending"}
@@ -357,7 +365,7 @@ WriteStarted412(w) ==
              /\ UNCHANGED <<blobStatus, blobEtag, blobLeased, blobDeadLettered, sbMessages,
                              workerMsg, workerTask, workerResult, workerCapturedEtag,
                              workerSnapshot, workerSnapshotEtags,
-                             workerReadySet, workerCurrentReady>>
+                             workerReadySet, workerCurrentReady, workerDispatchFailed>>
 
 \* ===== RetryStartedWrite =====
 \* Worker retries the Started write using the etag captured from the re-read.
@@ -382,7 +390,7 @@ RetryStartedWriteSuccess(w) ==
        /\ UNCHANGED <<blobLeased, blobDeadLettered, sbMessages, workerMsg, workerTask, workerResult,
                        workerCapturedEtag,
                        workerSnapshot, workerSnapshotEtags,
-                       workerReadySet, workerCurrentReady>>
+                       workerReadySet, workerCurrentReady, workerDispatchFailed>>
 
 RetryStartedWrite412(w) ==
     /\ workerPhase[w] = "RetryStartedAfterScheduled"
@@ -395,7 +403,7 @@ RetryStartedWrite412(w) ==
        /\ UNCHANGED <<blobStatus, blobEtag, blobLeased, blobDeadLettered, sbMessages,
                        workerMsg, workerTask, workerResult, workerCapturedEtag,
                        workerSnapshot, workerSnapshotEtags,
-                       workerReadySet, workerCurrentReady>>
+                       workerReadySet, workerCurrentReady, workerDispatchFailed>>
 
 RetryStartedWriteNon412Error(w) ==
     /\ workerPhase[w] = "RetryStartedAfterScheduled"
@@ -404,7 +412,7 @@ RetryStartedWriteNon412Error(w) ==
     /\ UNCHANGED <<blobStatus, blobEtag, blobLeased, blobDeadLettered, sbMessages,
                     workerMsg, workerTask, workerResult, workerCapturedEtag,
                     workerSnapshot, workerSnapshotEtags,
-                    workerReadySet, workerCurrentReady>>
+                    workerReadySet, workerCurrentReady, workerDispatchFailed>>
 
 \* ===== RereadAfterRetry =====
 \* Worker got a second 412 on the retry. Re-reads the blob to determine action.
@@ -425,7 +433,7 @@ RereadAfterRetrySettle(w) ==
     /\ UNCHANGED <<blobStatus, blobEtag, blobLeased, blobDeadLettered, sbMessages,
                     workerMsg, workerTask, workerResult, workerCapturedEtag,
                     workerSnapshot, workerSnapshotEtags,
-                    workerReadySet, workerCurrentReady>>
+                    workerReadySet, workerCurrentReady, workerDispatchFailed>>
 
 \* No-settle variant: blob is unclaimed (Pending or Scheduled).
 \* Return the SB message to the queue and reset the worker, exactly like LockExpiry.
@@ -459,7 +467,7 @@ WriteStartedNon412Error(w) ==
        /\ UNCHANGED <<blobStatus, blobEtag, blobLeased, blobDeadLettered, sbMessages, workerMsg, workerTask,
                        workerResult, workerCapturedEtag,
                        workerSnapshot, workerSnapshotEtags,
-                       workerReadySet, workerCurrentReady>>
+                       workerReadySet, workerCurrentReady, workerDispatchFailed>>
 
 \* NOTE: Settlement is now conditional on blob state.
 \* RereadAfterRetrySettle leads to Completing (settle) when the blob is claimed/terminal.
@@ -476,7 +484,7 @@ ExecuteTask(w) ==
         /\ UNCHANGED <<blobStatus, blobEtag, blobLeased, blobDeadLettered, sbMessages, workerMsg, workerTask,
                         workerCapturedEtag,
                         workerSnapshot, workerSnapshotEtags,
-                        workerReadySet, workerCurrentReady>>
+                        workerReadySet, workerCurrentReady, workerDispatchFailed>>
 
 \* ===== WriteResult =====
 \* Worker writes the execution result to blob storage (unconditional overwrite).
@@ -496,7 +504,7 @@ WriteResult(w) ==
        /\ UNCHANGED <<blobLeased, blobDeadLettered, sbMessages, workerMsg, workerTask, workerResult,
                        workerCapturedEtag,
                        workerSnapshot, workerSnapshotEtags,
-                       workerReadySet, workerCurrentReady>>
+                       workerReadySet, workerCurrentReady, workerDispatchFailed>>
 
 \* ===== LoadGraph =====
 \* Worker reads all task statuses from blob storage.
@@ -509,7 +517,7 @@ LoadGraph(w) ==
     /\ workerPhase' = [workerPhase EXCEPT ![w] = "CheckingMismatch"]
     /\ UNCHANGED <<blobStatus, blobEtag, blobLeased, blobDeadLettered, sbMessages, workerMsg, workerTask,
                     workerResult, workerCapturedEtag,
-                    workerReadySet, workerCurrentReady>>
+                    workerReadySet, workerCurrentReady, workerDispatchFailed>>
 
 \* ===== StatusMismatchCheck =====
 \* Verify that the loaded status for the completed task matches the written result.
@@ -531,6 +539,8 @@ StatusMismatchCheck(w) ==
              /\ workerReadySet' = [workerReadySet EXCEPT ![w] = readySet]
              /\ workerPhase' = [workerPhase EXCEPT ![w] = "AcquiringLease"]
              /\ workerCurrentReady' = [workerCurrentReady EXCEPT ![w] = Nil]
+             \* Initialize dispatch_failed to FALSE at the start of the scheduling loop
+             /\ workerDispatchFailed' = [workerDispatchFailed EXCEPT ![w] = FALSE]
           /\ UNCHANGED <<blobStatus, blobEtag, blobLeased, blobDeadLettered, sbMessages, workerMsg, workerTask,
                           workerResult, workerCapturedEtag,
                           workerSnapshot, workerSnapshotEtags>>
@@ -585,7 +595,7 @@ AcquireLeaseSuccess(w) ==
         /\ workerPhase' = [workerPhase EXCEPT ![w] = "PublishingTask"]
         /\ UNCHANGED <<blobStatus, blobEtag, blobDeadLettered, sbMessages, workerMsg, workerTask,
                         workerResult, workerCapturedEtag,
-                        workerSnapshot, workerSnapshotEtags>>
+                        workerSnapshot, workerSnapshotEtags, workerDispatchFailed>>
 
 AcquireLeaseFail(w) ==
     /\ workerPhase[w] = "AcquiringLease"
@@ -597,18 +607,64 @@ AcquireLeaseFail(w) ==
         /\ workerReadySet' = [workerReadySet EXCEPT ![w] = workerReadySet[w] \ {child}]
         /\ UNCHANGED <<blobStatus, blobEtag, blobLeased, blobDeadLettered, sbMessages, workerPhase,
                         workerMsg, workerTask, workerResult, workerCapturedEtag,
-                        workerSnapshot, workerSnapshotEtags, workerCurrentReady>>
+                        workerSnapshot, workerSnapshotEtags, workerCurrentReady, workerDispatchFailed>>
 
-FinishAcquiring(w) ==
+\* ===== AcquireLeaseStorageError =====
+\* try_acquire_lease raises a storage error (not 409/412 lease contention, but
+\* a genuine infrastructure failure). The dispatch is lost.
+\* Maps to _DispatchOutcome.FAILED in the implementation.
+\* Sets workerDispatchFailed so that FinishAcquiring suppresses settlement.
+AcquireLeaseStorageError(w) ==
+    /\ workerPhase[w] = "AcquiringLease"
+    /\ workerReadySet[w] /= {}
+    /\ \E child \in workerReadySet[w] :
+        /\ workerReadySet' = [workerReadySet EXCEPT ![w] = workerReadySet[w] \ {child}]
+        /\ workerDispatchFailed' = [workerDispatchFailed EXCEPT ![w] = TRUE]
+    /\ UNCHANGED <<blobStatus, blobEtag, blobLeased, blobDeadLettered, sbMessages, workerPhase,
+                    workerMsg, workerTask, workerResult, workerCapturedEtag,
+                    workerSnapshot, workerSnapshotEtags, workerCurrentReady>>
+
+\* ===== FinishAcquiring =====
+\* All ready tasks have been attempted. If any dispatch failed
+\* (workerDispatchFailed is TRUE), the parent message MUST NOT be settled:
+\* ContinueGraphError is raised, causing the message to be returned to
+\* SB for redelivery. Otherwise, settle the message normally.
+FinishAcquiringSuccess(w) ==
     /\ workerPhase[w] = "AcquiringLease"
     /\ workerReadySet[w] = {}
     /\ workerCurrentReady[w] = Nil
-    \* No more tasks to schedule in this pass; settle the message
+    /\ ~workerDispatchFailed[w]
+    \* No failures: settle the message
     /\ workerPhase' = [workerPhase EXCEPT ![w] = "Completing"]
     /\ UNCHANGED <<blobStatus, blobEtag, blobLeased, blobDeadLettered, sbMessages, workerMsg, workerTask,
                     workerResult, workerCapturedEtag,
                     workerSnapshot, workerSnapshotEtags,
-                    workerReadySet, workerCurrentReady>>
+                    workerReadySet, workerCurrentReady, workerDispatchFailed>>
+
+\* Dispatch-failed variant: at least one ready task could not be published.
+\* ContinueGraphError is raised: do NOT settle the parent message.
+\* Return it to SB for redelivery (bounded by MaxDeliveryCount).
+\* On redelivery, the idempotent guard skips re-executing the finished parent
+\* task and retries continue_graph; SB duplicate-detection suppresses
+\* re-publishing tasks that already succeeded.
+FinishAcquiringDispatchFailed(w) ==
+    /\ workerPhase[w] = "AcquiringLease"
+    /\ workerReadySet[w] = {}
+    /\ workerCurrentReady[w] = Nil
+    /\ workerDispatchFailed[w]
+    \* Dispatch failed: suppress settlement, return message to SB
+    /\ LET msg == workerMsg[w]
+       IN
+       /\ \/ /\ msg.deliveryCount < MaxDeliveryCount
+             /\ sbMessages' = sbMessages \cup
+                   {[taskId |-> msg.taskId,
+                     deliveryCount |-> msg.deliveryCount + 1]}
+             /\ UNCHANGED blobDeadLettered
+          \/ /\ msg.deliveryCount = MaxDeliveryCount
+             /\ UNCHANGED sbMessages
+             /\ blobDeadLettered' = [blobDeadLettered EXCEPT ![msg.taskId] = TRUE]
+    /\ WorkerReset(w)
+    /\ UNCHANGED <<blobStatus, blobEtag, blobLeased>>
 
 \* ===== PublishTask =====
 \* Publish SB message for the leased task (publish-before-store).
@@ -624,17 +680,19 @@ PublishTaskSuccess(w) ==
        /\ UNCHANGED <<blobStatus, blobEtag, blobLeased, blobDeadLettered, workerMsg, workerTask,
                        workerResult, workerCapturedEtag,
                        workerSnapshot, workerSnapshotEtags,
-                       workerReadySet, workerCurrentReady>>
+                       workerReadySet, workerCurrentReady, workerDispatchFailed>>
 
 PublishTaskFail(w) ==
     /\ workerPhase[w] = "PublishingTask"
     /\ workerCurrentReady[w] /= Nil
     /\ LET child == workerCurrentReady[w]
        IN
-       \* Publish failed: release lease (in finally), return to acquiring next task
+       \* Publish failed: release lease (in finally), set dispatch_failed,
+       \* return to acquiring next task (best-effort: try remaining tasks).
        /\ blobLeased' = [blobLeased EXCEPT ![child] = FALSE]
        /\ workerCurrentReady' = [workerCurrentReady EXCEPT ![w] = Nil]
        /\ workerPhase' = [workerPhase EXCEPT ![w] = "AcquiringLease"]
+       /\ workerDispatchFailed' = [workerDispatchFailed EXCEPT ![w] = TRUE]
        /\ UNCHANGED <<blobStatus, blobEtag, blobDeadLettered, sbMessages, workerMsg, workerTask,
                        workerResult, workerCapturedEtag,
                        workerSnapshot, workerSnapshotEtags, workerReadySet>>
@@ -655,7 +713,7 @@ WriteScheduledSuccess(w) ==
        /\ UNCHANGED <<blobLeased, blobDeadLettered, sbMessages, workerMsg, workerTask,
                        workerResult, workerCapturedEtag,
                        workerSnapshot, workerSnapshotEtags,
-                       workerReadySet, workerCurrentReady>>
+                       workerReadySet, workerCurrentReady, workerDispatchFailed>>
 
 WriteScheduledFail(w) ==
     /\ workerPhase[w] = "WritingScheduled"
@@ -665,7 +723,7 @@ WriteScheduledFail(w) ==
     /\ UNCHANGED <<blobStatus, blobEtag, blobLeased, blobDeadLettered, sbMessages, workerMsg, workerTask,
                     workerResult, workerCapturedEtag,
                     workerSnapshot, workerSnapshotEtags,
-                    workerReadySet, workerCurrentReady>>
+                    workerReadySet, workerCurrentReady, workerDispatchFailed>>
 
 \* ===== ReleaseLease =====
 \* Release the blob lease (always, in finally block).
@@ -680,10 +738,12 @@ ReleaseLease(w) ==
        /\ workerPhase' = [workerPhase EXCEPT ![w] = "AcquiringLease"]
        /\ UNCHANGED <<blobStatus, blobEtag, blobDeadLettered, sbMessages, workerMsg, workerTask,
                        workerResult, workerCapturedEtag,
-                       workerSnapshot, workerSnapshotEtags, workerReadySet>>
+                       workerSnapshot, workerSnapshotEtags, workerReadySet, workerDispatchFailed>>
 
 \* ===== CompleteMessage =====
 \* Settle the SB message. Message was already removed from sbMessages on receive.
+\* This action is only reachable when workerDispatchFailed is FALSE
+\* (FinishAcquiringDispatchFailed handles the failed case by returning the message).
 CompleteMessage(w) ==
     /\ workerPhase[w] = "Completing"
     /\ WorkerReset(w)
@@ -725,24 +785,21 @@ Crash(w) == LockExpiry(w)
 \* Next-state relation
 \* ---------------------------------------------------------------------------
 
-\* PublishTaskFail is excluded from the Next relation.
+\* PublishTaskFail and AcquireLeaseStorageError are now included in Next.
 \*
-\* In the real implementation (task_graph.py line 629), a publish failure is
-\* caught, logged, and the scheduling loop continues — the message is completed
-\* normally.  This orphans the child task (Pending, all antecedents Success,
-\* no SB message).  Recovery relies on the dead-letter reprocessor, which is
-\* outside this spec's scope.
+\* Previously, PublishTaskFail was excluded because publish failures were
+\* silently swallowed — the parent message was settled and the child task
+\* was orphaned in Pending forever.  Recovery relied on a dead-letter
+\* reprocessor outside this spec's scope.
 \*
-\* The Azure SB SDK retries sends internally; a permanent publish failure
-\* represents an infrastructure outage.  Modeling it here would require either
-\* (a) a reprocessor action or (b) vacuous liveness properties.  Since the
-\* safety-relevant effects of PublishTaskFail (lease released, no SB message)
-\* are also reachable via LockExpiry during the publishing phase (which
-\* additionally returns the parent message for redelivery), we do not lose
-\* meaningful safety coverage by excluding it.
-\*
-\* The PublishTaskFail action definition is retained above for documentation
-\* and can be re-added to Next for targeted safety analysis.
+\* With the _DispatchOutcome change, publish failures and lease-acquisition
+\* storage errors now set workerDispatchFailed=TRUE.  After the scheduling
+\* loop completes, FinishAcquiringDispatchFailed returns the parent message
+\* to Service Bus (ContinueGraphError) instead of settling it.  On
+\* redelivery, the idempotent guard skips re-executing the finished parent
+\* and retries continue_graph; SB duplicate-detection suppresses re-publishing
+\* tasks that already succeeded.  This makes PublishTaskFail a recoverable
+\* fault within the protocol rather than a permanent stall.
 Next ==
     \E w \in Workers :
         \/ ReceiveMessage(w)
@@ -761,8 +818,11 @@ Next ==
         \/ StatusMismatchCheck(w)
         \/ AcquireLeaseSuccess(w)
         \/ AcquireLeaseFail(w)
-        \/ FinishAcquiring(w)
+        \/ AcquireLeaseStorageError(w)
+        \/ FinishAcquiringSuccess(w)
+        \/ FinishAcquiringDispatchFailed(w)
         \/ PublishTaskSuccess(w)
+        \/ PublishTaskFail(w)
         \/ WriteScheduledSuccess(w)
         \/ WriteScheduledFail(w)
         \/ ReleaseLease(w)
@@ -857,16 +917,19 @@ Fairness ==
         /\ WF_vars(StatusMismatchCheck(w))
         /\ WF_vars(AcquireLeaseSuccess(w))
         /\ WF_vars(AcquireLeaseFail(w))
-        /\ WF_vars(FinishAcquiring(w))
+        /\ WF_vars(FinishAcquiringSuccess(w))
+        /\ WF_vars(FinishAcquiringDispatchFailed(w))
         /\ WF_vars(PublishTaskSuccess(w))
         /\ WF_vars(WriteScheduledSuccess(w))
         /\ WF_vars(ReleaseLease(w))
         /\ WF_vars(CompleteMessage(w))
         \* No fairness on fault actions:
-        \*   LockExpiry/Crash   -- SB lock expiry or worker crash
-        \*   WriteScheduledFail -- blob write failure (SB message already published
-        \*                        so the task is reachable; real impl retries)
-        \* PublishTaskFail is excluded from Next (see comment above Next).
+        \*   LockExpiry/Crash            -- SB lock expiry or worker crash
+        \*   WriteScheduledFail          -- blob write failure (SB message already published
+        \*                                  so the task is reachable; real impl retries)
+        \*   PublishTaskFail             -- SB publish failure (sets dispatch_failed;
+        \*                                  parent redelivered on FinishAcquiringDispatchFailed)
+        \*   AcquireLeaseStorageError    -- lease acquisition storage error (sets dispatch_failed)
 
 \* EventualCompletion: absent dead-letter exhaustion, every task eventually
 \* reaches a terminal state or is blocked by a failed antecedent.

--- a/tests/evaluators/test_lease_guard.py
+++ b/tests/evaluators/test_lease_guard.py
@@ -59,7 +59,12 @@ async def test_lease_skips_task_when_not_acquired(evaluator_context):
 
 
 async def test_lease_released_on_publish_failure(evaluator_context):
-    """Lease must be released even when publish_task raises an exception."""
+    """Lease must be released even when publish_task raises an exception.
+
+    The publish failure must surface as a ContinueGraphError so the caller can
+    suppress settlement and redeliver the parent (rather than silently orphaning
+    the child task in Pending).
+    """
     evaluator_context.prep_task_to_succeed()
 
     # Make publish_task raise an exception
@@ -79,12 +84,78 @@ async def test_lease_released_on_publish_failure(evaluator_context):
         result="OK",
     )
 
-    await evaluator_context.evaluator.continue_graph(completed)
+    # A lost dispatch must propagate so the parent is redelivered, not settled.
+    with pytest.raises(exc.ContinueGraphError):
+        await evaluator_context.evaluator.continue_graph(completed)
 
     # Lease should still have been released despite publish failure
     assert evaluator_context.mock_storage.release_lease.call_count > 0, (
         "release_lease must be called even when publish fails"
     )
+
+
+async def test_publish_failure_suppresses_parent_settlement(evaluator_context):
+    """Regression guard for graph stalls caused by a lost dispatch.
+
+    When a child task fails to publish during ``continue_graph`` (e.g. Service Bus
+    connection-pool exhaustion), the *succeeded* parent message must NOT be
+    completed. It must be abandoned for redelivery so the lost dispatch is retried.
+    Without this, the child is orphaned in Pending and the graph stalls forever:
+    no terminal state is ever reached, so no fan-in / all-failed callback fires.
+    """
+    evaluator_context.prep_task_to_succeed()
+
+    async def failing_publish(task, *args, **kwargs):
+        raise RuntimeError("No connections available: connection pool exhausted")
+
+    evaluator_context.evaluator.task_publisher = failing_publish
+
+    # Run the full message handler for the (successful) parent task.
+    result = await evaluator_context()
+
+    # The parent task itself still succeeded...
+    assert result.status == TaskStatus.Success
+
+    # ...but settlement must be a single abandon (redelivery) — never complete or
+    # dead-letter, which would strand the un-dispatched child.
+    receiver = evaluator_context.mockservicebus._receiver
+    assert len(receiver.method_calls) == 1, "expected exactly one settlement action"
+    assert receiver.method_calls[0][0] == "abandon_message", (
+        f"parent must be abandoned for redelivery when a child dispatch fails, got {receiver.method_calls[0][0]!r}"
+    )
+
+
+async def test_lease_acquisition_storage_error_raises_for_redelivery(evaluator_context):
+    """A storage error while acquiring the lease means the dispatch could not even be
+    attempted; continue_graph must raise so the parent is redelivered."""
+    evaluator_context.prep_task_to_succeed()
+    evaluator_context.mock_storage.try_acquire_lease.side_effect = exc.BoilermakerStorageError("boom")
+
+    completed = TaskResult(
+        task_id=evaluator_context.ok_task.task_id,
+        graph_id=evaluator_context.graph.graph_id,
+        status=TaskStatus.Success,
+        result="OK",
+    )
+    with pytest.raises(exc.ContinueGraphError):
+        await evaluator_context.evaluator.continue_graph(completed)
+
+
+async def test_lease_not_acquired_does_not_raise(evaluator_context):
+    """Lease-not-acquired (another worker owns the dispatch) is a benign skip and must
+    NOT raise — only genuine publish/lease failures trigger redelivery."""
+    evaluator_context.prep_task_to_succeed()
+    evaluator_context.mock_storage.try_acquire_lease.return_value = None
+
+    completed = TaskResult(
+        task_id=evaluator_context.ok_task.task_id,
+        graph_id=evaluator_context.graph.graph_id,
+        status=TaskStatus.Success,
+        result="OK",
+    )
+    # Must not raise, and nothing is counted as dispatched.
+    ready_count = await evaluator_context.evaluator.continue_graph(completed)
+    assert ready_count == 0
 
 
 async def test_lease_released_on_storage_error(evaluator_context):
@@ -173,9 +244,7 @@ async def test_lease_not_acquired_no_scheduled_write(evaluator_context):
     ) as ctx:
         # Only the started + result writes should exist (no scheduling writes)
         others = ctx.get_other_storage_calls()
-        assert len(others) == 0, (
-            "No scheduling writes should happen when lease is not acquired"
-        )
+        assert len(others) == 0, "No scheduling writes should happen when lease is not acquired"
 
 
 async def test_selective_lease_failure_skips_one_task(evaluator_context, app):
@@ -351,9 +420,7 @@ async def test_try_acquire_lease_returns_none_on_409(blob_storage):
     mock_blob_client = AsyncMock()
     mock_lease_client = AsyncMock()
 
-    mock_lease_client.acquire.side_effect = _make_azure_blob_error(
-        409, "There is already a lease present."
-    )
+    mock_lease_client.acquire.side_effect = _make_azure_blob_error(409, "There is already a lease present.")
 
     with patch.object(blob_storage, "get_blob_client") as mock_get_blob:
         mock_ctx = AsyncMock()
@@ -383,9 +450,7 @@ async def test_try_acquire_lease_returns_none_on_412(blob_storage):
         mock_get_blob.return_value = mock_ctx
 
         with patch("boilermaker.storage.blob_storage.BlobLeaseClient", return_value=mock_lease_client):
-            result = await blob_storage.try_acquire_lease(
-                "task-1", "graph-1", etag="stale-etag"
-            )
+            result = await blob_storage.try_acquire_lease("task-1", "graph-1", etag="stale-etag")
 
     assert result is None
 
@@ -395,9 +460,7 @@ async def test_try_acquire_lease_raises_on_non_409_412(blob_storage):
     mock_blob_client = AsyncMock()
     mock_lease_client = AsyncMock()
 
-    mock_lease_client.acquire.side_effect = _make_azure_blob_error(
-        404, "The specified blob does not exist."
-    )
+    mock_lease_client.acquire.side_effect = _make_azure_blob_error(404, "The specified blob does not exist.")
 
     with patch.object(blob_storage, "get_blob_client") as mock_get_blob:
         mock_ctx = AsyncMock()
@@ -426,9 +489,7 @@ async def test_try_acquire_lease_passes_etag_to_acquire(blob_storage):
         mock_get_blob.return_value = mock_ctx
 
         with patch("boilermaker.storage.blob_storage.BlobLeaseClient", return_value=mock_lease_client):
-            result = await blob_storage.try_acquire_lease(
-                "task-1", "graph-1", etag="my-etag-value"
-            )
+            result = await blob_storage.try_acquire_lease("task-1", "graph-1", etag="my-etag-value")
 
     assert result == "acquired-lease-id"
     mock_lease_client.acquire.assert_called_once_with(
@@ -550,9 +611,7 @@ async def test_publish_graph_publishes_before_store(app, mock_storage):
     assert "store" in call_order, "store_task_result must be called"
     publish_idx = call_order.index("publish")
     store_idx = call_order.index("store")
-    assert publish_idx < store_idx, (
-        f"publish must happen before store, but got order: {call_order}"
-    )
+    assert publish_idx < store_idx, f"publish must happen before store, but got order: {call_order}"
 
 
 async def test_publish_graph_publish_failure_skips_store(app, mock_storage):
@@ -588,9 +647,7 @@ async def test_publish_graph_publish_failure_skips_store(app, mock_storage):
     mock_storage.store_task_result.assert_not_called()
 
     # Lease must still be released despite publish failure
-    assert mock_storage.release_lease.call_count >= 1, (
-        "release_lease must be called even when publish fails"
-    )
+    assert mock_storage.release_lease.call_count >= 1, "release_lease must be called even when publish fails"
 
 
 async def test_publish_graph_passes_lease_id_to_store_task_result(app, mock_storage):

--- a/tests/evaluators/test_task_graphs.py
+++ b/tests/evaluators/test_task_graphs.py
@@ -895,9 +895,7 @@ async def test_no_publish_when_load_graph_fails(evaluator_context, mock_storage)
     assert evaluator_context.get_scheduled_messages() == [], "task_publisher must not be called when load_graph raises"
 
 
-async def test_non404_storage_error_retried_raises_continue_graph_error_no_settlement(
-    evaluator_context, mock_storage
-):
+async def test_non404_storage_error_retried_raises_continue_graph_error_no_settlement(evaluator_context, mock_storage):
     """A non-404 BoilermakerStorageError (e.g. 503) must be retried and eventually
     raise ContinueGraphError, leaving the message unsettled for Service Bus redelivery.
 
@@ -934,9 +932,7 @@ async def test_non404_storage_error_retried_raises_continue_graph_error_no_settl
     )
 
 
-async def test_retries_exhausted_continue_graph_error_does_not_propagate(
-    retries_exhausted_scenario, mock_storage
-):
+async def test_retries_exhausted_continue_graph_error_does_not_propagate(retries_exhausted_scenario, mock_storage):
     """ContinueGraphError from continue_graph on the RetriesExhausted path must not propagate.
 
     The message is already deadlettered before continue_graph is called, so
@@ -1266,8 +1262,7 @@ async def test_failure_callback_publish_before_store(evaluator_context, app):
 
     published_ids = {msg.task.task_id for msg in evaluator_context.get_scheduled_messages()}
     assert fail_task.task_id in published_ids, (
-        "Pending failure callback must be published on redelivery "
-        "(generate_failure_ready_tasks re-discovers it)"
+        "Pending failure callback must be published on redelivery (generate_failure_ready_tasks re-discovers it)"
     )
 
 
@@ -1280,8 +1275,9 @@ async def test_publish_task_exception_on_second_task_does_not_abort_loop(app, ev
     """A publish_task failure for one ready task must not abort publishing of remaining tasks.
 
     Two ready tasks are set up. publish_task raises on the second call.
-    Assert: first task is published, second task is also attempted, continue_graph does not raise,
-    and the failed task remains in Pending status (publish-before-store: blob write skipped on failure).
+    Assert: both tasks are attempted (the loop is best-effort, not aborted early), the first
+    is published, the failed one remains Pending, and continue_graph then raises
+    ContinueGraphError so the parent is redelivered to retry the lost dispatch.
     """
 
     async def task_b(state):
@@ -1334,17 +1330,16 @@ async def test_publish_task_exception_on_second_task_does_not_abort_loop(app, ev
         status=TaskStatus.Success,
     )
 
-    # continue_graph must not raise even though publish_task raises on the second call
-    ready_count = await evaluator_context.evaluator.continue_graph(completed)
+    # The loop is best-effort (attempts all ready tasks) but a lost dispatch must
+    # surface so the parent is redelivered rather than silently settled.
+    with pytest.raises(exc.ContinueGraphError):
+        await evaluator_context.evaluator.continue_graph(completed)
 
-    # Both t_b and t_c were attempted (3 attempts including the one that failed)
+    # Both t_b and t_c were attempted (loop not aborted by the first failure)
     assert len(attempted_task_ids) == 2, f"Expected both ready tasks to be attempted, got {attempted_task_ids}"
 
     # Only one task was successfully published (the one that didn't raise)
     assert len(published_task_ids) == 1, f"Expected exactly one successful publish, got {published_task_ids}"
-
-    # ready_count only counts successful publishes
-    assert ready_count == 1, f"Expected ready_count=1 (only successful publish), got {ready_count}"
 
     # The failed task remains in Pending status (publish-before-store: blob write is skipped on publish failure)
     failed_task_id = next(tid for tid in attempted_task_ids if tid not in published_task_ids)
@@ -1353,8 +1348,13 @@ async def test_publish_task_exception_on_second_task_does_not_abort_loop(app, ev
     )
 
 
-async def test_continue_graph_does_not_raise_when_publish_fails(evaluator_context):
-    """continue_graph must not raise when publish_task raises; message_handler can proceed to settle."""
+async def test_continue_graph_raises_when_publish_fails(evaluator_context):
+    """continue_graph must raise ContinueGraphError when a ready task fails to publish.
+
+    Suppressing settlement (via the raise) is what lets message_handler abandon the
+    parent for redelivery. Swallowing the failure here would leave the un-dispatched
+    child orphaned in Pending and permanently stall the graph.
+    """
     graph = evaluator_context.graph
     # ok_task completed successfully
     graph.add_result(
@@ -1377,11 +1377,8 @@ async def test_continue_graph_does_not_raise_when_publish_fails(evaluator_contex
         status=TaskStatus.Success,
     )
 
-    # Must not raise — exception isolation means the loop continues and returns normally
-    ready_count = await evaluator_context.evaluator.continue_graph(completed)
-
-    # All publishes failed, so ready_count is 0
-    assert ready_count == 0
+    with pytest.raises(exc.ContinueGraphError):
+        await evaluator_context.evaluator.continue_graph(completed)
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -1553,8 +1550,7 @@ async def test_retry_publish_uses_differentiated_message_id(retry_scenario):
         expected_msg_id = f"{task.task_id}:{task.attempts.attempts}"
         actual_msg_id = kwargs.get("unique_msg_id")
         assert actual_msg_id == expected_msg_id, (
-            f"Retry publish must use differentiated message_id. "
-            f"Expected '{expected_msg_id}', got '{actual_msg_id}'"
+            f"Retry publish must use differentiated message_id. Expected '{expected_msg_id}', got '{actual_msg_id}'"
         )
 
 
@@ -1595,7 +1591,7 @@ async def test_started_write_passes_etag_from_initial_read(evaluator_context, mo
     ok_task = evaluator_context.ok_task
     ok_task.graph_id = graph.graph_id
 
-    observed_etag = "W/\"abc123\""
+    observed_etag = 'W/"abc123"'
 
     # Arrange: the task is Pending with a known ETag.
     pending_slim = TaskResultSlim(
@@ -1631,9 +1627,7 @@ async def test_started_write_passes_etag_from_initial_read(evaluator_context, mo
 
     # The first store_task_result call is the Started write — it must carry the ETag.
     started_call = mock_storage.store_task_result.call_args_list[0]
-    actual_etag = started_call.kwargs.get("etag") or (
-        started_call.args[1] if len(started_call.args) > 1 else None
-    )
+    actual_etag = started_call.kwargs.get("etag") or (started_call.args[1] if len(started_call.args) > 1 else None)
     assert actual_etag == observed_etag, (
         f"Started write must pass etag={observed_etag!r} from the initial read, got {actual_etag!r}"
     )
@@ -1660,7 +1654,7 @@ async def test_412_on_started_write_with_terminal_reread_skips_execution(evaluat
         task_id=ok_task.task_id,
         graph_id=GraphId(graph.graph_id),
         status=TaskStatus.Pending,
-        etag="W/\"etag-v1\"",
+        etag='W/"etag-v1"',
     )
     # After the 412, the re-read returns Success (another worker completed the task).
     success_slim = TaskResultSlim(
@@ -1671,9 +1665,7 @@ async def test_412_on_started_write_with_terminal_reread_skips_execution(evaluat
     mock_storage.load_task_result.side_effect = [pending_slim, success_slim]
 
     # The Started write raises 412.
-    mock_storage.store_task_result.side_effect = BoilermakerStorageError(
-        "412 Precondition Failed", status_code=412
-    )
+    mock_storage.store_task_result.side_effect = BoilermakerStorageError("412 Precondition Failed", status_code=412)
 
     evaluator_context.evaluator.task = ok_task
     ok_task.msg = evaluator_context.make_message(ok_task)
@@ -1686,9 +1678,7 @@ async def test_412_on_started_write_with_terminal_reread_skips_execution(evaluat
 
     # The returned result must reflect the terminal status from the re-read.
     assert result is not None
-    assert result.status == TaskStatus.Success, (
-        f"Expected Success (from re-read), got {result.status}"
-    )
+    assert result.status == TaskStatus.Success, f"Expected Success (from re-read), got {result.status}"
 
     # Message must have been completed (not left unsettled).
     assert evaluator_context.mockservicebus._receiver.complete_message.called, (
@@ -1717,7 +1707,7 @@ async def test_412_on_started_write_with_started_reread_yields_to_other_worker(e
         task_id=ok_task.task_id,
         graph_id=GraphId(graph.graph_id),
         status=TaskStatus.Pending,
-        etag="W/\"etag-v1\"",
+        etag='W/"etag-v1"',
     )
     # After the 412, the re-read returns Started (another worker won the CAS and is running).
     started_slim = TaskResultSlim(
@@ -1728,9 +1718,7 @@ async def test_412_on_started_write_with_started_reread_yields_to_other_worker(e
     mock_storage.load_task_result.side_effect = [pending_slim, started_slim]
 
     # The Started write raises 412.
-    mock_storage.store_task_result.side_effect = BoilermakerStorageError(
-        "412 Precondition Failed", status_code=412
-    )
+    mock_storage.store_task_result.side_effect = BoilermakerStorageError("412 Precondition Failed", status_code=412)
 
     evaluator_context.evaluator.task = ok_task
     ok_task.msg = evaluator_context.make_message(ok_task)
@@ -1743,9 +1731,7 @@ async def test_412_on_started_write_with_started_reread_yields_to_other_worker(e
 
     # The returned result carries Started status (we deferred to the other worker).
     assert result is not None
-    assert result.status == TaskStatus.Started, (
-        f"Expected Started (yielded to other worker), got {result.status}"
-    )
+    assert result.status == TaskStatus.Started, f"Expected Started (yielded to other worker), got {result.status}"
 
     # Message must have been completed so it is not redelivered.
     assert evaluator_context.mockservicebus._receiver.complete_message.called, (
@@ -1775,15 +1761,13 @@ async def test_412_on_started_write_with_none_reread_returns_failure(evaluator_c
         task_id=ok_task.task_id,
         graph_id=GraphId(graph.graph_id),
         status=TaskStatus.Pending,
-        etag="W/\"etag-v1\"",
+        etag='W/"etag-v1"',
     )
     # After the 412 the re-read returns None — the blob has vanished unexpectedly.
     mock_storage.load_task_result.side_effect = [pending_slim, None]
 
     # The Started write raises 412.
-    mock_storage.store_task_result.side_effect = BoilermakerStorageError(
-        "412 Precondition Failed", status_code=412
-    )
+    mock_storage.store_task_result.side_effect = BoilermakerStorageError("412 Precondition Failed", status_code=412)
 
     evaluator_context.evaluator.task = ok_task
     ok_task.msg = evaluator_context.make_message(ok_task)
@@ -1829,22 +1813,28 @@ async def test_412_scheduled_reread_retries_started_write_with_new_etag(evaluato
         task_id=ok_task.task_id,
         graph_id=GraphId(graph.graph_id),
         status=TaskStatus.Pending,
-        etag="W/\"etag-v1\"",
+        etag='W/"etag-v1"',
     )
     scheduled_slim = TaskResultSlim(
         task_id=ok_task.task_id,
         graph_id=GraphId(graph.graph_id),
         status=TaskStatus.Scheduled,
-        etag="W/\"etag-v2\"",
+        etag='W/"etag-v2"',
     )
     mock_storage.load_task_result.side_effect = [pending_slim, scheduled_slim]
 
-    # First store raises 412; retry succeeds; result write also succeeds.
-    mock_storage.store_task_result.side_effect = [
-        BoilermakerStorageError("412 Precondition Failed", status_code=412),
-        None,
-        None,
-    ]
+    # First store raises 412; retry succeeds. All subsequent writes (the result
+    # write and the Scheduled writes continue_graph makes when dispatching ready
+    # children) succeed, so the dispatch completes and the message settles normally.
+    _store_calls = {"n": 0}
+
+    def _store_side_effect(*args, **kwargs):
+        _store_calls["n"] += 1
+        if _store_calls["n"] == 1:
+            raise BoilermakerStorageError("412 Precondition Failed", status_code=412)
+        return None
+
+    mock_storage.store_task_result.side_effect = _store_side_effect
 
     graph.add_result(
         TaskResult(
@@ -1872,10 +1862,8 @@ async def test_412_scheduled_reread_retries_started_write_with_new_etag(evaluato
         "store_task_result must be called at least twice (Started write + retry)"
     )
     retry_call = mock_storage.store_task_result.call_args_list[1]
-    actual_etag = retry_call.kwargs.get("etag") or (
-        retry_call.args[1] if len(retry_call.args) > 1 else None
-    )
-    assert actual_etag == "W/\"etag-v2\"", (
+    actual_etag = retry_call.kwargs.get("etag") or (retry_call.args[1] if len(retry_call.args) > 1 else None)
+    assert actual_etag == 'W/"etag-v2"', (
         f"Retry Started write must use the Scheduled blob's etag 'W/\"etag-v2\"', got {actual_etag!r}"
     )
 
@@ -1899,22 +1887,28 @@ async def test_412_scheduled_retry_success_falls_through_to_execution(evaluator_
         task_id=ok_task.task_id,
         graph_id=GraphId(graph.graph_id),
         status=TaskStatus.Pending,
-        etag="W/\"etag-v1\"",
+        etag='W/"etag-v1"',
     )
     scheduled_slim = TaskResultSlim(
         task_id=ok_task.task_id,
         graph_id=GraphId(graph.graph_id),
         status=TaskStatus.Scheduled,
-        etag="W/\"etag-v2\"",
+        etag='W/"etag-v2"',
     )
     mock_storage.load_task_result.side_effect = [pending_slim, scheduled_slim]
 
-    # First store raises 412; retry succeeds; result write also succeeds.
-    mock_storage.store_task_result.side_effect = [
-        BoilermakerStorageError("412 Precondition Failed", status_code=412),
-        None,
-        None,
-    ]
+    # First store raises 412; retry succeeds. All subsequent writes (the result
+    # write and the Scheduled writes continue_graph makes when dispatching ready
+    # children) succeed, so the dispatch completes and the message settles normally.
+    _store_calls = {"n": 0}
+
+    def _store_side_effect(*args, **kwargs):
+        _store_calls["n"] += 1
+        if _store_calls["n"] == 1:
+            raise BoilermakerStorageError("412 Precondition Failed", status_code=412)
+        return None
+
+    mock_storage.store_task_result.side_effect = _store_side_effect
 
     graph.add_result(
         TaskResult(
@@ -1945,9 +1939,7 @@ async def test_412_scheduled_retry_success_falls_through_to_execution(evaluator_
     )
 
     assert result is not None
-    assert result.status == TaskStatus.Success, (
-        f"Expected Success after retry success + execution, got {result.status}"
-    )
+    assert result.status == TaskStatus.Success, f"Expected Success after retry success + execution, got {result.status}"
 
     assert evaluator_context.mockservicebus._receiver.complete_message.called, (
         "complete_message must be called via the normal execution path after retry success"
@@ -1973,13 +1965,13 @@ async def test_412_scheduled_retry_second_412_sees_started_yields_with_settle(ev
         task_id=ok_task.task_id,
         graph_id=GraphId(graph.graph_id),
         status=TaskStatus.Pending,
-        etag="W/\"etag-v1\"",
+        etag='W/"etag-v1"',
     )
     scheduled_slim = TaskResultSlim(
         task_id=ok_task.task_id,
         graph_id=GraphId(graph.graph_id),
         status=TaskStatus.Scheduled,
-        etag="W/\"etag-v2\"",
+        etag='W/"etag-v2"',
     )
     started_slim = TaskResultSlim(
         task_id=ok_task.task_id,
@@ -2035,13 +2027,13 @@ async def test_412_scheduled_retry_second_412_sees_terminal_settles(evaluator_co
         task_id=ok_task.task_id,
         graph_id=GraphId(graph.graph_id),
         status=TaskStatus.Pending,
-        etag="W/\"etag-v1\"",
+        etag='W/"etag-v1"',
     )
     scheduled_slim = TaskResultSlim(
         task_id=ok_task.task_id,
         graph_id=GraphId(graph.graph_id),
         status=TaskStatus.Scheduled,
-        etag="W/\"etag-v2\"",
+        etag='W/"etag-v2"',
     )
     success_slim = TaskResultSlim(
         task_id=ok_task.task_id,
@@ -2065,9 +2057,7 @@ async def test_412_scheduled_retry_second_412_sees_terminal_settles(evaluator_co
     mock_eval_task.assert_not_called()
 
     assert result is not None
-    assert result.status == TaskStatus.Success, (
-        f"Expected Success (terminal from second re-read), got {result.status}"
-    )
+    assert result.status == TaskStatus.Success, f"Expected Success (terminal from second re-read), got {result.status}"
 
     assert evaluator_context.mockservicebus._receiver.complete_message.called, (
         "complete_message must be called once after second 412 + terminal re-read"
@@ -2098,13 +2088,13 @@ async def test_412_scheduled_retry_second_412_sees_unclaimed_abandons(
         task_id=ok_task.task_id,
         graph_id=GraphId(graph.graph_id),
         status=TaskStatus.Pending,
-        etag="W/\"etag-v1\"",
+        etag='W/"etag-v1"',
     )
     scheduled_slim = TaskResultSlim(
         task_id=ok_task.task_id,
         graph_id=GraphId(graph.graph_id),
         status=TaskStatus.Scheduled,
-        etag="W/\"etag-v2\"",
+        etag='W/"etag-v2"',
     )
 
     if second_reread_value is None:
@@ -2169,23 +2159,29 @@ async def test_412_scheduled_retry_non412_error_proceeds_to_execution(evaluator_
         task_id=ok_task.task_id,
         graph_id=GraphId(graph.graph_id),
         status=TaskStatus.Pending,
-        etag="W/\"etag-v1\"",
+        etag='W/"etag-v1"',
     )
     scheduled_slim = TaskResultSlim(
         task_id=ok_task.task_id,
         graph_id=GraphId(graph.graph_id),
         status=TaskStatus.Scheduled,
-        etag="W/\"etag-v2\"",
+        etag='W/"etag-v2"',
     )
     mock_storage.load_task_result.side_effect = [pending_slim, scheduled_slim]
 
     # First store raises 412; retry raises a non-412 storage error (fail-open);
-    # result write succeeds after execution proceeds.
-    mock_storage.store_task_result.side_effect = [
-        BoilermakerStorageError("412 Precondition Failed", status_code=412),
-        BoilermakerStorageError("503 Service Unavailable", status_code=503),
-        None,
-    ]
+    # subsequent writes (result + continue_graph Scheduled writes) succeed.
+    _store_calls = {"n": 0}
+
+    def _store_side_effect(*args, **kwargs):
+        _store_calls["n"] += 1
+        if _store_calls["n"] == 1:
+            raise BoilermakerStorageError("412 Precondition Failed", status_code=412)
+        if _store_calls["n"] == 2:
+            raise BoilermakerStorageError("503 Service Unavailable", status_code=503)
+        return None
+
+    mock_storage.store_task_result.side_effect = _store_side_effect
 
     graph.add_result(
         TaskResult(
@@ -2244,23 +2240,29 @@ async def test_412_pending_reread_retries_started_write_with_new_etag(evaluator_
         task_id=ok_task.task_id,
         graph_id=GraphId(graph.graph_id),
         status=TaskStatus.Pending,
-        etag="W/\"etag-v1\"",
+        etag='W/"etag-v1"',
     )
     # Re-read after 412 returns Pending with a NEW etag — lease acquire bumped it.
     pending_slim_reread = TaskResultSlim(
         task_id=ok_task.task_id,
         graph_id=GraphId(graph.graph_id),
         status=TaskStatus.Pending,
-        etag="W/\"etag-v2\"",
+        etag='W/"etag-v2"',
     )
     mock_storage.load_task_result.side_effect = [pending_slim, pending_slim_reread]
 
-    # First store raises 412; retry succeeds; result write also succeeds.
-    mock_storage.store_task_result.side_effect = [
-        BoilermakerStorageError("412 Precondition Failed", status_code=412),
-        None,
-        None,
-    ]
+    # First store raises 412; retry succeeds. All subsequent writes (the result
+    # write and the Scheduled writes continue_graph makes when dispatching ready
+    # children) succeed, so the dispatch completes and the message settles normally.
+    _store_calls = {"n": 0}
+
+    def _store_side_effect(*args, **kwargs):
+        _store_calls["n"] += 1
+        if _store_calls["n"] == 1:
+            raise BoilermakerStorageError("412 Precondition Failed", status_code=412)
+        return None
+
+    mock_storage.store_task_result.side_effect = _store_side_effect
 
     graph.add_result(
         TaskResult(
@@ -2288,10 +2290,8 @@ async def test_412_pending_reread_retries_started_write_with_new_etag(evaluator_
         "store_task_result must be called at least twice (Started write + retry)"
     )
     retry_call = mock_storage.store_task_result.call_args_list[1]
-    actual_etag = retry_call.kwargs.get("etag") or (
-        retry_call.args[1] if len(retry_call.args) > 1 else None
-    )
-    assert actual_etag == "W/\"etag-v2\"", (
+    actual_etag = retry_call.kwargs.get("etag") or (retry_call.args[1] if len(retry_call.args) > 1 else None)
+    assert actual_etag == 'W/"etag-v2"', (
         f"Retry Started write must use the re-read Pending blob etag 'W/\"etag-v2\"', got {actual_etag!r}"
     )
 
@@ -2318,22 +2318,28 @@ async def test_412_pending_retry_success_falls_through_to_execution(evaluator_co
         task_id=ok_task.task_id,
         graph_id=GraphId(graph.graph_id),
         status=TaskStatus.Pending,
-        etag="W/\"etag-v1\"",
+        etag='W/"etag-v1"',
     )
     pending_slim_reread = TaskResultSlim(
         task_id=ok_task.task_id,
         graph_id=GraphId(graph.graph_id),
         status=TaskStatus.Pending,
-        etag="W/\"etag-v2\"",
+        etag='W/"etag-v2"',
     )
     mock_storage.load_task_result.side_effect = [pending_slim, pending_slim_reread]
 
-    # First store raises 412; retry succeeds; result write also succeeds.
-    mock_storage.store_task_result.side_effect = [
-        BoilermakerStorageError("412 Precondition Failed", status_code=412),
-        None,
-        None,
-    ]
+    # First store raises 412; retry succeeds. All subsequent writes (the result
+    # write and the Scheduled writes continue_graph makes when dispatching ready
+    # children) succeed, so the dispatch completes and the message settles normally.
+    _store_calls = {"n": 0}
+
+    def _store_side_effect(*args, **kwargs):
+        _store_calls["n"] += 1
+        if _store_calls["n"] == 1:
+            raise BoilermakerStorageError("412 Precondition Failed", status_code=412)
+        return None
+
+    mock_storage.store_task_result.side_effect = _store_side_effect
 
     graph.add_result(
         TaskResult(
@@ -2393,19 +2399,17 @@ async def test_412_retry_reread_settles_and_returns_retry(evaluator_context, moc
         task_id=ok_task.task_id,
         graph_id=GraphId(graph.graph_id),
         status=TaskStatus.Pending,
-        etag="W/\"etag-v1\"",
+        etag='W/"etag-v1"',
     )
     retry_slim_reread = TaskResultSlim(
         task_id=ok_task.task_id,
         graph_id=GraphId(graph.graph_id),
         status=TaskStatus.Retry,
-        etag="W/\"etag-v2\"",
+        etag='W/"etag-v2"',
     )
     mock_storage.load_task_result.side_effect = [pending_slim, retry_slim_reread]
 
-    mock_storage.store_task_result.side_effect = BoilermakerStorageError(
-        "412 Precondition Failed", status_code=412
-    )
+    mock_storage.store_task_result.side_effect = BoilermakerStorageError("412 Precondition Failed", status_code=412)
 
     evaluator_context.evaluator.task = ok_task
     ok_task.msg = evaluator_context.make_message(ok_task)
@@ -2416,9 +2420,7 @@ async def test_412_retry_reread_settles_and_returns_retry(evaluator_context, moc
     mock_eval_task.assert_not_called()
 
     assert result is not None
-    assert result.status == TaskStatus.Retry, (
-        f"Expected Retry for Retry re-read after 412, got {result.status}"
-    )
+    assert result.status == TaskStatus.Retry, f"Expected Retry for Retry re-read after 412, got {result.status}"
 
     assert evaluator_context.mockservicebus._receiver.complete_message.called, (
         "complete_message must be called — another worker already owns the retry"
@@ -3146,8 +3148,8 @@ async def test_continue_graph_callback_not_double_dispatched(evaluator_context, 
 
     # First call acquires lease; second call finds it held (returns None).
     evaluator_context.mock_storage.try_acquire_lease.side_effect = itertools.chain(
-        ["lease-id-1"],   # first worker acquires
-        [None],           # second worker cannot acquire
+        ["lease-id-1"],  # first worker acquires
+        [None],  # second worker cannot acquire
     )
 
     completed = TaskResult(


### PR DESCRIPTION
## Problem

A publish failure inside `continue_graph` → `_lease_publish_schedule` (e.g. Service Bus **connection-pool exhaustion**, `ConnectionsExhausted`) was logged as *"remains Pending, will retry on redelivery"* — but then silently swallowed. The already-succeeded **parent** message was settled immediately afterward, so **there was no redelivery**. The un-dispatched child task stayed `Pending` forever, wedging the entire graph: no main task ever reached a terminal state, so `is_terminal_failed()` never became true and **neither the fan-in success callback nor the `all_failed_callback` ever fired**.

### Observed in production

Surfaced as workflows that completed their work but **never emitted a completion event** (the downstream consumer was left waiting indefinitely). A scan of ~2,000 settled graphs found 10 permanently stalled, all with the same fingerprint: a `Pending` task whose parent was `success`, never notified. The decisive worker log:

```
business_callback_handler → Completed (success)
[Graph …] Failed to publish [business_report_handler …]; remains Pending, will retry on redelivery.
  ↳ aio_azure_clients_toolbox.connection_pooling.ConnectionsExhausted:
    'No connections available: consider using a larger value for `client_limit`'
```

The parent (`business_callback`) was then completed, so the dispatch of `business_report` was lost with no recovery path.

## Fix

Distinguish three dispatch outcomes in `_lease_publish_schedule` (`_DispatchOutcome`):

- **`PUBLISHED`** — task published to Service Bus (counts toward `ready_count`).
- **`SKIPPED`** — lease not acquired (another worker owns the dispatch, or the blob was modified). Benign; no redelivery.
- **`FAILED`** — publish raised, or the lease could not be acquired due to a storage error. The dispatch was lost.

`continue_graph` is best-effort (it still attempts every ready task) and then **raises `ContinueGraphError` if any task FAILED**. That routes into the existing `_abandon_or_let_expire()` path, so the parent message is **abandoned for redelivery instead of settled** (bounded by the queue's `max_delivery_count`).

On redelivery, the existing idempotent guard skips re-executing the already-finished parent and simply retries the dispatch; Service Bus duplicate-detection suppresses re-publishing the tasks that already succeeded. `SKIPPED` deliberately does **not** trigger redelivery, so normal multi-worker lease contention causes no extra churn.

This reuses the exact mechanism already used for transient `load_graph` failures — it just extends "suppress settlement and redeliver" to cover lost *publishes* as well.

## Tests

- `test_continue_graph_raises_when_publish_fails` — a publish failure now raises `ContinueGraphError` (was: swallowed).
- `test_publish_failure_suppresses_parent_settlement` — full `message_handler`: a child publish failure ⇒ the parent is **abandoned**, never completed/dead-lettered.
- `test_lease_acquisition_storage_error_raises_for_redelivery` — lease-acquisition storage error ⇒ raises (redelivery).
- `test_lease_not_acquired_does_not_raise` — `SKIPPED` stays benign (no raise, nothing dispatched).
- `test_publish_task_exception_on_second_task_does_not_abort_loop` — updated: loop is still best-effort (both tasks attempted), then raises.
- Three `test_412_*` tests: mock setups completed to cover the `Scheduled` writes `continue_graph` now makes.

Full suite: **938 passed, 96.95% coverage**. `ruff check` and `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)